### PR TITLE
fix: rechatting with npcs

### DIFF
--- a/packages/client/src/world/controller.ts
+++ b/packages/client/src/world/controller.ts
@@ -45,6 +45,10 @@ export function setGameState(state: GameState) {
 export function setChatting(chat: boolean) {
   console.log('setChatting', chat);
   chatting = chat;
+  // Allows for rechatting with the same NPC
+  if (!chat) {
+    lastChatCompanions = [];
+  }
 }
 
 export function setResponseCallback(callback: (responses: string[]) => void) {
@@ -91,7 +95,7 @@ function areInteractionsEqual(
   return true;
 }
 
-function areListsEqual(list1: Mob[], list2: Mob[]): boolean {
+export function areListsEqual(list1: Mob[], list2: Mob[]): boolean {
   if (list1.length !== list2.length) {
     return false;
   }
@@ -99,11 +103,12 @@ function areListsEqual(list1: Mob[], list2: Mob[]): boolean {
   return list1.every((item, index) => item.key === list2[index].key);
 }
 
-function mobRangeListener(mobs: Mob[]) {
+export function mobRangeListener(mobs: Mob[]) {
   if (chatCompanionCallback && !chatting) {
     const filteredMobs = mobs.filter((mob) => mob.type !== 'player');
     filteredMobs.sort((a, b) => a.key.localeCompare(b.key));
     if (!areListsEqual(filteredMobs, lastChatCompanions)) {
+      console.log("filter: ", filteredMobs, "last:", lastChatCompanions);
       chatCompanionCallback(filteredMobs);
       lastChatCompanions = filteredMobs;
     }

--- a/packages/client/test/chatui/chatui.test.ts
+++ b/packages/client/test/chatui/chatui.test.ts
@@ -119,6 +119,6 @@ describe('Chat UI updates based on chatting state', () => {
   });
 
   afterAll(() => {
-    world = null as World | null;
+    world = null;
   });
 });

--- a/packages/client/test/chatui/chatui.test.ts
+++ b/packages/client/test/chatui/chatui.test.ts
@@ -31,7 +31,7 @@ jest.mock('phaser', () => ({
 }));
 
 describe('Chat UI updates based on chatting state', () => {
-  let world: World | null;
+  let world: World | null = null;
   let mockChatCallback: jest.Mock;
 
   beforeAll(() => {
@@ -55,8 +55,8 @@ describe('Chat UI updates based on chatting state', () => {
   });
 
   test('triggers callback after chatting', () => {
-    const player1 = new Mob(world, 'mob1', 'Player1', 'player', 100, { x: 1, y: 1 }, 2, {});
-    const npc1 = new Mob(world, 'mob2', 'NPC1', 'npc', 100, { x: 2, y: 2 }, 2, {});
+    const player1 = new Mob(world!, 'mob1', 'Player1', 'player', 100, { x: 1, y: 1 }, 2, {});
+    const npc1 = new Mob(world!, 'mob2', 'NPC1', 'npc', 100, { x: 2, y: 2 }, 2, {});
     const mobs = [player1, npc1];
     const expectedFilteredMobs = [npc1];
 
@@ -79,8 +79,8 @@ describe('Chat UI updates based on chatting state', () => {
   });
 
   test('should not trigger callback if the nearby mobs does not change', () => {
-    const player1 = new Mob(world, 'mob1', 'Player1', 'player', 100, { x: 1, y: 1 }, 2, {});
-    const npc = new Mob(world, 'mob2', 'NPC1', 'npc', 100, { x: 2, y: 2 }, 2, {});
+    const player1 = new Mob(world!, 'mob1', 'Player1', 'player', 100, { x: 1, y: 1 }, 2, {});
+    const npc = new Mob(world!, 'mob2', 'NPC1', 'npc', 100, { x: 2, y: 2 }, 2, {});
     const mobs = [player1, npc];
 
     setChatting(false);
@@ -97,8 +97,8 @@ describe('Chat UI updates based on chatting state', () => {
   });
 
   test('should update chat companions when a second mob enters range', () => {
-    const player1 = new Mob(world, 'mob1', 'Player1', 'player', 100, { x: 1, y: 1 }, 2, {});
-    const npc1 = new Mob(world, 'mob2', 'NPC1', 'npc', 100, { x: 2, y: 2 }, 2, {});
+    const player1 = new Mob(world!, 'mob1', 'Player1', 'player', 100, { x: 1, y: 1 }, 2, {});
+    const npc1 = new Mob(world!, 'mob2', 'NPC1', 'npc', 100, { x: 2, y: 2 }, 2, {});
     let mobs = [player1, npc1];
 
     setChatting(false);
@@ -110,7 +110,7 @@ describe('Chat UI updates based on chatting state', () => {
     mockChatCallback.mockClear();
 
     // Add second mob
-    const npc2 = new Mob(world, 'mob3', 'NPC2', 'npc', 100, { x: 3, y: 3 }, 2, {});
+    const npc2 = new Mob(world!, 'mob3', 'NPC2', 'npc', 100, { x: 3, y: 3 }, 2, {});
     mobs = [player1, npc1, npc2];
     mobRangeListener(mobs);
 

--- a/packages/client/test/chatui/chatui.test.ts
+++ b/packages/client/test/chatui/chatui.test.ts
@@ -2,7 +2,7 @@ import { setChatting, setChatCompanionCallback, mobRangeListener } from "../../s
 import { Mob } from "../../src/world/mob";
 import { World } from "../../src/world/world";
 
-jest.mock('../../src/scenes/PauseScene', () => ({
+jest.mock('../../src/scenes/pauseScene', () => ({
   PauseScene: class MockPauseScene {},
 }));
 

--- a/packages/client/test/chatui/chatui.test.ts
+++ b/packages/client/test/chatui/chatui.test.ts
@@ -1,0 +1,124 @@
+import { setChatting, setChatCompanionCallback, mobRangeListener } from "../../src/world/controller";
+import { Mob } from "../../src/world/mob";
+import { World } from "../../src/world/world";
+
+jest.mock('../../src/scenes/PauseScene', () => ({
+  PauseScene: class MockPauseScene {},
+}));
+
+jest.mock('phaser', () => ({
+  Scene: class MockScene {
+    key: string;
+
+    constructor(config: { key: string }) {
+      this.key = config.key;
+    }
+
+    add = {
+      graphics: () => ({
+        fillStyle: jest.fn().mockReturnThis(),
+        fillRect: jest.fn(),
+      }),
+    };
+
+    game = {
+      scale: {
+        width: 800,
+        height: 600,
+      },
+    };
+  },
+}));
+
+describe('Chat UI updates based on chatting state', () => {
+  let world: World;
+  let mockChatCallback: jest.Mock;
+
+  beforeAll(() => {
+    // Initialize world
+    world = new World();
+    world.load({
+      tiles: [
+        [0, 0, 0],
+        [0, 0, 0],
+        [0, 0, 0],
+      ],
+      terrain_types: [{ id: 0, name: 'Grass', walkable: true }],
+      item_types: [],
+      mob_types: [],
+    });
+  });
+
+  beforeEach(() => {
+    mockChatCallback = jest.fn();
+    setChatCompanionCallback(mockChatCallback);
+  });
+
+  test('triggers callback after chatting', () => {
+    const player1 = new Mob(world, 'mob1', 'Player1', 'player', 100, { x: 1, y: 1 }, 2, {});
+    const npc1 = new Mob(world, 'mob2', 'NPC1', 'npc', 100, { x: 2, y: 2 }, 2, {});
+    const mobs = [player1, npc1];
+    const expectedFilteredMobs = [npc1];
+
+    mobRangeListener(mobs);
+
+    // start chatting
+    setChatting(true);
+
+    // conversation ends
+    setChatting(false);
+    mobRangeListener(mobs);
+
+    setChatting(true);
+
+    setChatting(false);
+    mobRangeListener(mobs);
+
+    expect(mockChatCallback).toHaveBeenCalledTimes(3);
+    expect(mockChatCallback).toHaveBeenCalledWith(expectedFilteredMobs);
+  });
+
+  test('should not trigger callback if the nearby mobs does not change', () => {
+    const player1 = new Mob(world, 'mob1', 'Player1', 'player', 100, { x: 1, y: 1 }, 2, {});
+    const npc = new Mob(world, 'mob2', 'NPC1', 'npc', 100, { x: 2, y: 2 }, 2, {});
+    const mobs = [player1, npc];
+
+    setChatting(false);
+
+    mobRangeListener(mobs);
+
+    const expectedFilteredMobs = [npc];
+    expect(mockChatCallback).toHaveBeenCalledWith(expectedFilteredMobs);
+
+    mockChatCallback.mockClear();
+    mobRangeListener(mobs);
+
+    expect(mockChatCallback).not.toHaveBeenCalled();
+  });
+
+  test('should update chat companions when a second mob enters range', () => {
+    const player1 = new Mob(world, 'mob1', 'Player1', 'player', 100, { x: 1, y: 1 }, 2, {});
+    const npc1 = new Mob(world, 'mob2', 'NPC1', 'npc', 100, { x: 2, y: 2 }, 2, {});
+    let mobs = [player1, npc1];
+
+    setChatting(false);
+    mobRangeListener(mobs);
+
+    const expectedFilteredMobs = [npc1];
+    expect(mockChatCallback).toHaveBeenCalledWith(expectedFilteredMobs);
+
+    mockChatCallback.mockClear();
+
+    // Add second mob
+    const npc2 = new Mob(world, 'mob3', 'NPC2', 'npc', 100, { x: 3, y: 3 }, 2, {});
+    mobs = [player1, npc1, npc2];
+    mobRangeListener(mobs);
+
+    const updatedFilteredMobs = [npc1, npc2];
+    expect(mockChatCallback).toHaveBeenCalledWith(updatedFilteredMobs);
+  });
+
+  afterAll(() => {
+    world = null as any;
+  });
+});

--- a/packages/client/test/chatui/chatui.test.ts
+++ b/packages/client/test/chatui/chatui.test.ts
@@ -31,7 +31,7 @@ jest.mock('phaser', () => ({
 }));
 
 describe('Chat UI updates based on chatting state', () => {
-  let world: World;
+  let world: World | null;
   let mockChatCallback: jest.Mock;
 
   beforeAll(() => {
@@ -119,6 +119,6 @@ describe('Chat UI updates based on chatting state', () => {
   });
 
   afterAll(() => {
-    world = null as any;
+    world = null as World | null;
   });
 });


### PR DESCRIPTION
**Group**: Darren Hong, Andrew Mei

**Bug Description** (Issue #40): When finishing a conversation (chatting) with an NPC, the player cannot talk with the same NPC unless the nearby Mobs List changes.

**What Changed**: We added a line of code in `controller.ts` for the `setChatting` function, where the list of `lastChatCompanions` is reset every time a conversation is finished. The function, `mobRangeListener`, compares the nearby mobs with the mobs the player has recently chatted with and resets the `lastChatCompanions` list whenever the conversation ends. This ensures that the same NPCs can be re-added to the chat companion list, even if they were recently interacted with, as long as they remain in range.

**Why**: Previously, to chat with the same NPC, the player would have to go out of the mob's range and get back in OR wait for a new mob to be near the player to update the list of nearby mobs. By solving this issue, the player does not have to take unnecessary actions to chat with the same NPC.

Before:
<img width="454" alt="image" src="https://github.com/user-attachments/assets/344fc0ed-353e-4e6e-8ca9-33337028ff1a" />


After:
<img width="454" alt="image" src="https://github.com/user-attachments/assets/0c28e308-c58a-4c92-ab46-69a20003d765" />

