### PR TITLE
Fix: Bug - User can walk over edges of water bodies

### DIFF
--- a/packages/common/src/coord.ts
+++ b/packages/common/src/coord.ts
@@ -28,6 +28,11 @@ export function floor(coord: Coord): Coord {
   return { x: Math.floor(coord.x), y: Math.floor(coord.y) };
 }
 
+// Return the rounded values of the coordinates
+export function round(coord: Coord): Coord {
+  return { x: Math.round(coord.x), y: Math.round(coord.y) };
+}
+
 // Normalized vector subtraction between two coordinates
 export function normalizedSubtraction(coord1: Coord, coord2: Coord): Coord {
   const dx = coord1.x - coord2.x;

--- a/packages/common/src/coord.ts
+++ b/packages/common/src/coord.ts
@@ -33,6 +33,11 @@ export function round(coord: Coord): Coord {
   return { x: Math.round(coord.x), y: Math.round(coord.y) };
 }
 
+// Return the ceiling values of the coordinates
+export function ceiling(coord: Coord): Coord {
+  return { x: Math.ceil(coord.x), y: Math.ceil(coord.y) };
+}
+
 // Normalized vector subtraction between two coordinates
 export function normalizedSubtraction(coord1: Coord, coord2: Coord): Coord {
   const dx = coord1.x - coord2.x;

--- a/packages/common/src/pathFinder.ts
+++ b/packages/common/src/pathFinder.ts
@@ -207,8 +207,20 @@ export class PathFinder {
     return simplifiedPath;
   }
 
-  // Check if surrounding tiles are walkable in specific cases
-  private checkSurrounding(start: Coord, end: Coord): boolean {
+  
+/**
+ * Determines if the surrounding tiles relative to the starting coordinate are walkable.
+ * 
+ * This function checks two adjacent tiles based on the direction from the start to the end
+ * coordinate, verifying if they are walkable.
+ * 
+ * @param start - The starting coordinate.
+ * @param end - The ending coordinate.
+ * 
+ * @returns True if the surrounding tiles in the direction to the end coordinate are walkable, 
+ * false otherwise.
+ */
+  private isSurroundingWalkable(start: Coord, end: Coord): boolean {
     start = floor(start);
 
     if (end.x <= start.x && end.y <= start.y) {
@@ -239,7 +251,7 @@ export class PathFinder {
   ): Coord[] {
     end = floor(end);
 
-    if (this.checkSurrounding(start, end)) {
+    if (this.isSurroundingWalkable(start, end)) {
       start = ceiling(start);
     }
     else {

--- a/packages/common/src/pathFinder.ts
+++ b/packages/common/src/pathFinder.ts
@@ -1,4 +1,4 @@
-import { Coord, floor, step } from './coord';
+import { Coord, floor, round, step } from './coord';
 import { TerrainType } from './terrainType';
 
 export class PathFinder {
@@ -214,7 +214,8 @@ export class PathFinder {
     fuzzy: boolean = false
   ): Coord[] {
     end = floor(end);
-    start = floor(start);
+    start = round(start);
+    //start = floor(start);
 
     if (!fuzzy && !this.isWalkable(unlocks, end.x, end.y)) {
       // new Error(`End position (${JSON.stringify(end)}) is not walkable`);

--- a/packages/common/src/pathFinder.ts
+++ b/packages/common/src/pathFinder.ts
@@ -1,4 +1,4 @@
-import { Coord, floor, round, step } from './coord';
+import { Coord, floor, ceiling, step } from './coord';
 import { TerrainType } from './terrainType';
 
 export class PathFinder {
@@ -207,6 +207,30 @@ export class PathFinder {
     return simplifiedPath;
   }
 
+  // Check if surrounding tiles are walkable in specific cases
+  private checkSurrounding(start: Coord, end: Coord): boolean {
+    start = floor(start);
+
+    if (end.x <= start.x && end.y <= start.y) {
+      return this.isWalkable([], start.x - 1, start.y) &&
+        this.isWalkable([], start.x, start.y - 1);
+    }
+    else if (end.x > start.x && end.y <= start.y) {
+      return this.isWalkable([], start.x + 1, start.y) &&
+        this.isWalkable([], start.x, start.y - 1);
+    }
+    else if (end.x <= start.x && end.y > start.y) {
+      return this.isWalkable([], start.x - 1, start.y) &&
+        this.isWalkable([], start.x, start.y + 1);
+    }
+    else if (end.x > start.x && end.y > start.y) {
+      return this.isWalkable([], start.x + 1, start.y) &&
+        this.isWalkable([], start.x, start.y + 1);
+    }
+
+    return false;
+  }
+
   generatePath(
     unlocks: string[],
     start: Coord,
@@ -214,8 +238,13 @@ export class PathFinder {
     fuzzy: boolean = false
   ): Coord[] {
     end = floor(end);
-    start = round(start);
-    //start = floor(start);
+
+    if (this.checkSurrounding(start, end)) {
+      start = ceiling(start);
+    }
+    else {
+      start = floor(start);
+    }
 
     if (!fuzzy && !this.isWalkable(unlocks, end.x, end.y)) {
       // new Error(`End position (${JSON.stringify(end)}) is not walkable`);

--- a/packages/common/test/pathFinder.test.ts
+++ b/packages/common/test/pathFinder.test.ts
@@ -81,4 +81,59 @@ describe('PathFinder', () => {
     const path = pathFinder.generatePath([], start, end, false);
     expect(path).toEqual([]);
   });
+
+  test('generatePath should not cut over unwalkable corners (#1)', () => {
+    // check not cutting top left corner
+    const start = { x: 0.75, y: 0 };
+    const end = { x: 1, y: 2 };
+    const cornerPoint = { x: 0, y: 0 };
+    const path = pathFinder.generatePath([], start, end, false);
+    expect(path).not.toHaveLength(0);
+    expect(path).toContainEqual(cornerPoint);
+    expect(path).toContainEqual(end);
+  });
+
+  test('generatePath should not cut over unwalkable corners (#2)', () => {
+    // check not cutting the top left corner, but different start point
+    const start = { x: 0.2, y: 0 };
+    const end = { x: 1, y: 2 };
+    const cornerPoint = { x: 0, y: 0 };
+    const path = pathFinder.generatePath([], start, end, false);
+    expect(path).not.toHaveLength(0);
+    expect(path).toContainEqual(cornerPoint);
+    expect(path).toContainEqual(end);
+  });
+
+  test('generatePath should not cut over unwalkable corners (#3)', () => {
+    // check not cutting top right corner
+    const start = { x: 0.4, y: 2 };
+    const end = { x: 1, y: 0 };
+    const cornerPoint = { x: 0, y: 2 };
+    const path = pathFinder.generatePath([], start, end, false);
+    expect(path).not.toHaveLength(0);
+    expect(path).toContainEqual(cornerPoint);
+    expect(path).toContainEqual(end);
+  });
+
+  test('generatePath should not cut over unwalkable corners (#4)', () => {
+    // check not cutting the bottom right corner
+    const start = { x: 2, y: 1.6 };
+    const end = { x: 0, y: 2 };
+    const cornerPoint = { x: 2, y: 2 };
+    const path = pathFinder.generatePath([], start, end, false);
+    expect(path).not.toHaveLength(0);
+    expect(path).toContainEqual(cornerPoint);
+    expect(path).toContainEqual(end);
+  });
+
+  test('generatePath should not cut over unwalkable corners (#5)', () => {
+    // check not cutting the bottom left corner
+    const start = { x: 1.9, y: 0 };
+    const end = { x: 2, y: 2 };
+    const cornerPoint = { x: 2, y: 0 };
+    const path = pathFinder.generatePath([], start, end, false);
+    expect(path).not.toHaveLength(0);
+    expect(path).toContainEqual(cornerPoint);
+    expect(path).toContainEqual(end);
+  });
 });


### PR DESCRIPTION
## **Problem:**

Whenever the user double-clicks to get to a point that is on the other side of an unwalkable area, they cut through the edges of the unwalkable area/tiles. This mainly occurs when near the top of the unwalkable areas.

![IMG_7971](https://github.com/user-attachments/assets/063a34c4-19cc-4532-b827-92735a8216a6)

We found that the issue arises because the pathing algorithm floor of the current point as the start (even if it is in between 2 tiles). The issue occurs when the second click happens as the current point is in between 2 tiles, so it considers the start as the floor, which makes it skip one of the points along its intended path.

## **Solution:**

- Added a ceiling method for coordinates
- Added a check to see if the floored start coordinate has an unwalkable area next to it (depending on the location of the target)
- Using that check, the starting coordinate is chosen as the ceiling or the floor in order to ensure points along the path are not skipped

## **Tests:**

Added few test cases in the pathFinder.test.ts file, to ensure that the path does not skip one of the points along the path. Tested cases where the starting position is in between two tiles and added checks to make sure that the corner coordinate that should be in the path is still there.

**Fixes** [#51](https://github.com/sloalchemist/potions/issues/51)
