### PR TITLE
Fix: resolved openable, smashable bug (Gabe Riedel, Calahan Lackovic)

### DIFF
--- a/packages/client/src/world/controller.ts
+++ b/packages/client/src/world/controller.ts
@@ -236,16 +236,22 @@ function getItemsAtPosition(physicals: Item[], position: Coord): Item[] {
   });
 }
 
-function getInteractablePhysicals(physicals: Item[], playerPos: Coord): Item[] {
+export function getInteractablePhysicals(physicals: Item[], playerPos: Coord): Item[] {
   // player is standing on
   let onTopObjects = getItemsAtPosition(physicals, playerPos);
 
+  // nearby "openable" items
+  let nearbyOpenableObjects = physicals.filter(p => p.itemType.layout_type === "opens")
+  if (nearbyOpenableObjects.length > 1) {
+    nearbyOpenableObjects = [getClosestPhysical(nearbyOpenableObjects, playerPos)];
+  }
+  
   // nearby non-walkable items
   let nearbyObjects = physicals.filter(p => !p.itemType.walkable);
   if (nearbyObjects.length > 1) {
     nearbyObjects = [getClosestPhysical(nearbyObjects, playerPos)];
   }
-  return [...onTopObjects, ...nearbyObjects];
+  return [...onTopObjects, ...nearbyObjects, ...nearbyOpenableObjects];
 }
 
 function collisionListener(physicals: Item[]) {

--- a/packages/client/test/items/uses/smashGate.test.ts
+++ b/packages/client/test/items/uses/smashGate.test.ts
@@ -1,0 +1,139 @@
+import { getInteractablePhysicals, getPhysicalInteractions } from "../../../src/world/controller";
+import { Item } from "../../../src/world/item";
+import { World } from "../../../src/world/world";
+import { ItemType } from "../../../src/worldDescription";
+import { Coord, followPath } from '@rt-potion/common';
+
+describe('Openable, smashable items have prompts to smash', () => {
+  let world: World | null = null;
+  let mockChatCallback: jest.Mock;
+
+  beforeAll(() => {
+    // Initialize world
+    world = new World();
+    world.load({
+      tiles: [
+        [0, 0, 0],
+        [0, 0, 0],
+        [0, 0, 0],
+      ],
+      terrain_types: [{ id: 0, name: 'Grass', walkable: true }],
+      item_types: [],
+      mob_types: [],
+    });
+    
+  });
+
+  test('Proximity to gate results in "smash gate" prompt', () => {
+
+    const gateItemType: ItemType = {
+        name: "Gate",
+        type: "gate",
+        item_group: "fence",
+        layout_type: "opens", 
+        carryable: false,     
+        smashable: true,               
+        walkable: true,       
+        interactions: [],
+        attributes: [
+            {
+                "name": "health",
+                "value": 100
+            }
+        ],
+      };
+       
+    
+    //const player1 = new Mob(world!, 'mob1', 'Player1', 'player', 100, playerPos, 2, {});
+
+    // Instantiate the gate object  
+    const gate = new Item(world!, "gate1", { x: 1, y: 1 }, gateItemType)
+
+    // Establish player position (don't need a full player mob)
+    const playerPos: Coord = { x: 1, y: 0 };
+
+    // Put gate into Item list form to be accepted as an input for getInteractablePhysicals
+    const physicals: Item[] = [
+        gate
+      ];
+    
+    // Get physicals (should just be gate) that are able to be interacted with
+    // from the player position
+    const interactablePhysicals = getInteractablePhysicals(physicals, playerPos);
+
+    // Determine if the gate object appears as an interactable object
+    const gateExists = interactablePhysicals.some(
+        (item) => item.itemType.name === 'Gate'
+      );
+
+    expect(gateExists).toBe(true);
+    console.log("Interactable items in proximity: ", interactablePhysicals)
+
+    // Acquire all of the possible interactions with the gate object
+    const interactions = getPhysicalInteractions(gate)
+
+    // Determine if the smash interaction is possible with the gate object
+    const hasSmashInteraction = interactions.some(interaction => interaction.action === 'smash');
+    expect(hasSmashInteraction).toBe(true); 
+    console.log("Interactions available: ", interactions)
+
+  });
+
+  test('Proximity to door results in "smash door" prompt', () => {
+
+    const gateItemType: ItemType = {
+        name: "Door",
+        type: "door",
+        item_group: "wall",
+        layout_type: "opens", 
+        carryable: false,     
+        smashable: true,               
+        walkable: true,       
+        interactions: [],
+        attributes: [
+            {
+                "name": "health",
+                "value": 100
+            }
+        ],
+      };
+       
+
+    // Instantiate the door object  
+    const door = new Item(world!, "door1", { x: 1, y: 1 }, gateItemType)
+
+    // Establish player position (don't need a full player mob)
+    const playerPos: Coord = { x: 1, y: 0 };
+
+    // Put door into Item list form to be accepted as an input for getInteractablePhysicals
+    const physicals: Item[] = [
+        door
+      ];
+    
+    // Get physicals (should just be door) that are able to be interacted with
+    // from the player position
+    const interactablePhysicals = getInteractablePhysicals(physicals, playerPos);
+
+    // Determine if the door object appears as an interactable object
+    const doorExists = interactablePhysicals.some(
+        (item) => item.itemType.name === 'Door'
+      );
+
+    expect(doorExists).toBe(true);
+    console.log("Interactable items in proximity: ", interactablePhysicals)
+
+    // Acquire all of the possible interactions with the door object
+    const interactions = getPhysicalInteractions(door)
+
+    // Determine if the smash interaction is possible with the door object
+    const hasSmashInteraction = interactions.some(interaction => interaction.action === 'smash');
+    expect(hasSmashInteraction).toBe(true); 
+    console.log("Interactions available: ", interactions)
+
+  });
+
+
+  afterAll(() => {
+    world = null;
+  });
+});

--- a/packages/client/test/items/uses/smashGate.test.ts
+++ b/packages/client/test/items/uses/smashGate.test.ts
@@ -2,11 +2,10 @@ import { getInteractablePhysicals, getPhysicalInteractions } from "../../../src/
 import { Item } from "../../../src/world/item";
 import { World } from "../../../src/world/world";
 import { ItemType } from "../../../src/worldDescription";
-import { Coord, followPath } from '@rt-potion/common';
+import { Coord } from '@rt-potion/common';
 
 describe('Openable, smashable items have prompts to smash', () => {
   let world: World | null = null;
-  let mockChatCallback: jest.Mock;
 
   beforeAll(() => {
     // Initialize world


### PR DESCRIPTION
# Problem

When approaching a smashable item that is walkable and has a layout_type of "opens" (i.e. a gate or a door), there is no button to smash that item.

<img width="508" alt="Screenshot 2025-01-12 at 8 23 25 PM" src="https://github.com/user-attachments/assets/8f4dae1c-6f08-4aed-a284-2c6906c72e3e" />

This issue arose because any items that were walkable but not able to be stood on top of (i.e. a closed gate or door) were getting filtered out from having a smash interaction. 

# Solution

1. Added logic for items who have a layout_type of "opens" to be checked if they were in proximity to the player's position
2. Now all nearby, openable items were added to the array of items that could be interacted with

# Tests

Added one test case for gates and one for doors that checked if the respective object was interactable from a player location one tile away, and it checked if one of the interactions with this object was that it could be smashed.