### PR TITLE
Feat: Blue potions no longer decrease health, but rather increase player speed

### DIFF
--- a/packages/client/src/scenes/uxScene.ts
+++ b/packages/client/src/scenes/uxScene.ts
@@ -27,6 +27,7 @@ export class UxScene extends Phaser.Scene {
   chatButtons: ChatButtonManager = new ChatButtonManager([]);
   goldText: Phaser.GameObjects.Text | null = null;
   healthText: Phaser.GameObjects.Text | null = null;
+  speedText: Phaser.GameObjects.Text | null = null;
   dateText: Phaser.GameObjects.Text | null = null;
   chatRequested: boolean = false;
 
@@ -147,6 +148,10 @@ export class UxScene extends Phaser.Scene {
         'Health: ' + currentCharacter.health
       );
       this.statsContainer.add(this.healthText);
+
+      this.speedText = this.add.text(15, 115, 'Speed: ' + currentCharacter.speed);
+      this.statsContainer.add(this.speedText);
+
       this.dateText = this.add.text(
         15,
         115,
@@ -201,6 +206,7 @@ export class UxScene extends Phaser.Scene {
     if (currentCharacter) {
       this.goldText?.setText('Gold: ' + currentCharacter.gold);
       this.healthText?.setText('Health: ' + currentCharacter.health);
+      this.speedText?.setText('Speed: ' + currentCharacter.speed);
     }
   }
 

--- a/packages/client/src/scenes/uxScene.ts
+++ b/packages/client/src/scenes/uxScene.ts
@@ -154,7 +154,7 @@ export class UxScene extends Phaser.Scene {
 
       this.dateText = this.add.text(
         15,
-        115,
+        140,
         'Date: reading position of sun and stars'
       );
       this.statsContainer.add(this.dateText);

--- a/packages/client/src/sprite/sprite_mob.ts
+++ b/packages/client/src/sprite/sprite_mob.ts
@@ -47,7 +47,6 @@ export class SpriteMob extends Mob {
       mob.type,
       mob.maxHealth,
       mob.position,
-      // mob.speed,
       mob.attributes
     );
     this.scene = scene;

--- a/packages/client/src/sprite/sprite_mob.ts
+++ b/packages/client/src/sprite/sprite_mob.ts
@@ -1,3 +1,4 @@
+
 import { MobI } from '@rt-potion/common';
 import { WorldScene } from '../scenes/worldScene';
 import { SpriteItem } from './sprite_item';
@@ -46,7 +47,7 @@ export class SpriteMob extends Mob {
       mob.type,
       mob.maxHealth,
       mob.position,
-      mob.speed,
+      // mob.speed,
       mob.attributes
     );
     this.scene = scene;

--- a/packages/client/src/world/mob.ts
+++ b/packages/client/src/world/mob.ts
@@ -5,7 +5,7 @@ import { World } from './world';
 export class Mob extends Physical {
   _target?: Coord;
   path: Coord[] = [];
-  speed: number;
+  // speed: number;
   name: string;
   maxHealth: number;
   dead: boolean = false;
@@ -21,11 +21,11 @@ export class Mob extends Physical {
     type: string,
     maxHealth: number,
     position: Coord | null,
-    speed: number,
+    // speed: number,
     attributes: Record<string, number>
   ) {
     super(world, key, type, position);
-    this.speed = speed;
+    // this.speed = speed;
     this.name = name;
     this.maxHealth = maxHealth;
 
@@ -80,7 +80,7 @@ export class Mob extends Physical {
       const [position, angle] = followPath(
         this.position,
         this.path,
-        this.speed,
+        this.attributes['speed'],
         deltaTime
       );
       this.changePosition(world, position);

--- a/packages/client/src/world/mob.ts
+++ b/packages/client/src/world/mob.ts
@@ -5,7 +5,6 @@ import { World } from './world';
 export class Mob extends Physical {
   _target?: Coord;
   path: Coord[] = [];
-  // speed: number;
   name: string;
   maxHealth: number;
   dead: boolean = false;
@@ -21,11 +20,9 @@ export class Mob extends Physical {
     type: string,
     maxHealth: number,
     position: Coord | null,
-    // speed: number,
     attributes: Record<string, number>
   ) {
     super(world, key, type, position);
-    // this.speed = speed;
     this.name = name;
     this.maxHealth = maxHealth;
 

--- a/packages/client/src/worldMetadata.ts
+++ b/packages/client/src/worldMetadata.ts
@@ -41,6 +41,13 @@ export class Character {
     return world.mobs[publicCharacterId].attributes['health'];
   }
 
+  get speed(): number {
+    if (!world || !world.mobs[publicCharacterId]) {
+      return 0;
+    }
+    return world.mobs[publicCharacterId].attributes['speed'];
+  }
+
   subtype(): string {
     return `${this.eyeColor}-${this.bellyColor}-${this.furColor}`;
   }

--- a/packages/client/test/chatui/chatui.test.ts
+++ b/packages/client/test/chatui/chatui.test.ts
@@ -55,8 +55,8 @@ describe('Chat UI updates based on chatting state', () => {
   });
 
   test('triggers callback after chatting', () => {
-    const player1 = new Mob(world!, 'mob1', 'Player1', 'player', 100, { x: 1, y: 1 }, 2, {});
-    const npc1 = new Mob(world!, 'mob2', 'NPC1', 'npc', 100, { x: 2, y: 2 }, 2, {});
+    const player1 = new Mob(world!, 'mob1', 'Player1', 'player', 100, { x: 1, y: 1 }, {});
+    const npc1 = new Mob(world!, 'mob2', 'NPC1', 'npc', 100, { x: 2, y: 2 }, {});
     const mobs = [player1, npc1];
     const expectedFilteredMobs = [npc1];
 
@@ -79,8 +79,8 @@ describe('Chat UI updates based on chatting state', () => {
   });
 
   test('should not trigger callback if the nearby mobs does not change', () => {
-    const player1 = new Mob(world!, 'mob1', 'Player1', 'player', 100, { x: 1, y: 1 }, 2, {});
-    const npc = new Mob(world!, 'mob2', 'NPC1', 'npc', 100, { x: 2, y: 2 }, 2, {});
+    const player1 = new Mob(world!, 'mob1', 'Player1', 'player', 100, { x: 1, y: 1 }, {});
+    const npc = new Mob(world!, 'mob2', 'NPC1', 'npc', 100, { x: 2, y: 2 }, {});
     const mobs = [player1, npc];
 
     setChatting(false);
@@ -97,8 +97,8 @@ describe('Chat UI updates based on chatting state', () => {
   });
 
   test('should update chat companions when a second mob enters range', () => {
-    const player1 = new Mob(world!, 'mob1', 'Player1', 'player', 100, { x: 1, y: 1 }, 2, {});
-    const npc1 = new Mob(world!, 'mob2', 'NPC1', 'npc', 100, { x: 2, y: 2 }, 2, {});
+    const player1 = new Mob(world!, 'mob1', 'Player1', 'player', 100, { x: 1, y: 1 }, {});
+    const npc1 = new Mob(world!, 'mob2', 'NPC1', 'npc', 100, { x: 2, y: 2 }, {});
     let mobs = [player1, npc1];
 
     setChatting(false);
@@ -110,7 +110,7 @@ describe('Chat UI updates based on chatting state', () => {
     mockChatCallback.mockClear();
 
     // Add second mob
-    const npc2 = new Mob(world!, 'mob3', 'NPC2', 'npc', 100, { x: 3, y: 3 }, 2, {});
+    const npc2 = new Mob(world!, 'mob3', 'NPC2', 'npc', 100, { x: 3, y: 3 }, {});
     mobs = [player1, npc1, npc2];
     mobRangeListener(mobs);
 

--- a/packages/client/test/world/mob.test.ts
+++ b/packages/client/test/world/mob.test.ts
@@ -28,7 +28,6 @@ const createTestMob = (): Mob => {
     'test',
     1,
     { x: 0, y: 0 },
-    1,
     {}
   );
   mob.path = TEST_OLD_PATH;

--- a/packages/common/src/mob.ts
+++ b/packages/common/src/mob.ts
@@ -7,7 +7,6 @@ export type MobI = {
   subtype: string;
   target?: Coord;
   path: Coord[];
-  // speed: number;
   name: string;
   maxHealth: number;
   carrying?: string;

--- a/packages/common/src/mob.ts
+++ b/packages/common/src/mob.ts
@@ -7,7 +7,7 @@ export type MobI = {
   subtype: string;
   target?: Coord;
   path: Coord[];
-  speed: number;
+  // speed: number;
   name: string;
   maxHealth: number;
   carrying?: string;

--- a/packages/server/src/items/potionEffects.ts
+++ b/packages/server/src/items/potionEffects.ts
@@ -8,6 +8,6 @@ export function drinkPotion(mob: Mob, potionType: string): boolean {
     return true;
   }
 
-  mob.changeHealth(-50);
+  mob.changeSpeed(2);
   return false;
 }

--- a/packages/server/src/mobs/mob.ts
+++ b/packages/server/src/mobs/mob.ts
@@ -168,7 +168,7 @@ export class Mob {
     return this._health;
   }
 
-  getSpeed(): number {
+  get _speed(): number {
     return this.speed;
 }
 

--- a/packages/server/src/mobs/mob.ts
+++ b/packages/server/src/mobs/mob.ts
@@ -168,6 +168,10 @@ export class Mob {
     return this._health;
   }
 
+  getSpeed(): number {
+    return this.speed;
+}
+
   get name(): string {
     return this._name;
   }
@@ -357,6 +361,21 @@ export class Mob {
       ).run({ id: this.id });
       this.destroy();
     }
+  }
+
+    changeSpeed(amount: number) {
+    if (amount === 0) return;
+    let newSpeed = this.speed + amount;
+    if (newSpeed > 10) newSpeed = 10;
+    DB.prepare(
+      `
+            UPDATE mobs
+            SET speed = :speed
+            WHERE id = :id
+        `
+    ).run({ speed: newSpeed, id: this.id });
+    this.speed = newSpeed;
+    pubSub.changeSpeed(this.id, amount, this.speed);
   }
 
   getHouse(): House | undefined {

--- a/packages/server/src/services/clientCommunication/ablyService.ts
+++ b/packages/server/src/services/clientCommunication/ablyService.ts
@@ -217,7 +217,24 @@ export class AblyService implements PubSub {
       }
     });
   }
-
+ 
+  public changeSpeed(key: string, speed: number, newValue: number): void {
+    if (newValue == undefined || key == undefined || speed == undefined) {
+      throw new Error(
+        `Sending invalid changeSpeed message ${key}, ${speed}, ${newValue}`
+      );
+    }
+    this.addToBroadcast({
+      type: 'mob_change',
+      data: {
+        id: key,
+        property: 'speed',
+        delta: speed,
+        new_value: newValue
+      }
+    });
+  }
+  
   public changeGold(key: string, gold: number, newValue: number): void {
     if (newValue == undefined || key == undefined || gold == undefined) {
       throw new Error(

--- a/packages/server/src/services/clientCommunication/clientMarshalling.ts
+++ b/packages/server/src/services/clientCommunication/clientMarshalling.ts
@@ -49,7 +49,6 @@ function mobDataToMob(mobData: MobData): MobI {
         ? { x: mobData.target_x, y: mobData.target_y }
         : undefined,
     path: mobData.path ? JSON.parse(mobData.path) : [],
-    // speed: mobData.speed,
     name: mobData.name,
     maxHealth: mobData.maxHealth,
     carrying: mobData.carrying_id,

--- a/packages/server/src/services/clientCommunication/clientMarshalling.ts
+++ b/packages/server/src/services/clientCommunication/clientMarshalling.ts
@@ -49,11 +49,11 @@ function mobDataToMob(mobData: MobData): MobI {
         ? { x: mobData.target_x, y: mobData.target_y }
         : undefined,
     path: mobData.path ? JSON.parse(mobData.path) : [],
-    speed: mobData.speed,
+    // speed: mobData.speed,
     name: mobData.name,
     maxHealth: mobData.maxHealth,
     carrying: mobData.carrying_id,
-    attributes: { health: mobData.health, gold: mobData.gold },
+    attributes: { health: mobData.health, gold: mobData.gold, speed: mobData.speed },
     unlocks: mobData.community_id ? [mobData.community_id] : [],
     doing: mobData.current_action
   };

--- a/packages/server/src/services/clientCommunication/pubsub.ts
+++ b/packages/server/src/services/clientCommunication/pubsub.ts
@@ -21,6 +21,7 @@ export interface PubSub {
   move(key: string, target: Coord | undefined, path: Coord[]): void;
   destroy(item: Item): void;
   changeHealth(key: string, health: number, newValue: number): void;
+  changeSpeed(key: string, speed: number, newValue: number): void;
   changeGold(key: string, gold: number, newValue: number): void;
   changeItemAttribute(itemKey: string, property: string, value: number): void;
   speak(key: string, message: string): void;

--- a/packages/server/src/services/clientCommunication/stubbedPubSub.ts
+++ b/packages/server/src/services/clientCommunication/stubbedPubSub.ts
@@ -26,6 +26,8 @@ export class StubbedPubSub implements PubSub {
 
   changeHealth(_key: string, _health: number, _newValue: number): void {}
 
+  changeSpeed(_key: string, _speed: number, _newValue: number): void {}
+
   changeGold(_key: string, _gold: number, _newValue: number): void {}
 
   changeItemAttribute(

--- a/packages/server/test/items/potionEffects.test.ts
+++ b/packages/server/test/items/potionEffects.test.ts
@@ -3,7 +3,6 @@ import { DB } from '../../src/services/database';
 import { mobFactory } from '../../src/mobs/mobFactory';
 import { Community } from '../../src/community/community';
 import { Item } from '../../src/items/item';
-import { AddItem } from '../../src/items/uses/container/addItem';
 import { Mob } from '../../src/mobs/mob';
 import { ItemGenerator } from '../../src/items/itemGenerator';
 import { Drink } from '../../src/items/uses/drink';
@@ -66,7 +65,6 @@ describe('Try to consume blue potion in various cases', () => {
     };
 
     //set up the world
-    const standPosition = { x: 0, y: 1 };
     const position = { x: 0, y: 0 };
     mobFactory.loadTemplates(worldDescription.mob_types);
 
@@ -190,7 +188,6 @@ describe('Try to consume blue potion in various cases', () => {
     };
 
     //set up the world
-    const standPosition = { x: 0, y: 1 };
     const position = { x: 0, y: 0 };
     mobFactory.loadTemplates(worldDescription.mob_types);
 

--- a/packages/server/test/items/potionEffects.test.ts
+++ b/packages/server/test/items/potionEffects.test.ts
@@ -1,0 +1,157 @@
+import { commonSetup } from '../testSetup';
+import { DB } from '../../src/services/database';
+import { mobFactory } from '../../src/mobs/mobFactory';
+import { Community } from '../../src/community/community';
+import { Item } from '../../src/items/item';
+import { AddItem } from '../../src/items/uses/container/addItem';
+import { Mob } from '../../src/mobs/mob';
+import { ItemGenerator } from '../../src/items/itemGenerator';
+
+test('Add a blue potion: Should increase speed by 2', () => {
+    const worldDescription = {
+      tiles: [
+        [-1, -1],
+        [-1, -1]
+      ],
+      terrain_types: [],
+      item_types: [
+        {
+          name: 'Potion',
+          description: 'A magical concoction',
+          type: 'potion',
+          carryable: true,
+          walkable: true,
+          interactions: [],
+          attributes: [],
+          on_tick: []
+        },
+  
+        {
+          name: 'Potion stand',
+          description: 'A stand that sells health potions.',
+          type: 'potion-stand',
+          carryable: false,
+          smashable: true,
+          walkable: true,
+          show_price_at: {
+            x: 7,
+            y: -10
+          },
+  
+          subtype: '255',
+          interactions: [
+            {
+              description: 'Add $item_name',
+              action: 'add_item',
+              while_carried: false
+            }
+          ],
+          attributes: [
+            {
+              name: 'items',
+              value: 0
+            },
+            {
+              name: 'price',
+              value: 10
+            },
+            {
+              name: 'gold',
+              value: 0
+            },
+            {
+              name: 'health',
+              value: 1
+            }
+          ],
+          on_tick: []
+        }
+      ],
+      mob_types: [
+        {
+          name: 'Player',
+          description: 'The player',
+          name_style: 'norse-english',
+          type: 'player',
+          health: 100,
+          speed: 2.5,  // initial speed
+          attack: 5,
+          gold: 0,
+          community: 'alchemists',
+          stubbornness: 20,
+          bravery: 5,
+          aggression: 5,
+          industriousness: 40,
+          adventurousness: 10,
+          gluttony: 50,
+          sleepy: 80,
+          extroversion: 50,
+          speaker: true
+        }
+      ],
+      communities: [
+        {
+          id: 'alchemists',
+          name: 'Alchemists guild',
+          description:
+            "The Alchemist's guild, a group of alchemists who study the primal colors and their effects."
+        }
+      ]
+    };
+  
+    //set up the world
+    const standPosition = { x: 0, y: 1 };
+    const position = { x: 0, y: 0 };
+    mobFactory.loadTemplates(worldDescription.mob_types);
+  
+    //create a blue potion stand
+    const itemGenerator = new ItemGenerator(worldDescription.item_types);
+    itemGenerator.createItem({
+      type: 'potion-stand',
+      subtype: '255',
+      position: standPosition,
+      attributes: {
+        templateType: 'potion'
+      }
+    });
+    const standID = Item.getItemIDAt(standPosition);
+    expect(standID).not.toBeNull();
+    const testStand = Item.getItem(standID!);
+    expect(testStand).not.toBeNull();
+  
+    // create a player
+    mobFactory.makeMob('player', position, 'TestID', 'TestPlayer');
+    const testMob = Mob.getMob('TestID');
+    expect(testMob).not.toBeNull();
+  
+    // record the player's initial speed
+    const initialSpeed = testMob!.getSpeed();
+    expect(initialSpeed).toBe(2.5);  // initial speed should be 2.5
+  
+    // create a blue potion that increases speed by 2
+    itemGenerator.createItem({
+      type: 'potion',
+      subtype: 'bluePotion',  // assuming this is a unique identifier for blue potions
+      position: { x: 1, y: 0 },
+      carriedBy: testMob
+    });
+    const potion = Item.getItemIDAt({ x: 1, y: 0 });
+    expect(potion).not.toBeNull();
+    const potionItem = Item.getItem(potion!);
+    expect(potionItem).not.toBeNull();
+  
+    // ensure the player is carrying the potion
+    expect(testMob!.carrying).not.toBeNull();
+    expect(testMob!.carrying!.type).toBe('potion');
+    expect(testMob!.carrying!.subtype).toBe('bluePotion');
+  
+    // add the blue potion to the stand
+    const testAddItem = new AddItem();
+    const test = testAddItem.interact(testMob!, testStand!);
+    expect(test).toBe(true);
+  
+    // check that the player's speed has increased by 2
+    const finalSpeed = testMob!.getSpeed();
+    expect(finalSpeed).toBe(initialSpeed + 2);  // final speed should be initial speed + 2
+  });
+  

--- a/packages/server/test/items/potionEffects.test.ts
+++ b/packages/server/test/items/potionEffects.test.ts
@@ -7,7 +7,13 @@ import { AddItem } from '../../src/items/uses/container/addItem';
 import { Mob } from '../../src/mobs/mob';
 import { ItemGenerator } from '../../src/items/itemGenerator';
 
-test('Add a blue potion: Should increase speed by 2', () => {
+beforeEach(() => {
+  commonSetup();
+  Community.makeVillage('alchemists', 'Alchemists guild');
+});
+
+describe('Try to add various color potions to a blue potion-stand', () => {
+  test('Add a blue potion: Should add the potion', () => {
     const worldDescription = {
       tiles: [
         [-1, -1],
@@ -25,7 +31,7 @@ test('Add a blue potion: Should increase speed by 2', () => {
           attributes: [],
           on_tick: []
         },
-  
+
         {
           name: 'Potion stand',
           description: 'A stand that sells health potions.',
@@ -37,7 +43,7 @@ test('Add a blue potion: Should increase speed by 2', () => {
             x: 7,
             y: -10
           },
-  
+
           subtype: '255',
           interactions: [
             {
@@ -74,7 +80,7 @@ test('Add a blue potion: Should increase speed by 2', () => {
           name_style: 'norse-english',
           type: 'player',
           health: 100,
-          speed: 2.5,  // initial speed
+          speed: 2.5,
           attack: 5,
           gold: 0,
           community: 'alchemists',
@@ -98,12 +104,12 @@ test('Add a blue potion: Should increase speed by 2', () => {
         }
       ]
     };
-  
+
     //set up the world
     const standPosition = { x: 0, y: 1 };
     const position = { x: 0, y: 0 };
     mobFactory.loadTemplates(worldDescription.mob_types);
-  
+
     //create a blue potion stand
     const itemGenerator = new ItemGenerator(worldDescription.item_types);
     itemGenerator.createItem({
@@ -118,20 +124,16 @@ test('Add a blue potion: Should increase speed by 2', () => {
     expect(standID).not.toBeNull();
     const testStand = Item.getItem(standID!);
     expect(testStand).not.toBeNull();
-  
+
     // create a player
     mobFactory.makeMob('player', position, 'TestID', 'TestPlayer');
     const testMob = Mob.getMob('TestID');
     expect(testMob).not.toBeNull();
-  
-    // record the player's initial speed
-    const initialSpeed = testMob!.getSpeed();
-    expect(initialSpeed).toBe(2.5);  // initial speed should be 2.5
-  
-    // create a blue potion that increases speed by 2
+
+    // create a potion
     itemGenerator.createItem({
       type: 'potion',
-      subtype: 'bluePotion',  // assuming this is a unique identifier for blue potions
+      subtype: '255',
       position: { x: 1, y: 0 },
       carriedBy: testMob
     });
@@ -139,19 +141,149 @@ test('Add a blue potion: Should increase speed by 2', () => {
     expect(potion).not.toBeNull();
     const potionItem = Item.getItem(potion!);
     expect(potionItem).not.toBeNull();
-  
+
     // ensure the player is carrying the potion
     expect(testMob!.carrying).not.toBeNull();
     expect(testMob!.carrying!.type).toBe('potion');
-    expect(testMob!.carrying!.subtype).toBe('bluePotion');
-  
-    // add the blue potion to the stand
+    expect(testMob!.carrying!.subtype).toBe('255');
+
+    // add the potion to the stand
     const testAddItem = new AddItem();
     const test = testAddItem.interact(testMob!, testStand!);
     expect(test).toBe(true);
-  
-    // check that the player's speed has increased by 2
-    const finalSpeed = testMob!.getSpeed();
-    expect(finalSpeed).toBe(initialSpeed + 2);  // final speed should be initial speed + 2
+
+    // check that the potion was added
+    const standAfter = Item.getItem(standID!);
+    expect(standAfter).not.toBeNull();
+    expect(standAfter!.getAttribute('items')).toBe(1);
   });
+
+  test('Add a red potion: Should NOT add the potion', () => {
+    const worldDescription = {
+      tiles: [
+        [-1, -1],
+        [-1, -1]
+      ],
+      terrain_types: [],
+      item_types: [
+        {
+          name: 'Potion',
+          description: 'A magical concoction',
+          type: 'potion',
+          carryable: true,
+          walkable: true,
+          interactions: [],
+          attributes: [],
+          on_tick: []
+        },
+
+        {
+          name: 'Potion stand',
+          description: 'A stand that sells health potions.',
+          type: 'potion-stand',
+          carryable: false,
+          smashable: true,
+          walkable: true,
+          show_price_at: {
+            x: 7,
+            y: -10
+          },
+
+          subtype: '255',
+          interactions: [
+            {
+              description: 'Add $item_name',
+              action: 'add_item',
+              while_carried: false
+            }
+          ],
+          attributes: [
+            {
+              name: 'items',
+              value: 0
+            },
+            {
+              name: 'price',
+              value: 10
+            },
+            {
+              name: 'gold',
+              value: 0
+            },
+            {
+              name: 'health',
+              value: 1
+            }
+          ],
+          on_tick: []
+        }
+      ],
+      mob_types: [
+        {
+          name: 'Player',
+          description: 'The player',
+          name_style: 'norse-english',
+          type: 'player',
+          health: 100,
+          speed: 2.5,
+          attack: 5,
+          gold: 0,
+          community: 'alchemists',
+          stubbornness: 20,
+          bravery: 5,
+          aggression: 5,
+          industriousness: 40,
+          adventurousness: 10,
+          gluttony: 50,
+          sleepy: 80,
+          extroversion: 50,
+          speaker: true
+        }
+      ],
+      communities: [
+        {
+          id: 'alchemists',
+          name: 'Alchemists guild',
+          description:
+            "The Alchemist's guild, a group of alchemists who study the primal colors and their effects."
+        }
+      ]
+    };
+
+    //set up the world
+    const standPosition = { x: 0, y: 1 };
+    const position = { x: 0, y: 0 };
+    mobFactory.loadTemplates(worldDescription.mob_types);
+
+    const itemGenerator = new ItemGenerator(worldDescription.item_types);
+
+    // create a player
+    mobFactory.makeMob('player', position, 'TestID', 'TestPlayer');
+    const testMob = Mob.getMob('TestID');
+    expect(testMob).not.toBeNull();
+
+    // create a potion
+    itemGenerator.createItem({
+        type: 'potion',
+        subtype: '255',
+        position: { x: 1, y: 0 },
+        carriedBy: testMob
+      });
+      const potion = Item.getItemIDAt({ x: 1, y: 0 });
+      expect(potion).not.toBeNull();
+      const potionItem = Item.getItem(potion!);
+      expect(potionItem).not.toBeNull();
   
+      // ensure the player is carrying the potion
+      expect(testMob!.carrying).not.toBeNull();
+      expect(testMob!.carrying!.type).toBe('potion');
+      expect(testMob!.carrying!.subtype).toBe('255');
+
+      // have the player drink the potion
+      let test
+  });
+});
+
+afterEach(() => {
+  DB.close();
+});

--- a/packages/server/test/items/potionEffects.test.ts
+++ b/packages/server/test/items/potionEffects.test.ts
@@ -6,6 +6,7 @@ import { Item } from '../../src/items/item';
 import { AddItem } from '../../src/items/uses/container/addItem';
 import { Mob } from '../../src/mobs/mob';
 import { ItemGenerator } from '../../src/items/itemGenerator';
+import { Drink } from '../../src/items/uses/drink';
 
 beforeEach(() => {
   commonSetup();
@@ -13,7 +14,7 @@ beforeEach(() => {
 });
 
 describe('Try to add various color potions to a blue potion-stand', () => {
-  test('Add a blue potion: Should add the potion', () => {
+  test('Create player, consumer blue potions, check increased speed.', () => {
     const worldDescription = {
       tiles: [
         [-1, -1],
@@ -29,192 +30,6 @@ describe('Try to add various color potions to a blue potion-stand', () => {
           walkable: true,
           interactions: [],
           attributes: [],
-          on_tick: []
-        },
-
-        {
-          name: 'Potion stand',
-          description: 'A stand that sells health potions.',
-          type: 'potion-stand',
-          carryable: false,
-          smashable: true,
-          walkable: true,
-          show_price_at: {
-            x: 7,
-            y: -10
-          },
-
-          subtype: '255',
-          interactions: [
-            {
-              description: 'Add $item_name',
-              action: 'add_item',
-              while_carried: false
-            }
-          ],
-          attributes: [
-            {
-              name: 'items',
-              value: 0
-            },
-            {
-              name: 'price',
-              value: 10
-            },
-            {
-              name: 'gold',
-              value: 0
-            },
-            {
-              name: 'health',
-              value: 1
-            }
-          ],
-          on_tick: []
-        }
-      ],
-      mob_types: [
-        {
-          name: 'Player',
-          description: 'The player',
-          name_style: 'norse-english',
-          type: 'player',
-          health: 100,
-          speed: 2.5,
-          attack: 5,
-          gold: 0,
-          community: 'alchemists',
-          stubbornness: 20,
-          bravery: 5,
-          aggression: 5,
-          industriousness: 40,
-          adventurousness: 10,
-          gluttony: 50,
-          sleepy: 80,
-          extroversion: 50,
-          speaker: true
-        }
-      ],
-      communities: [
-        {
-          id: 'alchemists',
-          name: 'Alchemists guild',
-          description:
-            "The Alchemist's guild, a group of alchemists who study the primal colors and their effects."
-        }
-      ]
-    };
-
-    //set up the world
-    const standPosition = { x: 0, y: 1 };
-    const position = { x: 0, y: 0 };
-    mobFactory.loadTemplates(worldDescription.mob_types);
-
-    //create a blue potion stand
-    const itemGenerator = new ItemGenerator(worldDescription.item_types);
-    itemGenerator.createItem({
-      type: 'potion-stand',
-      subtype: '255',
-      position: standPosition,
-      attributes: {
-        templateType: 'potion'
-      }
-    });
-    const standID = Item.getItemIDAt(standPosition);
-    expect(standID).not.toBeNull();
-    const testStand = Item.getItem(standID!);
-    expect(testStand).not.toBeNull();
-
-    // create a player
-    mobFactory.makeMob('player', position, 'TestID', 'TestPlayer');
-    const testMob = Mob.getMob('TestID');
-    expect(testMob).not.toBeNull();
-
-    // create a potion
-    itemGenerator.createItem({
-      type: 'potion',
-      subtype: '255',
-      position: { x: 1, y: 0 },
-      carriedBy: testMob
-    });
-    const potion = Item.getItemIDAt({ x: 1, y: 0 });
-    expect(potion).not.toBeNull();
-    const potionItem = Item.getItem(potion!);
-    expect(potionItem).not.toBeNull();
-
-    // ensure the player is carrying the potion
-    expect(testMob!.carrying).not.toBeNull();
-    expect(testMob!.carrying!.type).toBe('potion');
-    expect(testMob!.carrying!.subtype).toBe('255');
-
-    // add the potion to the stand
-    const testAddItem = new AddItem();
-    const test = testAddItem.interact(testMob!, testStand!);
-    expect(test).toBe(true);
-
-    // check that the potion was added
-    const standAfter = Item.getItem(standID!);
-    expect(standAfter).not.toBeNull();
-    expect(standAfter!.getAttribute('items')).toBe(1);
-  });
-
-  test('Add a red potion: Should NOT add the potion', () => {
-    const worldDescription = {
-      tiles: [
-        [-1, -1],
-        [-1, -1]
-      ],
-      terrain_types: [],
-      item_types: [
-        {
-          name: 'Potion',
-          description: 'A magical concoction',
-          type: 'potion',
-          carryable: true,
-          walkable: true,
-          interactions: [],
-          attributes: [],
-          on_tick: []
-        },
-
-        {
-          name: 'Potion stand',
-          description: 'A stand that sells health potions.',
-          type: 'potion-stand',
-          carryable: false,
-          smashable: true,
-          walkable: true,
-          show_price_at: {
-            x: 7,
-            y: -10
-          },
-
-          subtype: '255',
-          interactions: [
-            {
-              description: 'Add $item_name',
-              action: 'add_item',
-              while_carried: false
-            }
-          ],
-          attributes: [
-            {
-              name: 'items',
-              value: 0
-            },
-            {
-              name: 'price',
-              value: 10
-            },
-            {
-              name: 'gold',
-              value: 0
-            },
-            {
-              name: 'health',
-              value: 1
-            }
-          ],
           on_tick: []
         }
       ],
@@ -280,7 +95,13 @@ describe('Try to add various color potions to a blue potion-stand', () => {
       expect(testMob!.carrying!.subtype).toBe('255');
 
       // have the player drink the potion
-      let test
+      const testDrink = new Drink();
+      const test = testDrink.interact(testMob!, potionItem!);
+      expect(test).toBe(true);
+
+      // check new speed on player
+      
+
   });
 });
 

--- a/packages/server/test/items/potionEffects.test.ts
+++ b/packages/server/test/items/potionEffects.test.ts
@@ -13,8 +13,8 @@ beforeEach(() => {
   Community.makeVillage('alchemists', 'Alchemists guild');
 });
 
-describe('Try to add various color potions to a blue potion-stand', () => {
-  test('Create player, consumer blue potions, check increased speed.', () => {
+describe('Try to consume blue potion in various cases', () => {
+  test('Create player, consume blue potion, then check attributes', () => {
     const worldDescription = {
       tiles: [
         [-1, -1],
@@ -79,29 +79,127 @@ describe('Try to add various color potions to a blue potion-stand', () => {
 
     // create a potion
     itemGenerator.createItem({
-        type: 'potion',
-        subtype: '255',
-        position: { x: 1, y: 0 },
-        carriedBy: testMob
-      });
-      const potion = Item.getItemIDAt({ x: 1, y: 0 });
-      expect(potion).not.toBeNull();
-      const potionItem = Item.getItem(potion!);
-      expect(potionItem).not.toBeNull();
-  
-      // ensure the player is carrying the potion
-      expect(testMob!.carrying).not.toBeNull();
-      expect(testMob!.carrying!.type).toBe('potion');
-      expect(testMob!.carrying!.subtype).toBe('255');
+      type: 'potion',
+      subtype: '255',
+      position: { x: 1, y: 0 },
+      carriedBy: testMob
+    });
+    const potion = Item.getItemIDAt({ x: 1, y: 0 });
+    expect(potion).not.toBeNull();
+    const potionItem = Item.getItem(potion!);
+    expect(potionItem).not.toBeNull();
 
-      // have the player drink the potion
-      const testDrink = new Drink();
-      const test = testDrink.interact(testMob!, potionItem!);
-      expect(test).toBe(true);
+    // ensure the player is carrying the potion
+    expect(testMob!.carrying).not.toBeNull();
+    expect(testMob!.carrying!.type).toBe('potion');
+    expect(testMob!.carrying!.subtype).toBe('255');
 
-      // check new speed on player
-      
+    // have the player drink the potion
+    const testDrink = new Drink();
+    const test = testDrink.interact(testMob!, potionItem!);
+    expect(test).toBe(true);
 
+    // check to make sure potion is not being carried
+    expect(testMob!.carrying).toBeUndefined();
+
+    // check attributes on player
+    expect(testMob!._speed).toBe(4.5);
+    expect(testMob!.health).toBe(100);
+    expect(testMob!.gold).toBe(0);
+  });
+
+  test('Create player with near max speed, consume blue potion, then check attributes', () => {
+    const worldDescription = {
+      tiles: [
+        [-1, -1],
+        [-1, -1]
+      ],
+      terrain_types: [],
+      item_types: [
+        {
+          name: 'Potion',
+          description: 'A magical concoction',
+          type: 'potion',
+          carryable: true,
+          walkable: true,
+          interactions: [],
+          attributes: [],
+          on_tick: []
+        }
+      ],
+      mob_types: [
+        {
+          name: 'Player',
+          description: 'The player',
+          name_style: 'norse-english',
+          type: 'player',
+          health: 100,
+          speed: 9,
+          attack: 5,
+          gold: 0,
+          community: 'alchemists',
+          stubbornness: 20,
+          bravery: 5,
+          aggression: 5,
+          industriousness: 40,
+          adventurousness: 10,
+          gluttony: 50,
+          sleepy: 80,
+          extroversion: 50,
+          speaker: true
+        }
+      ],
+      communities: [
+        {
+          id: 'alchemists',
+          name: 'Alchemists guild',
+          description:
+            "The Alchemist's guild, a group of alchemists who study the primal colors and their effects."
+        }
+      ]
+    };
+
+    //set up the world
+    const standPosition = { x: 0, y: 1 };
+    const position = { x: 0, y: 0 };
+    mobFactory.loadTemplates(worldDescription.mob_types);
+
+    const itemGenerator = new ItemGenerator(worldDescription.item_types);
+
+    // create a player
+    mobFactory.makeMob('player', position, 'TestID', 'TestPlayer');
+    const testMob = Mob.getMob('TestID');
+    expect(testMob).not.toBeNull();
+
+    // create a potion
+    itemGenerator.createItem({
+      type: 'potion',
+      subtype: '255',
+      position: { x: 1, y: 0 },
+      carriedBy: testMob
+    });
+    const potion = Item.getItemIDAt({ x: 1, y: 0 });
+    expect(potion).not.toBeNull();
+    const potionItem = Item.getItem(potion!);
+    expect(potionItem).not.toBeNull();
+
+    // ensure the player is carrying the potion
+    expect(testMob!.carrying).not.toBeNull();
+    expect(testMob!.carrying!.type).toBe('potion');
+    expect(testMob!.carrying!.subtype).toBe('255');
+
+    // have the player drink the potion
+    const testDrink = new Drink();
+    const test = testDrink.interact(testMob!, potionItem!);
+    expect(test).toBe(true);
+
+    // check to make sure potion is not being carried
+    expect(testMob!.carrying).toBeUndefined();
+
+    // check attributes on player, make sure 10 is cap for speed
+    expect(testMob!._speed).toBe(10);
+    expect(testMob!.health).toBe(100);
+    expect(testMob!.gold).toBe(0);
   });
 });
 

--- a/packages/server/test/items/potionEffects.test.ts
+++ b/packages/server/test/items/potionEffects.test.ts
@@ -106,6 +106,36 @@ describe('Try to consume blue potion in various cases', () => {
     expect(testMob!._speed).toBe(4.5);
     expect(testMob!.health).toBe(100);
     expect(testMob!.gold).toBe(0);
+
+    // create a potion
+    itemGenerator.createItem({
+      type: 'potion',
+      subtype: '255',
+      position: { x: 1, y: 0 },
+      carriedBy: testMob
+    });
+    const potion2 = Item.getItemIDAt({ x: 1, y: 0 });
+    expect(potion2).not.toBeNull();
+    const potionItem2 = Item.getItem(potion2!);
+    expect(potionItem2).not.toBeNull();
+
+    // ensure the player is carrying the potion
+    expect(testMob!.carrying).not.toBeNull();
+    expect(testMob!.carrying!.type).toBe('potion');
+    expect(testMob!.carrying!.subtype).toBe('255');
+
+    // have the player drink the potion
+    const testDrink2 = new Drink();
+    const test2 = testDrink2.interact(testMob!, potionItem2!);
+    expect(test2).toBe(true);
+
+    // check to make sure potion is not being carried
+    expect(testMob!.carrying).toBeUndefined();
+
+    // check attributes on player
+    expect(testMob!._speed).toBe(6.5);
+    expect(testMob!.health).toBe(100);
+    expect(testMob!.gold).toBe(0);
   });
 
   test('Create player with near max speed, consume blue potion, then check attributes', () => {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9,16 +9,11 @@ importers:
   .:
     devDependencies:
       eslint:
-<<<<<<< HEAD
         specifier: ^9.18.0
         version: 9.18.0
-=======
-        specifier: ^9.17.0
-        version: 9.17.0
       jest-environment-jsdom:
         specifier: ^29.7.0
-        version: 29.7.0
->>>>>>> f0b1ffc (fix: remove yarn file from root)
+        version: 29.7.0(canvas@3.0.1)
       rimraf:
         specifier: ^6.0.1
         version: 6.0.1
@@ -51,7 +46,7 @@ importers:
         version: 4.21.2
       jsdom:
         specifier: ^24.1.0
-        version: 24.1.3(canvas@2.11.2)
+        version: 24.1.3
     devDependencies:
       '@types/cookie-parser':
         specifier: ^1.4.7
@@ -104,7 +99,7 @@ importers:
         version: 29.5.14
       '@types/node':
         specifier: ^22.10.2
-        version: 22.10.5
+        version: 22.10.6
       '@types/uuid':
         specifier: ^10.0.0
         version: 10.0.0
@@ -119,24 +114,16 @@ importers:
         version: 8.57.1
       jest:
         specifier: ^29.7.0
-<<<<<<< HEAD
-        version: 29.7.0(@types/node@22.10.5)(ts-node@10.9.2(@types/node@22.10.5)(typescript@5.7.3))
-=======
-        version: 29.7.0(@types/node@22.10.2)(ts-node@10.9.2(@types/node@22.10.2)(typescript@5.7.2))
->>>>>>> f0b1ffc (fix: remove yarn file from root)
+        version: 29.7.0(@types/node@22.10.6)(ts-node@10.9.2(@types/node@22.10.6)(typescript@5.7.3))
       jest-canvas-mock:
         specifier: ^2.5.2
         version: 2.5.2
       jest-environment-jsdom:
         specifier: ^29.7.0
-<<<<<<< HEAD
         version: 29.7.0(canvas@3.0.1)
-=======
-        version: 29.7.0
       phaser3spectorjs:
         specifier: ^0.0.8
         version: 0.0.8
->>>>>>> f0b1ffc (fix: remove yarn file from root)
       prettier:
         specifier: ^3.0.0
         version: 3.4.2
@@ -145,7 +132,7 @@ importers:
         version: 5.0.10
       ts-jest:
         specifier: ^29.2.5
-        version: 29.2.5(@babel/core@7.26.0)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.26.0))(jest@29.7.0(@types/node@22.10.5)(ts-node@10.9.2(@types/node@22.10.5)(typescript@5.7.3)))(typescript@5.7.3)
+        version: 29.2.5(@babel/core@7.26.0)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.26.0))(jest@29.7.0(@types/node@22.10.6)(ts-node@10.9.2(@types/node@22.10.6)(typescript@5.7.3)))(typescript@5.7.3)
       ts-loader:
         specifier: ^8.0.0
         version: 8.4.0(typescript@5.7.3)(webpack@5.97.1)
@@ -176,7 +163,7 @@ importers:
         version: 8.57.1
       jest:
         specifier: ^29.7.0
-        version: 29.7.0(@types/node@22.10.5)(ts-node@10.9.2(@types/node@22.10.5)(typescript@5.7.3))
+        version: 29.7.0(@types/node@22.10.6)(ts-node@10.9.2(@types/node@22.10.6)(typescript@5.7.3))
       prettier:
         specifier: ^3.4.2
         version: 3.4.2
@@ -185,7 +172,7 @@ importers:
         version: 5.0.10
       ts-jest:
         specifier: ^29.2.5
-        version: 29.2.5(@babel/core@7.26.0)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.26.0))(jest@29.7.0(@types/node@22.10.5)(ts-node@10.9.2(@types/node@22.10.5)(typescript@5.7.3)))(typescript@5.7.3)
+        version: 29.2.5(@babel/core@7.26.0)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.26.0))(jest@29.7.0(@types/node@22.10.6)(ts-node@10.9.2(@types/node@22.10.6)(typescript@5.7.3)))(typescript@5.7.3)
 
   packages/converse:
     dependencies:
@@ -216,10 +203,10 @@ importers:
         version: 10.0.0
       '@typescript-eslint/eslint-plugin':
         specifier: ^8.18.1
-        version: 8.19.1(@typescript-eslint/parser@8.19.1(eslint@9.18.0)(typescript@5.7.3))(eslint@9.18.0)(typescript@5.7.3)
+        version: 8.20.0(@typescript-eslint/parser@8.20.0(eslint@9.18.0)(typescript@5.7.3))(eslint@9.18.0)(typescript@5.7.3)
       '@typescript-eslint/parser':
         specifier: ^8.18.1
-        version: 8.19.1(eslint@9.18.0)(typescript@5.7.3)
+        version: 8.20.0(eslint@9.18.0)(typescript@5.7.3)
       eslint:
         specifier: ^9.17.0
         version: 9.18.0
@@ -316,7 +303,7 @@ importers:
         version: 4.21.2
       jsdom:
         specifier: ^24.1.0
-        version: 24.1.3(canvas@2.11.2)
+        version: 24.1.3
       simplex-noise:
         specifier: ^4.0.1
         version: 4.0.3
@@ -732,10 +719,6 @@ packages:
   '@jridgewell/trace-mapping@0.3.9':
     resolution: {integrity: sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ==}
 
-  '@mapbox/node-pre-gyp@1.0.11':
-    resolution: {integrity: sha512-Yhlar6v9WQgUp/He7BdgzOz8lqMQ8sU+jkCq7Wx8Myc5YFJLbEe7lgui/V7G1qB1DJykHSGwreceSaD60Y0PUQ==}
-    hasBin: true
-
   '@nodelib/fs.scandir@2.1.5':
     resolution: {integrity: sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==}
     engines: {node: '>= 8'}
@@ -919,8 +902,8 @@ packages:
   '@types/node@20.17.12':
     resolution: {integrity: sha512-vo/wmBgMIiEA23A/knMfn/cf37VnuF52nZh5ZoW0GWt4e4sxNquibrMRJ7UQsA06+MBx9r/H1jsI9grYjQCQlw==}
 
-  '@types/node@22.10.5':
-    resolution: {integrity: sha512-F8Q+SeGimwOo86fiovQh8qiXfFEh2/ocYv7tU5pJ3EXMSSxk1Joj5wefpFK2fHTf/N6HKGSxIDBT9f3gCxXPkQ==}
+  '@types/node@22.10.6':
+    resolution: {integrity: sha512-qNiuwC4ZDAUNcY47xgaSuS92cjf8JbSUoaKS77bmLG1rU7MlATVSiw/IlrjtIyyskXBZ8KkNfjK/P5na7rgXbQ==}
 
   '@types/phoenix@1.6.6':
     resolution: {integrity: sha512-PIzZZlEppgrpoT2QgbnDU+MMzuR6BbCjllj0bM70lWoejMeNJAxCchxnv7J3XFkI8MpygtRpzXrIlmWUBclP5A==}
@@ -958,51 +941,51 @@ packages:
   '@types/yargs@17.0.33':
     resolution: {integrity: sha512-WpxBCKWPLr4xSsHgz511rFJAM+wS28w2zEO1QDNY5zM/S8ok70NNfztH0xwhqKyaK0OHCbN98LDAZuy1ctxDkA==}
 
-  '@typescript-eslint/eslint-plugin@8.19.1':
-    resolution: {integrity: sha512-tJzcVyvvb9h/PB96g30MpxACd9IrunT7GF9wfA9/0TJ1LxGOJx1TdPzSbBBnNED7K9Ka8ybJsnEpiXPktolTLg==}
+  '@typescript-eslint/eslint-plugin@8.20.0':
+    resolution: {integrity: sha512-naduuphVw5StFfqp4Gq4WhIBE2gN1GEmMUExpJYknZJdRnc+2gDzB8Z3+5+/Kv33hPQRDGzQO/0opHE72lZZ6A==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
     peerDependencies:
       '@typescript-eslint/parser': ^8.0.0 || ^8.0.0-alpha.0
       eslint: ^8.57.0 || ^9.0.0
       typescript: '>=4.8.4 <5.8.0'
 
-  '@typescript-eslint/parser@8.19.1':
-    resolution: {integrity: sha512-67gbfv8rAwawjYx3fYArwldTQKoYfezNUT4D5ioWetr/xCrxXxvleo3uuiFuKfejipvq+og7mjz3b0G2bVyUCw==}
+  '@typescript-eslint/parser@8.20.0':
+    resolution: {integrity: sha512-gKXG7A5HMyjDIedBi6bUrDcun8GIjnI8qOwVLiY3rx6T/sHP/19XLJOnIq/FgQvWLHja5JN/LSE7eklNBr612g==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
     peerDependencies:
       eslint: ^8.57.0 || ^9.0.0
       typescript: '>=4.8.4 <5.8.0'
 
-  '@typescript-eslint/scope-manager@8.19.1':
-    resolution: {integrity: sha512-60L9KIuN/xgmsINzonOcMDSB8p82h95hoBfSBtXuO4jlR1R9L1xSkmVZKgCPVfavDlXihh4ARNjXhh1gGnLC7Q==}
+  '@typescript-eslint/scope-manager@8.20.0':
+    resolution: {integrity: sha512-J7+VkpeGzhOt3FeG1+SzhiMj9NzGD/M6KoGn9f4dbz3YzK9hvbhVTmLj/HiTp9DazIzJ8B4XcM80LrR9Dm1rJw==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
-  '@typescript-eslint/type-utils@8.19.1':
-    resolution: {integrity: sha512-Rp7k9lhDKBMRJB/nM9Ksp1zs4796wVNyihG9/TU9R6KCJDNkQbc2EOKjrBtLYh3396ZdpXLtr/MkaSEmNMtykw==}
-    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
-    peerDependencies:
-      eslint: ^8.57.0 || ^9.0.0
-      typescript: '>=4.8.4 <5.8.0'
-
-  '@typescript-eslint/types@8.19.1':
-    resolution: {integrity: sha512-JBVHMLj7B1K1v1051ZaMMgLW4Q/jre5qGK0Ew6UgXz1Rqh+/xPzV1aW581OM00X6iOfyr1be+QyW8LOUf19BbA==}
-    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
-
-  '@typescript-eslint/typescript-estree@8.19.1':
-    resolution: {integrity: sha512-jk/TZwSMJlxlNnqhy0Eod1PNEvCkpY6MXOXE/WLlblZ6ibb32i2We4uByoKPv1d0OD2xebDv4hbs3fm11SMw8Q==}
-    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
-    peerDependencies:
-      typescript: '>=4.8.4 <5.8.0'
-
-  '@typescript-eslint/utils@8.19.1':
-    resolution: {integrity: sha512-IxG5gLO0Ne+KaUc8iW1A+XuKLd63o4wlbI1Zp692n1xojCl/THvgIKXJXBZixTh5dd5+yTJ/VXH7GJaaw21qXA==}
+  '@typescript-eslint/type-utils@8.20.0':
+    resolution: {integrity: sha512-bPC+j71GGvA7rVNAHAtOjbVXbLN5PkwqMvy1cwGeaxUoRQXVuKCebRoLzm+IPW/NtFFpstn1ummSIasD5t60GA==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
     peerDependencies:
       eslint: ^8.57.0 || ^9.0.0
       typescript: '>=4.8.4 <5.8.0'
 
-  '@typescript-eslint/visitor-keys@8.19.1':
-    resolution: {integrity: sha512-fzmjU8CHK853V/avYZAvuVut3ZTfwN5YtMaoi+X9Y9MA9keaWNHC3zEQ9zvyX/7Hj+5JkNyK1l7TOR2hevHB6Q==}
+  '@typescript-eslint/types@8.20.0':
+    resolution: {integrity: sha512-cqaMiY72CkP+2xZRrFt3ExRBu0WmVitN/rYPZErA80mHjHx/Svgp8yfbzkJmDoQ/whcytOPO9/IZXnOc+wigRA==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
+  '@typescript-eslint/typescript-estree@8.20.0':
+    resolution: {integrity: sha512-Y7ncuy78bJqHI35NwzWol8E0X7XkRVS4K4P4TCyzWkOJih5NDvtoRDW4Ba9YJJoB2igm9yXDdYI/+fkiiAxPzA==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    peerDependencies:
+      typescript: '>=4.8.4 <5.8.0'
+
+  '@typescript-eslint/utils@8.20.0':
+    resolution: {integrity: sha512-dq70RUw6UK9ei7vxc4KQtBRk7qkHZv447OUZ6RPQMQl71I3NZxQJX/f32Smr+iqWrB02pHKn2yAdHBb0KNrRMA==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    peerDependencies:
+      eslint: ^8.57.0 || ^9.0.0
+      typescript: '>=4.8.4 <5.8.0'
+
+  '@typescript-eslint/visitor-keys@8.20.0':
+    resolution: {integrity: sha512-v/BpkeeYAsPkKCkR8BDwcno0llhzWVqPOamQrAEMdpZav2Y9OVjd9dwJyBLJWwf335B5DmlifECIkZRJCaGaHA==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
   '@ungap/structured-clone@1.2.1':
@@ -1088,12 +1071,6 @@ packages:
     resolution: {integrity: sha512-j2afSsaIENvHZN2B8GOpF566vZ5WVk5opAiMTvWgaQT8DkbOqsTfvNAvHoRGU2zzP8cPoqys+xHTRDWW8L+/BA==}
     deprecated: Use your platform's native atob() and btoa() methods instead
 
-<<<<<<< HEAD
-  abbrev@1.1.1:
-    resolution: {integrity: sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q==}
-
-=======
->>>>>>> f0b1ffc (fix: remove yarn file from root)
   ably@1.2.50:
     resolution: {integrity: sha512-9uC5lE7wFBR7nOJdltArHU1UDaBu6CTMbMuie+brUuH884fM1mQuFiMzZetxVacygyUG38dp5MFOyOPF9h0RsQ==}
     engines: {node: '>=5.10.x'}
@@ -1190,14 +1167,6 @@ packages:
   anymatch@3.1.3:
     resolution: {integrity: sha512-KMReFUr0B4t+D+OBkjR3KYqvocp2XaSzO55UcB6mgQMd3KbcE+mWTyvVV7D/zsdEbNnV6acZUutkiHQXvTr1Rw==}
     engines: {node: '>= 8'}
-
-  aproba@2.0.0:
-    resolution: {integrity: sha512-lYe4Gx7QT+MKGbDsA+Z+he/Wtef0BiwDOlK/XkBrdfsh9J/jPPXbX0tE9x9cl27Tmu5gg3QUbUrQYa/y+KOHPQ==}
-
-  are-we-there-yet@2.0.0:
-    resolution: {integrity: sha512-Ci/qENmwHnsYo9xKIcUJN5LeDKdJ6R1Z1j9V/J5wyq8nh/mYPEpIKJbBZXtZjG04HiK7zV/p6Vs9952MrMeUIw==}
-    engines: {node: '>=10'}
-    deprecated: This package is no longer supported.
 
   arg@4.1.3:
     resolution: {integrity: sha512-58S9QDqG0Xx27YwPSt9fJxivjYl432YCwfDMfZ+71RAqUrZef7LrKQZ3LHLOwCS4FLNBplP533Zx895SeOCHvA==}
@@ -1342,10 +1311,6 @@ packages:
   caniuse-lite@1.0.30001692:
     resolution: {integrity: sha512-A95VKan0kdtrsnMubMKxEKUKImOPSuCpYgxSQBo036P5YYgVIcOYJEgt/txJWqObiRQeISNCfef9nvlQ0vbV7A==}
 
-  canvas@2.11.2:
-    resolution: {integrity: sha512-ItanGBMrmRV7Py2Z+Xhs7cT+FNt5K0vPL4p9EZ/UX/Mu7hFbkxSjKF2KVtPwX7UYWp7dRKnrTvReflgrItJbdw==}
-    engines: {node: '>=6'}
-
   canvas@3.0.1:
     resolution: {integrity: sha512-PcpVF4f8RubAeN/jCQQ/UymDKzOiLmRPph8fOTzDnlsUihkO/AUlxuhaa7wGRc3vMcCbV1fzuvyu5cWZlIcn1w==}
     engines: {node: ^18.12.0 || >= 20.9.0}
@@ -1364,10 +1329,6 @@ packages:
 
   chownr@1.1.4:
     resolution: {integrity: sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg==}
-
-  chownr@2.0.0:
-    resolution: {integrity: sha512-bIomtDF5KGpdogkLd9VspvFzk9KfpyyGlS8YFVZl7TGPBHL5snIOnxeshwVgPteQ9b4Eydl+pVbIyE1DcvCWgQ==}
-    engines: {node: '>=10'}
 
   chrome-trace-event@1.0.4:
     resolution: {integrity: sha512-rNjApaLzuwaOTjCiT8lSDdGN1APCiqkChLMJxJPWLunPAt5fy8xgU9/jNOchV84wfIxrA0lRQB7oCT8jrn/wrQ==}
@@ -1413,10 +1374,6 @@ packages:
   color-name@1.1.4:
     resolution: {integrity: sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==}
 
-  color-support@1.1.3:
-    resolution: {integrity: sha512-qiBjkpbMLO/HL68y+lh4q0/O1MZFj2RX6X/KmMa3+gJD3z+WwI1ZzDHysvqHGS3mP6mznPckpXmw1nI9cJjyRg==}
-    hasBin: true
-
   colorette@2.0.20:
     resolution: {integrity: sha512-IfEDxwoWIjkeXL1eXcDiow4UbKjhLdq6/EuSVR9GMN7KVH3r9gQ83e73hsz1Nd1T3ijd5xv1wcWRYO+D6kCI2w==}
 
@@ -1443,9 +1400,6 @@ packages:
     resolution: {integrity: sha512-1dP4gpXFhei8IOtlXRE/T/4H88ElHgTiUzh71YUmtjTEHMSRS2Z/fgOxHSxxusGHogsRfxNq1vyAwxSC+EVyDg==}
     engines: {node: ^14.13.0 || >=16.0.0}
     hasBin: true
-
-  console-control-strings@1.1.0:
-    resolution: {integrity: sha512-ty/fTekppD2fIwRvnZAVdeOiGd1c7YXEixbgJTNzqcxJWKQnjJ/V1bNEEE6hygpM3WjwHFUVK6HTjWSzV4a8sQ==}
 
   content-disposition@0.5.4:
     resolution: {integrity: sha512-FveZTNuGw04cxlAiWbzi6zTAL/lhehaWbTtgluJh4/E95DqMwTmha3KZN1aAWA8cFIhHzMZUvLevkw5Rqk+tSQ==}
@@ -1518,13 +1472,8 @@ packages:
     resolution: {integrity: sha512-AZL67abkUzIuvcHqk7c09cezpGNcxUxU4Ioi/05xHk4DQeTkWmGYftIE6ctU6AEt+Gn4n1lDStOtj7FKycP71A==}
     engines: {node: '>=8'}
 
-<<<<<<< HEAD
   cssstyle@4.2.1:
     resolution: {integrity: sha512-9+vem03dMXG7gDmZ62uqmRiMRNtinIZ9ZyuF6BdxzfOD+FdN5hretzynkn0ReS2DO2GSw76RWHs0UmJPI2zUjw==}
-=======
-  cssstyle@4.1.0:
-    resolution: {integrity: sha512-h66W1URKpBS5YMI/V8PyXvTMFT8SupJ1IzoIV8IeBC/ji8WVmrO8dGlTi+2dh6whmdk6BiKJLD/ZBkhWbcg6nA==}
->>>>>>> f0b1ffc (fix: remove yarn file from root)
     engines: {node: '>=18'}
 
   data-urls@3.0.2:
@@ -1601,9 +1550,6 @@ packages:
   delayed-stream@1.0.0:
     resolution: {integrity: sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==}
     engines: {node: '>=0.4.0'}
-
-  delegates@1.0.0:
-    resolution: {integrity: sha512-bd2L678uiWATM6m5Z1VzNCErI3jiGzt6HGY8OVICs40JQq/HALfbyNJmp0UDakEY4pMMaN0Ly5om/B1VI/+xfQ==}
 
   depd@2.0.0:
     resolution: {integrity: sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==}
@@ -1955,10 +1901,6 @@ packages:
   fs-constants@1.0.0:
     resolution: {integrity: sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow==}
 
-  fs-minipass@2.1.0:
-    resolution: {integrity: sha512-V/JgOLFCS+R6Vcq0slCuaeWEdNC3ouDlJMNIsacH2VtALiu9mV4LPrHc5cDl8k5aw6J8jwgWWpiTo5RYhmIzvg==}
-    engines: {node: '>= 8'}
-
   fs.realpath@1.0.0:
     resolution: {integrity: sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==}
 
@@ -1969,11 +1911,6 @@ packages:
 
   function-bind@1.1.2:
     resolution: {integrity: sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==}
-
-  gauge@3.0.2:
-    resolution: {integrity: sha512-+5J6MS/5XksCuXq++uFRsnUd7Ovu1XenbeuIuNRJxYWjgQbPuFhT14lAvsWfqfAmnwluf1OwMjz39HjfLPci0Q==}
-    engines: {node: '>=10'}
-    deprecated: This package is no longer supported.
 
   generic-pool@3.9.0:
     resolution: {integrity: sha512-hymDOu5B53XvN4QT9dBmZxPX4CWhBPPLguTZ9MMFeFa/Kg0xWVfylOVNlJji/E7yTZWFd/q9GO5TxDLq156D7g==}
@@ -2075,9 +2012,6 @@ packages:
   has-symbols@1.1.0:
     resolution: {integrity: sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==}
     engines: {node: '>= 0.4'}
-
-  has-unicode@2.0.1:
-    resolution: {integrity: sha512-8Rf9Y83NBReMnx0gFzA8JImQACstCYWUplepDa9xprwwtmgEZUF0h/i5xSA625zB/I37EtrswSST6OXxwaaIJQ==}
 
   hasown@2.0.2:
     resolution: {integrity: sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==}
@@ -2539,10 +2473,6 @@ packages:
   lru-cache@5.1.1:
     resolution: {integrity: sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==}
 
-  make-dir@3.1.0:
-    resolution: {integrity: sha512-g3FeP20LNwhALb/6Cz6Dd4F2ngze0jz7tbzrD2wAV+o9FeNHe4rL+yK2md0J/fiSf1sa1ADhXqi5+oVwOM/eGw==}
-    engines: {node: '>=8'}
-
   make-dir@4.0.0:
     resolution: {integrity: sha512-hXdUTZYIVOt1Ex//jAQi+wTZZpUpwBj/0QsOzqegb3rGMMeJiSEu5xLHnYfBrRV4RH2+OCSOO95Is/7x1WJ4bw==}
     engines: {node: '>=10'}
@@ -2634,33 +2564,13 @@ packages:
   minimist@1.2.8:
     resolution: {integrity: sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==}
 
-  minipass@3.3.6:
-    resolution: {integrity: sha512-DxiNidxSEK+tHG6zOIklvNOwm3hvCrbUrdtzY74U6HKTJxvIDfOUL5W5P2Ghd3DTkhhKPYGqeNUIh5qcM4YBfw==}
-    engines: {node: '>=8'}
-
-  minipass@5.0.0:
-    resolution: {integrity: sha512-3FnjYuehv9k6ovOEbyOswadCDPX1piCfhV8ncmYtHOjuPwylVWsghTLo7rabjC3Rx5xD4HDx8Wm1xnMF7S5qFQ==}
-    engines: {node: '>=8'}
-
   minipass@7.1.2:
     resolution: {integrity: sha512-qOOzS1cBTWYF4BH8fVePDBOO9iptMnGUEZwNc/cMWnTV2nVLZ7VoNWEPHkYczZA0pdoA7dl6e7FL659nX9S2aw==}
     engines: {node: '>=16 || 14 >=14.17'}
 
-  minizlib@2.1.2:
-    resolution: {integrity: sha512-bAxsR8BVfj60DWXHE3u30oHzfl4G7khkSuPW+qvpd7jFRHm7dLxOjUk1EHACJ/hxLY8phGJ0YhYHZo7jil7Qdg==}
-    engines: {node: '>= 8'}
-
   mkdirp-classic@0.5.3:
     resolution: {integrity: sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A==}
 
-<<<<<<< HEAD
-  mkdirp@1.0.4:
-    resolution: {integrity: sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==}
-    engines: {node: '>=10'}
-    hasBin: true
-
-=======
->>>>>>> f0b1ffc (fix: remove yarn file from root)
   moo-color@1.0.3:
     resolution: {integrity: sha512-i/+ZKXMDf6aqYtBhuOcej71YSlbjT3wCO/4H1j8rPvxDJEifdwgg5MaFyu6iYAT8GBZJg2z0dkgK4YMzvURALQ==}
 
@@ -2669,9 +2579,6 @@ packages:
 
   ms@2.1.3:
     resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
-
-  nan@2.22.0:
-    resolution: {integrity: sha512-nbajikzWTMwsW+eSsNm3QwlOs7het9gGJU5dDZzRTQGk03vyBOauxgI4VakDzE0PtsGTmXPsXTbbjVhRwR5mpw==}
 
   napi-build-utils@1.0.2:
     resolution: {integrity: sha512-ONmRUqK7zj7DWX0D9ADe03wbwOBZxNAfF20PlGfCWQcD3+/MakShIHrMqx9YwPTfxDdF1zLeL+RGZiR9kGMLdg==}
@@ -2696,15 +2603,6 @@ packages:
   node-addon-api@7.1.1:
     resolution: {integrity: sha512-5m3bsyrjFWE1xf7nz7YXdN4udnVtXK6/Yfgn5qnahL6bCkf2yKt4k3nuTKAtT4r3IG8JNR2ncsIMdZuAzJjHQQ==}
 
-  node-fetch@2.7.0:
-    resolution: {integrity: sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==}
-    engines: {node: 4.x || >=6.0.0}
-    peerDependencies:
-      encoding: ^0.1.0
-    peerDependenciesMeta:
-      encoding:
-        optional: true
-
   node-int64@0.4.0:
     resolution: {integrity: sha512-O5lz91xSOeoXP6DulyHfllpq+Eg00MWitZIbtPfoSEvqIHdl5gfcY6hYzDWnj0qD5tz52PI08u9qUvSVeUBeHw==}
 
@@ -2721,11 +2619,6 @@ packages:
     engines: {node: '>=10'}
     hasBin: true
 
-  nopt@5.0.0:
-    resolution: {integrity: sha512-Tbj67rffqceeLpcRXrT7vKAN8CwfPeIBgM7E6iBkmKLV7bEMwpGgYLGv0jACUsECaa/vuxP0IjEont6umdMgtQ==}
-    engines: {node: '>=6'}
-    hasBin: true
-
   normalize-path@3.0.0:
     resolution: {integrity: sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==}
     engines: {node: '>=0.10.0'}
@@ -2737,10 +2630,6 @@ packages:
   npm-run-path@4.0.1:
     resolution: {integrity: sha512-S48WzZW777zhNIrn7gxOlISNAqi9ZC/uQFnRdbeIHhZhCA6UqpkOT8T1G7BvfdgP4Er8gF4sUbaS0i7QvIfCWw==}
     engines: {node: '>=8'}
-
-  npmlog@5.0.1:
-    resolution: {integrity: sha512-AqZtDUWOMKs1G/8lwylVjrdYgqA4d9nu8hc+0gzRxlDb1I10+FHBGMXs6aiQHFdCUUlqH99MUMuLfzWDNDtfxw==}
-    deprecated: This package is no longer supported.
 
   nwsapi@2.2.16:
     resolution: {integrity: sha512-F1I/bimDpj3ncaNDhfyMWuFqmQDBwDB0Fogc2qpL3BWvkQteFD/8BzWuIRl83rq0DXfm8SGt/HFhLXZyljTXcQ==}
@@ -3099,9 +2988,6 @@ packages:
     resolution: {integrity: sha512-VqpjJZKadQB/PEbEwvFdO43Ax5dFBZ2UECszz8bQ7pi7wt//PWe1P6MN7eCnjsatYtBT6EuiClbjSWP2WrIoTw==}
     engines: {node: '>= 0.8.0'}
 
-  set-blocking@2.0.0:
-    resolution: {integrity: sha512-KiKBS8AnWGEyLzofFfmvKwpdPzqiy16LvQfK3yv/fVH7Bj13/wl3JSR1J+rfgRE9q7xUJK4qvgS8raSOeLUehw==}
-
   setprototypeof@1.2.0:
     resolution: {integrity: sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==}
 
@@ -3268,16 +3154,12 @@ packages:
     resolution: {integrity: sha512-GNzQvQTOIP6RyTfE2Qxb8ZVlNmw0n88vp1szwWRimP02mnTsx3Wtn5qRdqY9w2XduFNUgvOwhNnQsjwCp+kqaQ==}
     engines: {node: '>=6'}
 
-  tar-fs@2.1.1:
-    resolution: {integrity: sha512-V0r2Y9scmbDRLCNex/+hYzvp/zyYjvFbHPNgVTKfQvVrb6guiE/fxP+XblDNR011utopbkex2nM4dHNV6GDsng==}
+  tar-fs@2.1.2:
+    resolution: {integrity: sha512-EsaAXwxmx8UB7FRKqeozqEPop69DXcmYwTQwXvyAPF352HJsPdkVhvTaDPYqfNgruveJIJy3TA2l+2zj8LJIJA==}
 
   tar-stream@2.2.0:
     resolution: {integrity: sha512-ujeqbceABgwMZxEJnk2HDY2DlnUZ+9oEcb1KzTVfYHio0UE6dG71n60d8D2I4qNvleWrrXpmjpt7vZeF1LnMZQ==}
     engines: {node: '>=6'}
-
-  tar@6.2.1:
-    resolution: {integrity: sha512-DZ4yORTwrbTj/7MZYq2w+/ZFdI6OZ/f9SFHR+71gIVUZhOQPHzVCLpvRnPgyaMpfWxxk/4ONva3GQSyNIKRv6A==}
-    engines: {node: '>=10'}
 
   terser-webpack-plugin@5.3.11:
     resolution: {integrity: sha512-RVCsMfuD0+cTt3EwX8hSl2Ks56EbFHWmhluwcqoPKtBnfjiT6olaq7PRIRfhyU8nnC2MrnDrBLfrD/RGE+cVXQ==}
@@ -3565,9 +3447,6 @@ packages:
     resolution: {integrity: sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==}
     engines: {node: '>= 8'}
     hasBin: true
-
-  wide-align@1.1.5:
-    resolution: {integrity: sha512-eDMORYaPNZ4sQIuuYPDHdQvf4gyCF9rEEV/yPxGfwPkRodwEgiMUUXTx/dex+Me0wxx53S+NgUHaP7y3MGlDmg==}
 
   wildcard@2.0.1:
     resolution: {integrity: sha512-CC1bOL87PIWSBhDcTrdeLo6eGT7mCFtrg0uIJtqJUFyK+eJnzl8A1niH56uu7KMa5XFrtiV+AQuHO3n7DsHnLQ==}
@@ -3984,7 +3863,7 @@ snapshots:
   '@jest/console@29.7.0':
     dependencies:
       '@jest/types': 29.6.3
-      '@types/node': 20.17.12
+      '@types/node': 22.10.6
       chalk: 4.1.2
       jest-message-util: 29.7.0
       jest-util: 29.7.0
@@ -3997,14 +3876,14 @@ snapshots:
       '@jest/test-result': 29.7.0
       '@jest/transform': 29.7.0
       '@jest/types': 29.6.3
-      '@types/node': 20.17.12
+      '@types/node': 22.10.6
       ansi-escapes: 4.3.2
       chalk: 4.1.2
       ci-info: 3.9.0
       exit: 0.1.2
       graceful-fs: 4.2.11
       jest-changed-files: 29.7.0
-      jest-config: 29.7.0(@types/node@20.17.12)(ts-node@10.9.2(@types/node@20.17.12)(typescript@5.7.3))
+      jest-config: 29.7.0(@types/node@22.10.6)(ts-node@10.9.2(@types/node@20.17.12)(typescript@5.7.3))
       jest-haste-map: 29.7.0
       jest-message-util: 29.7.0
       jest-regex-util: 29.6.3
@@ -4025,56 +3904,21 @@ snapshots:
       - supports-color
       - ts-node
 
-  '@jest/core@29.7.0(ts-node@10.9.2(@types/node@22.10.5)(typescript@5.7.3))':
+  '@jest/core@29.7.0(ts-node@10.9.2(@types/node@22.10.6)(typescript@5.7.3))':
     dependencies:
       '@jest/console': 29.7.0
       '@jest/reporters': 29.7.0
       '@jest/test-result': 29.7.0
       '@jest/transform': 29.7.0
       '@jest/types': 29.6.3
-      '@types/node': 20.17.12
+      '@types/node': 22.10.6
       ansi-escapes: 4.3.2
       chalk: 4.1.2
       ci-info: 3.9.0
       exit: 0.1.2
       graceful-fs: 4.2.11
       jest-changed-files: 29.7.0
-      jest-config: 29.7.0(@types/node@20.17.12)(ts-node@10.9.2(@types/node@22.10.5)(typescript@5.7.3))
-      jest-haste-map: 29.7.0
-      jest-message-util: 29.7.0
-      jest-regex-util: 29.6.3
-      jest-resolve: 29.7.0
-      jest-resolve-dependencies: 29.7.0
-      jest-runner: 29.7.0
-      jest-runtime: 29.7.0
-      jest-snapshot: 29.7.0
-      jest-util: 29.7.0
-      jest-validate: 29.7.0
-      jest-watcher: 29.7.0
-      micromatch: 4.0.8
-      pretty-format: 29.7.0
-      slash: 3.0.0
-      strip-ansi: 6.0.1
-    transitivePeerDependencies:
-      - babel-plugin-macros
-      - supports-color
-      - ts-node
-
-  '@jest/core@29.7.0(ts-node@10.9.2(@types/node@22.10.2)(typescript@5.7.2))':
-    dependencies:
-      '@jest/console': 29.7.0
-      '@jest/reporters': 29.7.0
-      '@jest/test-result': 29.7.0
-      '@jest/transform': 29.7.0
-      '@jest/types': 29.6.3
-      '@types/node': 20.17.10
-      ansi-escapes: 4.3.2
-      chalk: 4.1.2
-      ci-info: 3.9.0
-      exit: 0.1.2
-      graceful-fs: 4.2.11
-      jest-changed-files: 29.7.0
-      jest-config: 29.7.0(@types/node@20.17.10)(ts-node@10.9.2(@types/node@22.10.2)(typescript@5.7.2))
+      jest-config: 29.7.0(@types/node@22.10.6)(ts-node@10.9.2(@types/node@22.10.6)(typescript@5.7.3))
       jest-haste-map: 29.7.0
       jest-message-util: 29.7.0
       jest-regex-util: 29.6.3
@@ -4139,7 +3983,7 @@ snapshots:
       '@jest/transform': 29.7.0
       '@jest/types': 29.6.3
       '@jridgewell/trace-mapping': 0.3.25
-      '@types/node': 20.17.12
+      '@types/node': 22.10.6
       chalk: 4.1.2
       collect-v8-coverage: 1.0.2
       exit: 0.1.2
@@ -4239,22 +4083,6 @@ snapshots:
     dependencies:
       '@jridgewell/resolve-uri': 3.1.2
       '@jridgewell/sourcemap-codec': 1.5.0
-
-  '@mapbox/node-pre-gyp@1.0.11':
-    dependencies:
-      detect-libc: 2.0.3
-      https-proxy-agent: 5.0.1
-      make-dir: 3.1.0
-      node-fetch: 2.7.0
-      nopt: 5.0.0
-      npmlog: 5.0.1
-      rimraf: 3.0.2
-      semver: 7.6.3
-      tar: 6.2.1
-    transitivePeerDependencies:
-      - encoding
-      - supports-color
-    optional: true
 
   '@nodelib/fs.scandir@2.1.5':
     dependencies:
@@ -4442,7 +4270,7 @@ snapshots:
 
   '@types/graceful-fs@4.1.9':
     dependencies:
-      '@types/node': 20.17.12
+      '@types/node': 22.10.6
 
   '@types/http-cache-semantics@4.0.4': {}
 
@@ -4465,11 +4293,7 @@ snapshots:
 
   '@types/jsdom@20.0.1':
     dependencies:
-<<<<<<< HEAD
       '@types/node': 20.17.12
-=======
-      '@types/node': 20.17.10
->>>>>>> f0b1ffc (fix: remove yarn file from root)
       '@types/tough-cookie': 4.0.5
       parse5: 7.2.1
 
@@ -4485,7 +4309,7 @@ snapshots:
     dependencies:
       undici-types: 6.19.8
 
-  '@types/node@22.10.5':
+  '@types/node@22.10.6':
     dependencies:
       undici-types: 6.20.0
 
@@ -4526,14 +4350,14 @@ snapshots:
     dependencies:
       '@types/yargs-parser': 21.0.3
 
-  '@typescript-eslint/eslint-plugin@8.19.1(@typescript-eslint/parser@8.19.1(eslint@9.18.0)(typescript@5.7.3))(eslint@9.18.0)(typescript@5.7.3)':
+  '@typescript-eslint/eslint-plugin@8.20.0(@typescript-eslint/parser@8.20.0(eslint@9.18.0)(typescript@5.7.3))(eslint@9.18.0)(typescript@5.7.3)':
     dependencies:
       '@eslint-community/regexpp': 4.12.1
-      '@typescript-eslint/parser': 8.19.1(eslint@9.18.0)(typescript@5.7.3)
-      '@typescript-eslint/scope-manager': 8.19.1
-      '@typescript-eslint/type-utils': 8.19.1(eslint@9.18.0)(typescript@5.7.3)
-      '@typescript-eslint/utils': 8.19.1(eslint@9.18.0)(typescript@5.7.3)
-      '@typescript-eslint/visitor-keys': 8.19.1
+      '@typescript-eslint/parser': 8.20.0(eslint@9.18.0)(typescript@5.7.3)
+      '@typescript-eslint/scope-manager': 8.20.0
+      '@typescript-eslint/type-utils': 8.20.0(eslint@9.18.0)(typescript@5.7.3)
+      '@typescript-eslint/utils': 8.20.0(eslint@9.18.0)(typescript@5.7.3)
+      '@typescript-eslint/visitor-keys': 8.20.0
       eslint: 9.18.0
       graphemer: 1.4.0
       ignore: 5.3.2
@@ -4543,27 +4367,27 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/parser@8.19.1(eslint@9.18.0)(typescript@5.7.3)':
+  '@typescript-eslint/parser@8.20.0(eslint@9.18.0)(typescript@5.7.3)':
     dependencies:
-      '@typescript-eslint/scope-manager': 8.19.1
-      '@typescript-eslint/types': 8.19.1
-      '@typescript-eslint/typescript-estree': 8.19.1(typescript@5.7.3)
-      '@typescript-eslint/visitor-keys': 8.19.1
+      '@typescript-eslint/scope-manager': 8.20.0
+      '@typescript-eslint/types': 8.20.0
+      '@typescript-eslint/typescript-estree': 8.20.0(typescript@5.7.3)
+      '@typescript-eslint/visitor-keys': 8.20.0
       debug: 4.4.0(supports-color@5.5.0)
       eslint: 9.18.0
       typescript: 5.7.3
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/scope-manager@8.19.1':
+  '@typescript-eslint/scope-manager@8.20.0':
     dependencies:
-      '@typescript-eslint/types': 8.19.1
-      '@typescript-eslint/visitor-keys': 8.19.1
+      '@typescript-eslint/types': 8.20.0
+      '@typescript-eslint/visitor-keys': 8.20.0
 
-  '@typescript-eslint/type-utils@8.19.1(eslint@9.18.0)(typescript@5.7.3)':
+  '@typescript-eslint/type-utils@8.20.0(eslint@9.18.0)(typescript@5.7.3)':
     dependencies:
-      '@typescript-eslint/typescript-estree': 8.19.1(typescript@5.7.3)
-      '@typescript-eslint/utils': 8.19.1(eslint@9.18.0)(typescript@5.7.3)
+      '@typescript-eslint/typescript-estree': 8.20.0(typescript@5.7.3)
+      '@typescript-eslint/utils': 8.20.0(eslint@9.18.0)(typescript@5.7.3)
       debug: 4.4.0(supports-color@5.5.0)
       eslint: 9.18.0
       ts-api-utils: 2.0.0(typescript@5.7.3)
@@ -4571,12 +4395,12 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/types@8.19.1': {}
+  '@typescript-eslint/types@8.20.0': {}
 
-  '@typescript-eslint/typescript-estree@8.19.1(typescript@5.7.3)':
+  '@typescript-eslint/typescript-estree@8.20.0(typescript@5.7.3)':
     dependencies:
-      '@typescript-eslint/types': 8.19.1
-      '@typescript-eslint/visitor-keys': 8.19.1
+      '@typescript-eslint/types': 8.20.0
+      '@typescript-eslint/visitor-keys': 8.20.0
       debug: 4.4.0(supports-color@5.5.0)
       fast-glob: 3.3.3
       is-glob: 4.0.3
@@ -4587,20 +4411,20 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/utils@8.19.1(eslint@9.18.0)(typescript@5.7.3)':
+  '@typescript-eslint/utils@8.20.0(eslint@9.18.0)(typescript@5.7.3)':
     dependencies:
       '@eslint-community/eslint-utils': 4.4.1(eslint@9.18.0)
-      '@typescript-eslint/scope-manager': 8.19.1
-      '@typescript-eslint/types': 8.19.1
-      '@typescript-eslint/typescript-estree': 8.19.1(typescript@5.7.3)
+      '@typescript-eslint/scope-manager': 8.20.0
+      '@typescript-eslint/types': 8.20.0
+      '@typescript-eslint/typescript-estree': 8.20.0(typescript@5.7.3)
       eslint: 9.18.0
       typescript: 5.7.3
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/visitor-keys@8.19.1':
+  '@typescript-eslint/visitor-keys@8.20.0':
     dependencies:
-      '@typescript-eslint/types': 8.19.1
+      '@typescript-eslint/types': 8.20.0
       eslint-visitor-keys: 4.2.0
 
   '@ungap/structured-clone@1.2.1': {}
@@ -4702,12 +4526,6 @@ snapshots:
 
   abab@2.0.6: {}
 
-<<<<<<< HEAD
-  abbrev@1.1.1:
-    optional: true
-
-=======
->>>>>>> f0b1ffc (fix: remove yarn file from root)
   ably@1.2.50:
     dependencies:
       '@ably/msgpack-js': 0.4.0
@@ -4797,15 +4615,6 @@ snapshots:
     dependencies:
       normalize-path: 3.0.0
       picomatch: 2.3.1
-
-  aproba@2.0.0:
-    optional: true
-
-  are-we-there-yet@2.0.0:
-    dependencies:
-      delegates: 1.0.0
-      readable-stream: 3.6.2
-    optional: true
 
   arg@4.1.3: {}
 
@@ -4992,16 +4801,6 @@ snapshots:
 
   caniuse-lite@1.0.30001692: {}
 
-  canvas@2.11.2:
-    dependencies:
-      '@mapbox/node-pre-gyp': 1.0.11
-      nan: 2.22.0
-      simple-get: 3.1.1
-    transitivePeerDependencies:
-      - encoding
-      - supports-color
-    optional: true
-
   canvas@3.0.1:
     dependencies:
       node-addon-api: 7.1.1
@@ -5028,9 +4827,6 @@ snapshots:
       fsevents: 2.3.3
 
   chownr@1.1.4: {}
-
-  chownr@2.0.0:
-    optional: true
 
   chrome-trace-event@1.0.4: {}
 
@@ -5070,9 +4866,6 @@ snapshots:
 
   color-name@1.1.4: {}
 
-  color-support@1.1.3:
-    optional: true
-
   colorette@2.0.20: {}
 
   combined-stream@1.0.8:
@@ -5108,9 +4901,6 @@ snapshots:
       supports-color: 8.1.1
       tree-kill: 1.2.2
       yargs: 17.7.2
-
-  console-control-strings@1.1.0:
-    optional: true
 
   content-disposition@0.5.4:
     dependencies:
@@ -5175,28 +4965,13 @@ snapshots:
       - supports-color
       - ts-node
 
-  create-jest@29.7.0(@types/node@22.10.5)(ts-node@10.9.2(@types/node@22.10.5)(typescript@5.7.3)):
+  create-jest@29.7.0(@types/node@22.10.6)(ts-node@10.9.2(@types/node@22.10.6)(typescript@5.7.3)):
     dependencies:
       '@jest/types': 29.6.3
       chalk: 4.1.2
       exit: 0.1.2
       graceful-fs: 4.2.11
-      jest-config: 29.7.0(@types/node@22.10.5)(ts-node@10.9.2(@types/node@22.10.5)(typescript@5.7.3))
-      jest-util: 29.7.0
-      prompts: 2.4.2
-    transitivePeerDependencies:
-      - '@types/node'
-      - babel-plugin-macros
-      - supports-color
-      - ts-node
-
-  create-jest@29.7.0(@types/node@22.10.2)(ts-node@10.9.2(@types/node@22.10.2)(typescript@5.7.2)):
-    dependencies:
-      '@jest/types': 29.6.3
-      chalk: 4.1.2
-      exit: 0.1.2
-      graceful-fs: 4.2.11
-      jest-config: 29.7.0(@types/node@22.10.2)(ts-node@10.9.2(@types/node@22.10.2)(typescript@5.7.2))
+      jest-config: 29.7.0(@types/node@22.10.6)(ts-node@10.9.2(@types/node@22.10.6)(typescript@5.7.3))
       jest-util: 29.7.0
       prompts: 2.4.2
     transitivePeerDependencies:
@@ -5220,13 +4995,6 @@ snapshots:
   cssom@0.5.0: {}
 
   cssstyle@2.3.0:
-<<<<<<< HEAD
-=======
-    dependencies:
-      cssom: 0.3.8
-
-  cssstyle@4.1.0:
->>>>>>> f0b1ffc (fix: remove yarn file from root)
     dependencies:
       cssom: 0.3.8
 
@@ -5234,12 +5002,6 @@ snapshots:
     dependencies:
       '@asamuzakjp/css-color': 2.8.2
       rrweb-cssom: 0.8.0
-
-  data-urls@3.0.2:
-    dependencies:
-      abab: 2.0.6
-      whatwg-mimetype: 3.0.0
-      whatwg-url: 11.0.0
 
   data-urls@3.0.2:
     dependencies:
@@ -5293,9 +5055,6 @@ snapshots:
   defer-to-connect@2.0.1: {}
 
   delayed-stream@1.0.0: {}
-
-  delegates@1.0.0:
-    optional: true
 
   depd@2.0.0: {}
 
@@ -5710,30 +5469,12 @@ snapshots:
 
   fs-constants@1.0.0: {}
 
-  fs-minipass@2.1.0:
-    dependencies:
-      minipass: 3.3.6
-    optional: true
-
   fs.realpath@1.0.0: {}
 
   fsevents@2.3.3:
     optional: true
 
   function-bind@1.1.2: {}
-
-  gauge@3.0.2:
-    dependencies:
-      aproba: 2.0.0
-      color-support: 1.1.3
-      console-control-strings: 1.1.0
-      has-unicode: 2.0.1
-      object-assign: 4.1.1
-      signal-exit: 3.0.7
-      string-width: 4.2.3
-      strip-ansi: 6.0.1
-      wide-align: 1.1.5
-    optional: true
 
   generic-pool@3.9.0: {}
 
@@ -5847,9 +5588,6 @@ snapshots:
   has-flag@4.0.0: {}
 
   has-symbols@1.1.0: {}
-
-  has-unicode@2.0.1:
-    optional: true
 
   hasown@2.0.2:
     dependencies:
@@ -6067,7 +5805,7 @@ snapshots:
       '@jest/expect': 29.7.0
       '@jest/test-result': 29.7.0
       '@jest/types': 29.6.3
-      '@types/node': 20.17.12
+      '@types/node': 22.10.6
       chalk: 4.1.2
       co: 4.6.0
       dedent: 1.5.3
@@ -6106,29 +5844,16 @@ snapshots:
       - supports-color
       - ts-node
 
-<<<<<<< HEAD
-  jest-cli@29.7.0(@types/node@22.10.5)(ts-node@10.9.2(@types/node@22.10.5)(typescript@5.7.3)):
+  jest-cli@29.7.0(@types/node@22.10.6)(ts-node@10.9.2(@types/node@22.10.6)(typescript@5.7.3)):
     dependencies:
-      '@jest/core': 29.7.0(ts-node@10.9.2(@types/node@22.10.5)(typescript@5.7.3))
+      '@jest/core': 29.7.0(ts-node@10.9.2(@types/node@22.10.6)(typescript@5.7.3))
       '@jest/test-result': 29.7.0
       '@jest/types': 29.6.3
       chalk: 4.1.2
-      create-jest: 29.7.0(@types/node@22.10.5)(ts-node@10.9.2(@types/node@22.10.5)(typescript@5.7.3))
+      create-jest: 29.7.0(@types/node@22.10.6)(ts-node@10.9.2(@types/node@22.10.6)(typescript@5.7.3))
       exit: 0.1.2
       import-local: 3.2.0
-      jest-config: 29.7.0(@types/node@22.10.5)(ts-node@10.9.2(@types/node@22.10.5)(typescript@5.7.3))
-=======
-  jest-cli@29.7.0(@types/node@22.10.2)(ts-node@10.9.2(@types/node@22.10.2)(typescript@5.7.2)):
-    dependencies:
-      '@jest/core': 29.7.0(ts-node@10.9.2(@types/node@22.10.2)(typescript@5.7.2))
-      '@jest/test-result': 29.7.0
-      '@jest/types': 29.6.3
-      chalk: 4.1.2
-      create-jest: 29.7.0(@types/node@22.10.2)(ts-node@10.9.2(@types/node@22.10.2)(typescript@5.7.2))
-      exit: 0.1.2
-      import-local: 3.2.0
-      jest-config: 29.7.0(@types/node@22.10.2)(ts-node@10.9.2(@types/node@22.10.2)(typescript@5.7.2))
->>>>>>> f0b1ffc (fix: remove yarn file from root)
+      jest-config: 29.7.0(@types/node@22.10.6)(ts-node@10.9.2(@types/node@22.10.6)(typescript@5.7.3))
       jest-util: 29.7.0
       jest-validate: 29.7.0
       yargs: 17.7.2
@@ -6138,11 +5863,7 @@ snapshots:
       - supports-color
       - ts-node
 
-<<<<<<< HEAD
   jest-config@29.7.0(@types/node@20.17.12)(ts-node@10.9.2(@types/node@20.17.12)(typescript@5.7.3)):
-=======
-  jest-config@29.7.0(@types/node@20.17.10)(ts-node@10.9.2(@types/node@20.17.10)(typescript@5.7.2)):
->>>>>>> f0b1ffc (fix: remove yarn file from root)
     dependencies:
       '@babel/core': 7.26.0
       '@jest/test-sequencer': 29.7.0
@@ -6173,7 +5894,7 @@ snapshots:
       - babel-plugin-macros
       - supports-color
 
-  jest-config@29.7.0(@types/node@20.17.12)(ts-node@10.9.2(@types/node@22.10.5)(typescript@5.7.3)):
+  jest-config@29.7.0(@types/node@22.10.6)(ts-node@10.9.2(@types/node@20.17.12)(typescript@5.7.3)):
     dependencies:
       '@babel/core': 7.26.0
       '@jest/test-sequencer': 29.7.0
@@ -6198,13 +5919,13 @@ snapshots:
       slash: 3.0.0
       strip-json-comments: 3.1.1
     optionalDependencies:
-      '@types/node': 20.17.12
-      ts-node: 10.9.2(@types/node@22.10.5)(typescript@5.7.3)
+      '@types/node': 22.10.6
+      ts-node: 10.9.2(@types/node@20.17.12)(typescript@5.7.3)
     transitivePeerDependencies:
       - babel-plugin-macros
       - supports-color
 
-  jest-config@29.7.0(@types/node@22.10.5)(ts-node@10.9.2(@types/node@22.10.5)(typescript@5.7.3)):
+  jest-config@29.7.0(@types/node@22.10.6)(ts-node@10.9.2(@types/node@22.10.6)(typescript@5.7.3)):
     dependencies:
       '@babel/core': 7.26.0
       '@jest/test-sequencer': 29.7.0
@@ -6229,70 +5950,8 @@ snapshots:
       slash: 3.0.0
       strip-json-comments: 3.1.1
     optionalDependencies:
-      '@types/node': 22.10.5
-      ts-node: 10.9.2(@types/node@22.10.5)(typescript@5.7.3)
-    transitivePeerDependencies:
-      - babel-plugin-macros
-      - supports-color
-
-  jest-config@29.7.0(@types/node@20.17.10)(ts-node@10.9.2(@types/node@22.10.2)(typescript@5.7.2)):
-    dependencies:
-      '@babel/core': 7.26.0
-      '@jest/test-sequencer': 29.7.0
-      '@jest/types': 29.6.3
-      babel-jest: 29.7.0(@babel/core@7.26.0)
-      chalk: 4.1.2
-      ci-info: 3.9.0
-      deepmerge: 4.3.1
-      glob: 7.2.3
-      graceful-fs: 4.2.11
-      jest-circus: 29.7.0
-      jest-environment-node: 29.7.0
-      jest-get-type: 29.6.3
-      jest-regex-util: 29.6.3
-      jest-resolve: 29.7.0
-      jest-runner: 29.7.0
-      jest-util: 29.7.0
-      jest-validate: 29.7.0
-      micromatch: 4.0.8
-      parse-json: 5.2.0
-      pretty-format: 29.7.0
-      slash: 3.0.0
-      strip-json-comments: 3.1.1
-    optionalDependencies:
-      '@types/node': 20.17.10
-      ts-node: 10.9.2(@types/node@22.10.2)(typescript@5.7.2)
-    transitivePeerDependencies:
-      - babel-plugin-macros
-      - supports-color
-
-  jest-config@29.7.0(@types/node@22.10.2)(ts-node@10.9.2(@types/node@22.10.2)(typescript@5.7.2)):
-    dependencies:
-      '@babel/core': 7.26.0
-      '@jest/test-sequencer': 29.7.0
-      '@jest/types': 29.6.3
-      babel-jest: 29.7.0(@babel/core@7.26.0)
-      chalk: 4.1.2
-      ci-info: 3.9.0
-      deepmerge: 4.3.1
-      glob: 7.2.3
-      graceful-fs: 4.2.11
-      jest-circus: 29.7.0
-      jest-environment-node: 29.7.0
-      jest-get-type: 29.6.3
-      jest-regex-util: 29.6.3
-      jest-resolve: 29.7.0
-      jest-runner: 29.7.0
-      jest-util: 29.7.0
-      jest-validate: 29.7.0
-      micromatch: 4.0.8
-      parse-json: 5.2.0
-      pretty-format: 29.7.0
-      slash: 3.0.0
-      strip-json-comments: 3.1.1
-    optionalDependencies:
-      '@types/node': 22.10.2
-      ts-node: 10.9.2(@types/node@22.10.2)(typescript@5.7.2)
+      '@types/node': 22.10.6
+      ts-node: 10.9.2(@types/node@22.10.6)(typescript@5.7.3)
     transitivePeerDependencies:
       - babel-plugin-macros
       - supports-color
@@ -6316,29 +5975,18 @@ snapshots:
       jest-util: 29.7.0
       pretty-format: 29.7.0
 
-<<<<<<< HEAD
   jest-environment-jsdom@29.7.0(canvas@3.0.1):
-=======
-  jest-environment-jsdom@29.7.0:
->>>>>>> f0b1ffc (fix: remove yarn file from root)
     dependencies:
       '@jest/environment': 29.7.0
       '@jest/fake-timers': 29.7.0
       '@jest/types': 29.6.3
       '@types/jsdom': 20.0.1
-<<<<<<< HEAD
       '@types/node': 20.17.12
       jest-mock: 29.7.0
       jest-util: 29.7.0
       jsdom: 20.0.3(canvas@3.0.1)
     optionalDependencies:
       canvas: 3.0.1
-=======
-      '@types/node': 20.17.10
-      jest-mock: 29.7.0
-      jest-util: 29.7.0
-      jsdom: 20.0.3
->>>>>>> f0b1ffc (fix: remove yarn file from root)
     transitivePeerDependencies:
       - bufferutil
       - supports-color
@@ -6349,7 +5997,7 @@ snapshots:
       '@jest/environment': 29.7.0
       '@jest/fake-timers': 29.7.0
       '@jest/types': 29.6.3
-      '@types/node': 20.17.12
+      '@types/node': 22.10.6
       jest-mock: 29.7.0
       jest-util: 29.7.0
 
@@ -6359,7 +6007,7 @@ snapshots:
     dependencies:
       '@jest/types': 29.6.3
       '@types/graceful-fs': 4.1.9
-      '@types/node': 20.17.12
+      '@types/node': 22.10.6
       anymatch: 3.1.3
       fb-watchman: 2.0.2
       graceful-fs: 4.2.11
@@ -6433,7 +6081,7 @@ snapshots:
       '@jest/test-result': 29.7.0
       '@jest/transform': 29.7.0
       '@jest/types': 29.6.3
-      '@types/node': 20.17.12
+      '@types/node': 22.10.6
       chalk: 4.1.2
       emittery: 0.13.1
       graceful-fs: 4.2.11
@@ -6461,7 +6109,7 @@ snapshots:
       '@jest/test-result': 29.7.0
       '@jest/transform': 29.7.0
       '@jest/types': 29.6.3
-      '@types/node': 20.17.12
+      '@types/node': 22.10.6
       chalk: 4.1.2
       cjs-module-lexer: 1.4.1
       collect-v8-coverage: 1.0.2
@@ -6526,7 +6174,7 @@ snapshots:
     dependencies:
       '@jest/test-result': 29.7.0
       '@jest/types': 29.6.3
-      '@types/node': 20.17.12
+      '@types/node': 22.10.6
       ansi-escapes: 4.3.2
       chalk: 4.1.2
       emittery: 0.13.1
@@ -6535,13 +6183,13 @@ snapshots:
 
   jest-worker@27.5.1:
     dependencies:
-      '@types/node': 20.17.12
+      '@types/node': 22.10.6
       merge-stream: 2.0.0
       supports-color: 8.1.1
 
   jest-worker@29.7.0:
     dependencies:
-      '@types/node': 20.17.12
+      '@types/node': 22.10.6
       jest-util: 29.7.0
       merge-stream: 2.0.0
       supports-color: 8.1.1
@@ -6558,24 +6206,12 @@ snapshots:
       - supports-color
       - ts-node
 
-  jest@29.7.0(@types/node@22.10.5)(ts-node@10.9.2(@types/node@22.10.5)(typescript@5.7.3)):
+  jest@29.7.0(@types/node@22.10.6)(ts-node@10.9.2(@types/node@22.10.6)(typescript@5.7.3)):
     dependencies:
-      '@jest/core': 29.7.0(ts-node@10.9.2(@types/node@22.10.5)(typescript@5.7.3))
+      '@jest/core': 29.7.0(ts-node@10.9.2(@types/node@22.10.6)(typescript@5.7.3))
       '@jest/types': 29.6.3
       import-local: 3.2.0
-      jest-cli: 29.7.0(@types/node@22.10.5)(ts-node@10.9.2(@types/node@22.10.5)(typescript@5.7.3))
-    transitivePeerDependencies:
-      - '@types/node'
-      - babel-plugin-macros
-      - supports-color
-      - ts-node
-
-  jest@29.7.0(@types/node@22.10.2)(ts-node@10.9.2(@types/node@22.10.2)(typescript@5.7.2)):
-    dependencies:
-      '@jest/core': 29.7.0(ts-node@10.9.2(@types/node@22.10.2)(typescript@5.7.2))
-      '@jest/types': 29.6.3
-      import-local: 3.2.0
-      jest-cli: 29.7.0(@types/node@22.10.2)(ts-node@10.9.2(@types/node@22.10.2)(typescript@5.7.2))
+      jest-cli: 29.7.0(@types/node@22.10.6)(ts-node@10.9.2(@types/node@22.10.6)(typescript@5.7.3))
     transitivePeerDependencies:
       - '@types/node'
       - babel-plugin-macros
@@ -6593,44 +6229,7 @@ snapshots:
     dependencies:
       argparse: 2.0.1
 
-<<<<<<< HEAD
   jsdom@20.0.3(canvas@3.0.1):
-=======
-  jsdom@20.0.3:
-    dependencies:
-      abab: 2.0.6
-      acorn: 8.14.0
-      acorn-globals: 7.0.1
-      cssom: 0.5.0
-      cssstyle: 2.3.0
-      data-urls: 3.0.2
-      decimal.js: 10.4.3
-      domexception: 4.0.0
-      escodegen: 2.1.0
-      form-data: 4.0.1
-      html-encoding-sniffer: 3.0.0
-      http-proxy-agent: 5.0.0
-      https-proxy-agent: 5.0.1
-      is-potential-custom-element-name: 1.0.1
-      nwsapi: 2.2.16
-      parse5: 7.2.1
-      saxes: 6.0.0
-      symbol-tree: 3.2.4
-      tough-cookie: 4.1.4
-      w3c-xmlserializer: 4.0.0
-      webidl-conversions: 7.0.0
-      whatwg-encoding: 2.0.0
-      whatwg-mimetype: 3.0.0
-      whatwg-url: 11.0.0
-      ws: 8.18.0
-      xml-name-validator: 4.0.0
-    transitivePeerDependencies:
-      - bufferutil
-      - supports-color
-      - utf-8-validate
-
-  jsdom@24.1.3:
->>>>>>> f0b1ffc (fix: remove yarn file from root)
     dependencies:
       abab: 2.0.6
       acorn: 8.14.0
@@ -6665,7 +6264,7 @@ snapshots:
       - supports-color
       - utf-8-validate
 
-  jsdom@24.1.3(canvas@2.11.2):
+  jsdom@24.1.3:
     dependencies:
       cssstyle: 4.2.1
       data-urls: 5.0.0
@@ -6688,8 +6287,6 @@ snapshots:
       whatwg-url: 14.1.0
       ws: 8.18.0
       xml-name-validator: 5.0.0
-    optionalDependencies:
-      canvas: 2.11.2
     transitivePeerDependencies:
       - bufferutil
       - supports-color
@@ -6760,11 +6357,6 @@ snapshots:
     dependencies:
       yallist: 3.1.1
 
-  make-dir@3.1.0:
-    dependencies:
-      semver: 6.3.1
-    optional: true
-
   make-dir@4.0.0:
     dependencies:
       semver: 7.6.3
@@ -6833,30 +6425,10 @@ snapshots:
 
   minimist@1.2.8: {}
 
-  minipass@3.3.6:
-    dependencies:
-      yallist: 4.0.0
-    optional: true
-
-  minipass@5.0.0:
-    optional: true
-
   minipass@7.1.2: {}
-
-  minizlib@2.1.2:
-    dependencies:
-      minipass: 3.3.6
-      yallist: 4.0.0
-    optional: true
 
   mkdirp-classic@0.5.3: {}
 
-<<<<<<< HEAD
-  mkdirp@1.0.4:
-    optional: true
-
-=======
->>>>>>> f0b1ffc (fix: remove yarn file from root)
   moo-color@1.0.3:
     dependencies:
       color-name: 1.1.4
@@ -6864,9 +6436,6 @@ snapshots:
   ms@2.0.0: {}
 
   ms@2.1.3: {}
-
-  nan@2.22.0:
-    optional: true
 
   napi-build-utils@1.0.2: {}
 
@@ -6883,11 +6452,6 @@ snapshots:
       semver: 7.6.3
 
   node-addon-api@7.1.1: {}
-
-  node-fetch@2.7.0:
-    dependencies:
-      whatwg-url: 5.0.0
-    optional: true
 
   node-int64@0.4.0: {}
 
@@ -6919,11 +6483,6 @@ snapshots:
       touch: 3.1.1
       undefsafe: 2.0.5
 
-  nopt@5.0.0:
-    dependencies:
-      abbrev: 1.1.1
-    optional: true
-
   normalize-path@3.0.0: {}
 
   normalize-url@6.1.0: {}
@@ -6931,14 +6490,6 @@ snapshots:
   npm-run-path@4.0.1:
     dependencies:
       path-key: 3.1.1
-
-  npmlog@5.0.1:
-    dependencies:
-      are-we-there-yet: 2.0.0
-      console-control-strings: 1.1.0
-      gauge: 3.0.2
-      set-blocking: 2.0.0
-    optional: true
 
   nwsapi@2.2.16: {}
 
@@ -7072,7 +6623,7 @@ snapshots:
       pump: 3.0.2
       rc: 1.2.8
       simple-get: 4.0.1
-      tar-fs: 2.1.1
+      tar-fs: 2.1.2
       tunnel-agent: 0.6.0
 
   prelude-ls@1.2.1: {}
@@ -7298,9 +6849,6 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  set-blocking@2.0.0:
-    optional: true
-
   setprototypeof@1.2.0: {}
 
   shallow-clone@3.0.1:
@@ -7460,7 +7008,7 @@ snapshots:
 
   tapable@2.2.1: {}
 
-  tar-fs@2.1.1:
+  tar-fs@2.1.2:
     dependencies:
       chownr: 1.1.4
       mkdirp-classic: 0.5.3
@@ -7474,16 +7022,6 @@ snapshots:
       fs-constants: 1.0.0
       inherits: 2.0.4
       readable-stream: 3.6.2
-
-  tar@6.2.1:
-    dependencies:
-      chownr: 2.0.0
-      fs-minipass: 2.1.0
-      minipass: 5.0.0
-      minizlib: 2.1.2
-      mkdirp: 1.0.4
-      yallist: 4.0.0
-    optional: true
 
   terser-webpack-plugin@5.3.11(webpack@5.97.1):
     dependencies:
@@ -7563,12 +7101,12 @@ snapshots:
       '@jest/types': 29.6.3
       babel-jest: 29.7.0(@babel/core@7.26.0)
 
-  ts-jest@29.2.5(@babel/core@7.26.0)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.26.0))(jest@29.7.0(@types/node@22.10.5)(ts-node@10.9.2(@types/node@22.10.5)(typescript@5.7.3)))(typescript@5.7.3):
+  ts-jest@29.2.5(@babel/core@7.26.0)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.26.0))(jest@29.7.0(@types/node@22.10.6)(ts-node@10.9.2(@types/node@22.10.6)(typescript@5.7.3)))(typescript@5.7.3):
     dependencies:
       bs-logger: 0.2.6
       ejs: 3.1.10
       fast-json-stable-stringify: 2.1.0
-      jest: 29.7.0(@types/node@22.10.5)(ts-node@10.9.2(@types/node@22.10.5)(typescript@5.7.3))
+      jest: 29.7.0(@types/node@22.10.6)(ts-node@10.9.2(@types/node@22.10.6)(typescript@5.7.3))
       jest-util: 29.7.0
       json5: 2.2.3
       lodash.memoize: 4.1.2
@@ -7610,33 +7148,21 @@ snapshots:
       v8-compile-cache-lib: 3.0.1
       yn: 3.1.1
 
-<<<<<<< HEAD
-  ts-node@10.9.2(@types/node@22.10.5)(typescript@5.7.3):
-=======
-  ts-node@10.9.2(@types/node@22.10.2)(typescript@5.7.2):
->>>>>>> f0b1ffc (fix: remove yarn file from root)
+  ts-node@10.9.2(@types/node@22.10.6)(typescript@5.7.3):
     dependencies:
       '@cspotcode/source-map-support': 0.8.1
       '@tsconfig/node10': 1.0.11
       '@tsconfig/node12': 1.0.11
       '@tsconfig/node14': 1.0.3
       '@tsconfig/node16': 1.0.4
-<<<<<<< HEAD
-      '@types/node': 22.10.5
-=======
-      '@types/node': 22.10.2
->>>>>>> f0b1ffc (fix: remove yarn file from root)
+      '@types/node': 22.10.6
       acorn: 8.14.0
       acorn-walk: 8.3.4
       arg: 4.1.3
       create-require: 1.1.1
       diff: 4.0.2
       make-error: 1.3.6
-<<<<<<< HEAD
       typescript: 5.7.3
-=======
-      typescript: 5.7.2
->>>>>>> f0b1ffc (fix: remove yarn file from root)
       v8-compile-cache-lib: 3.0.1
       yn: 3.1.1
     optional: true
@@ -7813,11 +7339,6 @@ snapshots:
   which@2.0.2:
     dependencies:
       isexe: 2.0.0
-
-  wide-align@1.1.5:
-    dependencies:
-      string-width: 4.2.3
-    optional: true
 
   wildcard@2.0.1: {}
 


### PR DESCRIPTION
## Issue 106: (Ethan Swenke, Jackson Isidor)

## Summary
- Changed the functionality of the blue potion from simply removing health. Now increases player speed. Also works with any mob who purchases and consumes a blue potion. Caps speed at 10 (which is REALLY fast), and is currently permanent until rebuild of game to refresh state.

## Changes
- `packages/server/src/mobs/mob.ts` Added a 'changeSpeed' method.
- `packages/server/src/items/potionEffects.ts`  Added a call to 'changeSpeed' to replace the old 'changeHealth'. Adds 2 speed to the player, capping at 10.
- `packages/server/src/services/clientCommunication/pubsub.ts`  Added 'changeSpeed' signature.
- `packages/server/src/services/clientCommunication/stubbedPubSub.ts` Added 'changeSpeed' signature.
- `packages/server/src/services/clientCommunication/ablyService.ts` Added 'changeSpeed' method for broadcasting mobChange.
- `packages/server/src/services/clientCommunication/clientMarshalling.ts` Added speed as an attribute to the player rather than a regular property.
- `packages/client/src/world/mob.ts` Comment speed out of the properties and parameters, as it is now an attribute.
- `packages/client/src/sprite/sprite_mob.ts` Comment speed out of constructor
- `packages/client/src/scenes/uxScenes.ts` Added speed to the current ux attributes shown in game (doesn't update in realtime yet)
- `packages/client/src/worldMetadata.ts` Added speed getter.
- `packages/common/src/mob.ts` Commented out speed.

## Added
- `packages/server/test/items/potionEffects.test.ts` Added unit testing.