### PR TITLE
Fix: Bug 31 Players cannot pick up their own potion after adding to a potion stand

### DIFF
--- a/packages/client/static/global.json
+++ b/packages/client/static/global.json
@@ -357,6 +357,18 @@
                 "while_carried": false
             },
             {
+                "description": "Get $item_name",
+                "action": "retrieve_item",
+                "while_carried": false,
+                "conditions": [
+                    {
+                        "attribute_name": "items",
+                        "value": 0,
+                        "comparison": "greater_than"
+                    }
+                ]
+            },
+            {
                 "description": "Raise price",
                 "action": "raise_price",
                 "while_carried": false,

--- a/packages/server/src/items/purchasable.ts
+++ b/packages/server/src/items/purchasable.ts
@@ -56,6 +56,22 @@ export class Purchasable {
     return true;
   }
 
+  retrieveItem(mob: Mob): boolean {
+    if (this.items <= 0) {
+      return false;
+    }
+
+    this.changeItems(-1);
+
+    itemGenerator.createItem({
+      type: this.templateType,
+      subtype: this.item.subtype,
+      carriedBy: mob
+    });
+
+    return true;
+  }
+
   collectGold(mob: Mob) {
     mob.changeGold(this.gold);
     this.item.setAttribute<number>('gold', 0);

--- a/packages/server/src/items/uses/stand/retrieve.ts
+++ b/packages/server/src/items/uses/stand/retrieve.ts
@@ -1,0 +1,25 @@
+import { Use } from '../use';
+import { Item } from '../../item';
+import { Mob } from '../../../mobs/mob';
+import { Purchasable } from '../../purchasable';
+
+export class Retrieve implements Use {
+  key: string;
+  constructor() {
+    this.key = 'retrieve_item';
+  }
+
+  description(_mob: Mob, _item: Item): string {
+    return 'Retrieve item from stand';
+  }
+
+  interact(mob: Mob, item: Item): boolean {
+    const stand = Purchasable.fromItem(item);
+
+    if (!stand) {
+      return false;
+    }
+
+    return stand.retrieveItem(mob);
+  }
+}

--- a/packages/server/src/items/uses/usesConfig.ts
+++ b/packages/server/src/items/uses/usesConfig.ts
@@ -11,6 +11,7 @@ import { CollectGold } from './stand/collectGold';
 import { CreateStand } from './stand/createStand';
 import { RaisePrice } from './stand/raisePrice';
 import { LowerPrice } from './stand/lowerPrice';
+import { Retrieve } from './stand/retrieve';
 import { BuildWall } from './building/buildWall';
 import { StartWall } from './building/startWall';
 import { AddItem } from './container/addItem';
@@ -30,6 +31,7 @@ const uses = [
   CreateStand,
   RaisePrice,
   LowerPrice,
+  Retrieve,
   BuildWall,
   StartWall,
   AddItem,

--- a/packages/server/test/items/itemRetrievePotionFromStand.test.ts
+++ b/packages/server/test/items/itemRetrievePotionFromStand.test.ts
@@ -130,6 +130,7 @@ describe('Try to retrieve a potion from a potion stand', () => {
     mobFactory.makeMob('player', playerPosition, 'TestID', 'TestPlayer');
     const testMob = Mob.getMob('TestID');
     expect(testMob).not.toBeNull();
+    expect(testMob!.carrying).toBeUndefined();
 
     // Give potion to player
     itemGenerator.createItem({
@@ -140,27 +141,25 @@ describe('Try to retrieve a potion from a potion stand', () => {
     });
 
     // Place potion on stand
-    const potion = new AddItem();
-    potion.interact(testMob!, testStand!);
+    const addPotion = new AddItem();
+    addPotion.interact(testMob!, testStand!);
 
     // Ensure potion is on stand
     expect(testStand).not.toBeNull();
     expect(testStand!.getAttribute('items')).toBe(1);
 
     // Check to see that player is not carrying anything before retrieval
-    // expect(testMob!.carrying).not.toBeNull();
-    expect(testMob!.carrying).toBeNull();
+    expect(testMob!.carrying).toBeUndefined();
 
-    // add the potion to the stand
     // Retrieve the potion from the stand
     const testAddItem = new Retrieve();
     const test = testAddItem.interact(testMob!, testStand!);
-    // expect(test).toBe(true);
+    expect(test).toBe(true);
+
+    // Check that the stand is empty
+    expect(testStand!.getAttribute('items')).toBe(0);
 
     // Check that the player has the potion
-    // const standAfter = Item.getItem(standID!);
-    // expect(standAfter).not.toBeNull();
-    // expect(standAfter!.getAttribute('items')).toBe(1);
     expect(testMob!.carrying).not.toBeNull();
     expect(testMob!.carrying!.type).toBe('potion');
   });

--- a/packages/server/test/items/itemRetrievePotionFromStand.test.ts
+++ b/packages/server/test/items/itemRetrievePotionFromStand.test.ts
@@ -1,0 +1,171 @@
+import { commonSetup } from '../testSetup';
+import { DB } from '../../src/services/database';
+import { mobFactory } from '../../src/mobs/mobFactory';
+import { Community } from '../../src/community/community';
+import { Item } from '../../src/items/item';
+import { AddItem } from '../../src/items/uses/container/addItem';
+import { Retrieve } from '../../src/items/uses/stand/retrieve';
+import { Mob } from '../../src/mobs/mob';
+import { ItemGenerator } from '../../src/items/itemGenerator';
+
+beforeEach(() => {
+  commonSetup();
+  Community.makeVillage('alchemists', 'Alchemists guild');
+});
+
+describe('Try to retrieve a potion from a potion stand', () => {
+  test('Should create a potion stand with a potion and player should retrieve it', () => {
+    const worldDescription = {
+      tiles: [
+        [-1, -1],
+        [-1, -1]
+      ],
+      terrain_types: [],
+      item_types: [
+        {
+          name: 'Potion',
+          description: 'A potion',
+          type: 'potion',
+          carryable: true,
+          walkable: true,
+          interactions: [],
+          attributes: [],
+          on_tick: []
+        },
+
+        {
+          name: 'Potion stand',
+          description: 'A stand that sells potions',
+          type: 'potion-stand',
+          carryable: false,
+          smashable: true,
+          walkable: true,
+          show_price_at: {
+            x: 7,
+            y: -10
+          },
+
+          subtype: '255',
+          interactions: [
+            {
+              description: 'Get $item_name',
+              action: 'retrieve_item',
+              while_carried: false
+            }
+          ],
+          attributes: [
+            {
+              name: 'items',
+              value: 0
+            },
+            {
+              name: 'price',
+              value: 10
+            },
+            {
+              name: 'gold',
+              value: 0
+            },
+            {
+              name: 'health',
+              value: 1
+            }
+          ],
+          on_tick: []
+        }
+      ],
+      mob_types: [
+        {
+          name: 'Player',
+          description: 'The player',
+          name_style: 'norse-english',
+          type: 'player',
+          health: 100,
+          speed: 2.5,
+          attack: 5,
+          gold: 0,
+          community: 'alchemists',
+          stubbornness: 20,
+          bravery: 5,
+          aggression: 5,
+          industriousness: 40,
+          adventurousness: 10,
+          gluttony: 50,
+          sleepy: 80,
+          extroversion: 50,
+          speaker: true
+        }
+      ],
+      communities: [
+        {
+          id: 'alchemists',
+          name: 'Alchemists guild',
+          description:
+            "The Alchemist's guild, a group of alchemists who study the primal colors and their effects."
+        }
+      ]
+    };
+
+    // Generate world
+    const standPosition = { x: 0, y: 1 };
+    const playerPosition = { x: 0, y: 0 };
+    mobFactory.loadTemplates(worldDescription.mob_types);
+
+    // Create a potion stand
+    const itemGenerator = new ItemGenerator(worldDescription.item_types);
+    itemGenerator.createItem({
+      type: 'potion-stand',
+      subtype: '255',
+      position: standPosition,
+      attributes: {
+        templateType: 'potion'
+      }
+    });
+    const standID = Item.getItemIDAt(standPosition);
+    expect(standID).not.toBeNull();
+    const testStand = Item.getItem(standID!);
+    expect(testStand).not.toBeNull();
+
+    // Create player
+    mobFactory.makeMob('player', playerPosition, 'TestID', 'TestPlayer');
+    const testMob = Mob.getMob('TestID');
+    expect(testMob).not.toBeNull();
+
+    // Give potion to player
+    itemGenerator.createItem({
+      type: 'potion',
+      subtype: '255',
+      position: { x: 1, y: 0 },
+      carriedBy: testMob
+    });
+
+    // Place potion on stand
+    const potion = new AddItem();
+    potion.interact(testMob!, testStand!);
+
+    // Ensure potion is on stand
+    expect(testStand).not.toBeNull();
+    expect(testStand!.getAttribute('items')).toBe(1);
+
+    // Check to see that player is not carrying anything before retrieval
+    // expect(testMob!.carrying).not.toBeNull();
+    expect(testMob!.carrying).toBeNull();
+
+    // add the potion to the stand
+    // Retrieve the potion from the stand
+    const testAddItem = new Retrieve();
+    const test = testAddItem.interact(testMob!, testStand!);
+    // expect(test).toBe(true);
+
+    // Check that the player has the potion
+    // const standAfter = Item.getItem(standID!);
+    // expect(standAfter).not.toBeNull();
+    // expect(standAfter!.getAttribute('items')).toBe(1);
+    expect(testMob!.carrying).not.toBeNull();
+    expect(testMob!.carrying!.type).toBe('potion');
+  });
+});
+
+afterEach(() => {
+  DB.close();
+});


### PR DESCRIPTION
### Group Members: Alex Ralston, Harshini Karthikeyan, Chelsey Harper

Fixes [#31](https://github.com/sloalchemist/potions/issues/31)

### Summary

Before the fix, when a player added a potion to a potion stand, the only way to retrieve that potion was to purchase it. Players should not need to buy back their own potions. We believe there should be a way to pick up a potion from a stand. 

### What Changed

-  `packages/client/static/global.json`: Added retrieve_item interaction to potion-stand.

-  `packages/server/src/items/purchasable.ts`: Added retrieveItem method to Purchasable class to transfer item from stand to mob.

-  `packages/server/src/items/uses/stand/retrieve.ts`: Created stand/retrieve.ts to define retrieval.

-  `packages/server/src/items/uses/usesConfig.ts`: Added Retrieve action.

- `packages/server/test/items/itemRetrievePotionFromStand.test.ts`: Tested functionality -- mob successfully retrieves potion from stand.



