### PR TITLE
fix: don't display health bar for all items

### DIFF
--- a/packages/client/src/sprite/sprite_item.ts
+++ b/packages/client/src/sprite/sprite_item.ts
@@ -27,7 +27,6 @@ export class SpriteItem extends Item {
     this.house = item.house;
     this.carried_by = item.carried_by;
     this.lock = item.lock;
-    this.healthBar = scene.add.graphics();
     this.maxHealth = 100;
 
     // copy over all attributes


### PR DESCRIPTION
**Group:** Daniel Ching, Josh Queja, Keith Lee

### Bug
When starting the game, we noticed items had health bars. Logs and blueberries are items that should not show health bars. 

### Changes
https://github.com/sloalchemist/potions/commit/1c9adc7729b80734e4a4ff4642f87c259901fcd4

- Removes adding the health bar graphic to every item unconditionally

### Testing
- UI change only, no unit test needed