### PR TITLE
Fix: Issue 44 - mobs already pathing into the fenced area do not respect player fences (Ryan Hu, Ryan Chan, Kyle Taschek)

### DIFF
--- a/packages/client/src/world/mob.ts
+++ b/packages/client/src/world/mob.ts
@@ -30,6 +30,7 @@ export class Mob extends Physical {
     this.maxHealth = maxHealth;
 
     if (position) {
+      console.log('Adding mob to grid', this.key, this.position);
       world.addMobToGrid(this);
     }
 
@@ -56,7 +57,7 @@ export class Mob extends Physical {
   }
 
   changePosition(world: World, newPosition: Coord) {
-    //console.log('changePosition', this.position, newPosition);
+    // console.log('changePosition', this.position, newPosition);
     world.moveMob(this, newPosition);
     this.position = newPosition;
   }
@@ -69,6 +70,15 @@ export class Mob extends Physical {
     }
 
     if (this.path.length > 0) {
+      // check if next step is blocked
+      const nextStep = this.path[0];
+      const lastStep = this.path[this.path.length - 1];
+      const nextItem = world.getItemAt(nextStep.x, nextStep.y);
+      if (!!nextItem && !nextItem.isWalkable(this.unlocks)) {
+        console.log(`Next step blocked for ${this.key} by ${nextItem.name}`);
+        this.path = world.generatePath(this.unlocks, this.position, lastStep);
+      }
+
       const [position, angle] = followPath(
         this.position,
         this.path,

--- a/packages/client/src/world/mob.ts
+++ b/packages/client/src/world/mob.ts
@@ -57,7 +57,7 @@ export class Mob extends Physical {
   }
 
   changePosition(world: World, newPosition: Coord) {
-    // console.log('changePosition', this.position, newPosition);
+    //console.log('changePosition', this.position, newPosition);
     world.moveMob(this, newPosition);
     this.position = newPosition;
   }
@@ -75,7 +75,6 @@ export class Mob extends Physical {
       const lastStep = this.path[this.path.length - 1];
       const nextItem = world.getItemAt(nextStep.x, nextStep.y);
       if (!!nextItem && !nextItem.isWalkable(this.unlocks)) {
-        console.log(`Next step blocked for ${this.key} by ${nextItem.name}`);
         this.path = world.generatePath(this.unlocks, this.position, lastStep);
       }
 

--- a/packages/client/src/world/mob.ts
+++ b/packages/client/src/world/mob.ts
@@ -30,7 +30,6 @@ export class Mob extends Physical {
     this.maxHealth = maxHealth;
 
     if (position) {
-      console.log('Adding mob to grid', this.key, this.position);
       world.addMobToGrid(this);
     }
 

--- a/packages/client/test/world/mob.test.ts
+++ b/packages/client/test/world/mob.test.ts
@@ -1,0 +1,88 @@
+import { Mob } from '../../src/world/mob';
+import { World } from '../../src/world/world';
+import { Item } from '../../src/world/item';
+
+const TEST_UNWALKABLE_ITEM = { isWalkable: () => false } as unknown as Item;
+const TEST_WALKABLE_ITEM = { isWalkable: () => true } as unknown as Item;
+const TEST_OLD_PATH = [
+  { x: 1, y: 1 },
+  { x: 2, y: 2 }
+];
+const TEST_NEW_PATH = [
+  { x: 2, y: 2 },
+  { x: 3, y: 3 }
+];
+
+const mockWorld = {
+  addMobToGrid: jest.fn(),
+  getItemAt: jest.fn(),
+  generatePath: jest.fn().mockReturnValue(TEST_NEW_PATH),
+  moveMob: jest.fn()
+};
+
+const createTestMob = (): Mob => {
+  const mob = new Mob(
+    mockWorld as unknown as World,
+    'test',
+    'test',
+    'test',
+    1,
+    { x: 0, y: 0 },
+    1,
+    {}
+  );
+  mob.path = TEST_OLD_PATH;
+  return mob;
+};
+
+describe('Mob', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('should be created in world', () => {
+    const mob = createTestMob();
+
+    expect(mob).toBeDefined();
+    expect(mockWorld.addMobToGrid).toHaveBeenCalledWith(mob);
+  });
+
+  describe('tick', () => {
+    it('should recalculate path if next step has unwalkable item', () => {
+      mockWorld.getItemAt.mockReturnValue(TEST_UNWALKABLE_ITEM);
+
+      const mob = createTestMob();
+      mob.tick(mockWorld as unknown as World, 1);
+
+      expect(mockWorld.generatePath).toHaveBeenCalledWith(
+        mob.unlocks,
+        expect.any(Object),
+        TEST_OLD_PATH[TEST_OLD_PATH.length - 1]
+      );
+      // Need to do separate floating point comparison for mob position
+      expect(mockWorld.generatePath.mock.calls[0][1].x).toBeCloseTo(0);
+      expect(mockWorld.generatePath.mock.calls[0][1].y).toBeCloseTo(0);
+      expect(mob.path).toEqual(TEST_NEW_PATH);
+    });
+
+    it('should not recalculate path if next step has walkable item', () => {
+      mockWorld.getItemAt.mockReturnValue(TEST_WALKABLE_ITEM);
+
+      const mob = createTestMob();
+      mob.tick(mockWorld as unknown as World, 1);
+
+      expect(mockWorld.generatePath).not.toHaveBeenCalled();
+      expect(mob.path).toEqual(TEST_OLD_PATH);
+    });
+
+    it('should not recalculate path if next step has no item', () => {
+      mockWorld.getItemAt.mockReturnValue(undefined);
+
+      const mob = createTestMob();
+      mob.tick(mockWorld as unknown as World, 1);
+
+      expect(mockWorld.generatePath).not.toHaveBeenCalled();
+      expect(mob.path).toEqual(TEST_OLD_PATH);
+    });
+  });
+});


### PR DESCRIPTION
Closes #44 

### Summary
This PR resolves the bug where mobs with an already calculated path can pass through newly created walls. Our fix checks at every tick whether the next step in the mob's path is occupied by an unwalkable item in the world's grid. If it is, the mob recalculates its path to avoid the obstacle.

NOTE: branch name indicated issue 49 should actually by 44

### Changes
`/client/src/world/mob.ts`
- `tick()`: We add additional checks and logic for regenerating the mob's path in the world. Utilizing the mob's path attribute and the `isWalkable()` method of the item at the next step, we determine if the mob is able to proceed or if it needs to recalculate its path.


### Testing
`/client/test/world.mob.test.ts`
- Unit tests for the new logic in the `tick()` method.
  - Test the mob's constructor to ensure that it can be created in the world.
  - Test the mob's path recalculation when the next step is blocked by an unwalkable item, mocking the world's grid and the mob's path.
  - Test that the mob's path is not recalculated when the next step contains a walkable item.
  - Test that the mob's path is not recalculated when the next step does not contain any item.
- 100% statement and branch coverage on our changes

We also ran the modified pathing logic in our local environment. The test involved building a new wall in front of the village gates and observing the mob's behavior. The mobs approaching the gates successfully recalculated its path to avoid the newly created wall rather than phasing through it, which confirms the fix.