### PR TITLE
Fix: don't display alert when cancel is pressed

### DIFF
--- a/packages/client/src/scenes/loadWorldScene.ts
+++ b/packages/client/src/scenes/loadWorldScene.ts
@@ -124,7 +124,10 @@ export class LoadWorldScene extends Phaser.Scene {
     });
 
     characterName.on('pointerdown', () => {
-      const userName = window.prompt('Please enter your name:') || '';
+      const userName = window.prompt('Please enter your name:');
+      if (userName === null) {
+        return;
+      }
       const parsedName = parseName(userName);
       if (parsedName) {
         changeName(parsedName);


### PR DESCRIPTION
**Group:** Daniel Ching, Josh Queja

### Bug
On the start screen, clicking cancel when the character name window appears displays the invalid name alert.

### Changes
https://github.com/sloalchemist/potions/commit/8841c1482e11ba02abeedd5cb856facc675c9011

- If the window prompt is null, exit the function early and do not display alert

### Testing
- UI change only, no unit test needed