### PR TITLE
fix: mob NPC text color

### DIFF
--- a/packages/client/src/sprite/sprite_mob.ts
+++ b/packages/client/src/sprite/sprite_mob.ts
@@ -117,7 +117,7 @@ export class SpriteMob extends Mob {
           fontStyle: 'bold',
           color: '#000000',
           strokeThickness: 2,
-          stroke: '#FFFFFF'
+          stroke: '#FFFFFF',
         }
       )
       .setOrigin(0.5);
@@ -128,7 +128,13 @@ export class SpriteMob extends Mob {
         this.sprite.x,
         this.sprite.y + TEXT_PLACEMENT_TO_SPRITE_OFFSET,
         mob.doing!,
-        { fontFamily: 'Arial', fontSize: '12px', color: '#000000' }
+        { 
+          fontFamily: 'Arial', 
+          fontSize: '12px', 
+          color: '#000000',
+          strokeThickness: 3,
+          stroke: '#FFFFFF', 
+        }
       )
       .setOrigin(0.5);
     this.doingText.setDepth(1);

--- a/packages/client/src/sprite/sprite_mob.ts
+++ b/packages/client/src/sprite/sprite_mob.ts
@@ -128,7 +128,7 @@ export class SpriteMob extends Mob {
         this.sprite.x,
         this.sprite.y + TEXT_PLACEMENT_TO_SPRITE_OFFSET,
         mob.doing!,
-        { fontFamily: 'Arial', fontSize: '10px', color: '#FFFFFF' }
+        { fontFamily: 'Arial', fontSize: '12px', color: '#000000' }
       )
       .setOrigin(0.5);
     this.doingText.setDepth(1);


### PR DESCRIPTION
Fix: Wall Can be Built From Partial Wall 

## Summary:
Fixed a bug where the "doingText" of the mob was not visible on yellow background. 

![image](https://github.com/user-attachments/assets/1b2e217e-68fe-408b-a0d0-cee4e50a402c)

## Changes:

`C:\Users\halli\369\potions\packages\client\src\sprite\sprite_mob.ts` : 

- Changed color of text to black, increased font size from 10px to 12 px 
- added white border to doing text

### Daytime: 
![image](https://github.com/user-attachments/assets/f9348bcb-daee-4ecb-8b36-d7eb0cb6d553)

### Nighttime:
![image](https://github.com/user-attachments/assets/9c67e1ec-e95d-495d-a5ce-cfca392b618e)