### PR TITLE
fix: items container interactions clear after player dies.

### DIFF
--- a/packages/client/src/scenes/uxScene.ts
+++ b/packages/client/src/scenes/uxScene.ts
@@ -16,7 +16,6 @@ import { ChatButtonManager } from "../components/chatButtonManager";
 import { Mob } from '../world/mob';
 import { World } from '../world/world';
 import { interact, requestChat, speak } from '../services/playerToServer';
-import { playerDead } from '../services/serverToBroadcast'
 
 export interface ChatOption {
   label: string;
@@ -180,17 +179,10 @@ export class UxScene extends Phaser.Scene {
           }))
         );
       });
-      if (playerDead) {
-        setInteractionCallback((interactions: Interactions[]) =>
-          this.setInteractions([])
-        );
-      } else {
-        // Set interaction callback for item interactions
+      // Set interaction callback for item interactions
       setInteractionCallback((interactions: Interactions[]) =>
         this.setInteractions(interactions)
       );
-      }
-
       setChatCompanionCallback((companions: Mob[]) =>
         this.setChatCompanions(companions)
       );
@@ -270,8 +262,7 @@ export class UxScene extends Phaser.Scene {
 
   // Method to set item interactions
   setInteractions(interactions: Interactions[]) {
-      this.interactButtons.forEach((button: Button) => button.destroy());
-      this.interactButtons = [];
+    this.chatButtons?.clearChatOptions();
 
     interactions.forEach((interaction, i) => {
       const y = 60 + (BUTTON_HEIGHT + 10) * Math.floor(i / 3);

--- a/packages/client/src/scenes/uxScene.ts
+++ b/packages/client/src/scenes/uxScene.ts
@@ -16,6 +16,7 @@ import { ChatButtonManager } from "../components/chatButtonManager";
 import { Mob } from '../world/mob';
 import { World } from '../world/world';
 import { interact, requestChat, speak } from '../services/playerToServer';
+import { playerDead } from '../services/serverToBroadcast'
 
 export interface ChatOption {
   label: string;
@@ -174,10 +175,17 @@ export class UxScene extends Phaser.Scene {
           }))
         );
       });
-      // Set interaction callback for item interactions
+      if (playerDead) {
+        setInteractionCallback((interactions: Interactions[]) =>
+          this.setInteractions([])
+        );
+      } else {
+        // Set interaction callback for item interactions
       setInteractionCallback((interactions: Interactions[]) =>
         this.setInteractions(interactions)
       );
+      }
+
       setChatCompanionCallback((companions: Mob[]) =>
         this.setChatCompanions(companions)
       );
@@ -256,7 +264,8 @@ export class UxScene extends Phaser.Scene {
 
   // Method to set item interactions
   setInteractions(interactions: Interactions[]) {
-    this.chatButtons?.clearChatOptions();
+      this.interactButtons.forEach((button: Button) => button.destroy());
+      this.interactButtons = [];
 
     interactions.forEach((interaction, i) => {
       const y = 60 + (BUTTON_HEIGHT + 10) * Math.floor(i / 3);

--- a/packages/client/src/scenes/uxScene.ts
+++ b/packages/client/src/scenes/uxScene.ts
@@ -280,6 +280,11 @@ export class UxScene extends Phaser.Scene {
     });
   }
 
+  clearInteractions() {
+    this.interactButtons.forEach((button) => button.destroy());
+    this.interactButtons = [];
+  }
+
   setChatCompanions(companions: Mob[]) {
     this.chatButtons?.clearChatOptions();
 

--- a/packages/client/src/scenes/worldScene.ts
+++ b/packages/client/src/scenes/worldScene.ts
@@ -431,7 +431,8 @@ export class WorldScene extends Phaser.Scene {
   showGameOver() {
     let uxscene = this.scene.get("UxScene") as UxScene;
     uxscene.chatButtons?.clearChatOptions();
-    
+    uxscene.interactButtons.forEach((button) => button.destroy());
+    uxscene.interactButtons = [];
     const text = this.add.text(75, 140, 'GAME OVER', {
       color: '#FFFFFF',
       fontSize: 60,

--- a/packages/client/src/scenes/worldScene.ts
+++ b/packages/client/src/scenes/worldScene.ts
@@ -447,6 +447,7 @@ export class WorldScene extends Phaser.Scene {
   showGameOver() {
     let uxscene = this.scene.get('UxScene') as UxScene;
     uxscene.chatButtons?.clearChatOptions();
+    uxscene.clearInteractions();
 
     const text = this.add.text(75, 140, 'GAME OVER', {
       color: '#FFFFFF',

--- a/packages/client/src/scenes/worldScene.ts
+++ b/packages/client/src/scenes/worldScene.ts
@@ -429,9 +429,9 @@ export class WorldScene extends Phaser.Scene {
   }
 
   showGameOver() {
-    let uxscene = this.scene.get("UxScene") as UxScene;
+    let uxscene = this.scene.get('UxScene') as UxScene;
     uxscene.chatButtons?.clearChatOptions();
-    
+
     const text = this.add.text(75, 140, 'GAME OVER', {
       color: '#FFFFFF',
       fontSize: 60,

--- a/packages/client/src/scenes/worldScene.ts
+++ b/packages/client/src/scenes/worldScene.ts
@@ -431,8 +431,7 @@ export class WorldScene extends Phaser.Scene {
   showGameOver() {
     let uxscene = this.scene.get("UxScene") as UxScene;
     uxscene.chatButtons?.clearChatOptions();
-    uxscene.interactButtons.forEach((button) => button.destroy());
-    uxscene.interactButtons = [];
+    
     const text = this.add.text(75, 140, 'GAME OVER', {
       color: '#FFFFFF',
       fontSize: 60,

--- a/packages/client/src/services/serverToBroadcast.ts
+++ b/packages/client/src/services/serverToBroadcast.ts
@@ -16,7 +16,7 @@ import {
   SpeakData
 } from '@rt-potion/common';
 import { world, WorldScene } from '../scenes/worldScene';
-import { addNewItem, addNewMob, gameState, setDate } from '../world/controller';
+import { addNewItem, addNewMob, gameState, setDate, clearInteractions } from '../world/controller';
 import { SpriteMob } from '../sprite/sprite_mob';
 import { publicCharacterId } from '../worldMetadata';
 import { SpriteItem } from '../sprite/sprite_item';
@@ -95,6 +95,7 @@ export function setupBroadcast(
       mob.destroy(world);
       if (data.id === publicCharacterId) {
         playerDead = true;
+        clearInteractions
 
         // wait until the window is focused before moving on
         const waitUntilFocused = new Promise<void>((resolve) => {

--- a/packages/client/src/services/serverToBroadcast.ts
+++ b/packages/client/src/services/serverToBroadcast.ts
@@ -16,13 +16,20 @@ import {
   SpeakData
 } from '@rt-potion/common';
 import { world, WorldScene } from '../scenes/worldScene';
-import { addNewItem, addNewMob, gameState, setDate, clearInteractions } from '../world/controller';
+import {
+  addNewItem,
+  addNewMob,
+  gameState,
+  setDate,
+  clearInteractions
+} from '../world/controller';
 import { SpriteMob } from '../sprite/sprite_mob';
 import { publicCharacterId } from '../worldMetadata';
 import { SpriteItem } from '../sprite/sprite_item';
 import { Types } from 'ably';
 import { leaveWorld } from './playerToServer';
 import { focused } from '../main';
+import { clear } from 'console';
 
 export let playerDead = false;
 
@@ -94,6 +101,8 @@ export function setupBroadcast(
     if (mob) {
       mob.destroy(world);
       if (data.id === publicCharacterId) {
+        console.log('Player is dead');
+        clearInteractions();
         playerDead = true;
         clearInteractions
 

--- a/packages/client/src/services/serverToBroadcast.ts
+++ b/packages/client/src/services/serverToBroadcast.ts
@@ -29,7 +29,6 @@ import { SpriteItem } from '../sprite/sprite_item';
 import { Types } from 'ably';
 import { leaveWorld } from './playerToServer';
 import { focused } from '../main';
-import { clear } from 'console';
 
 export let playerDead = false;
 

--- a/packages/client/src/services/serverToBroadcast.ts
+++ b/packages/client/src/services/serverToBroadcast.ts
@@ -16,13 +16,7 @@ import {
   SpeakData
 } from '@rt-potion/common';
 import { world, WorldScene } from '../scenes/worldScene';
-import {
-  addNewItem,
-  addNewMob,
-  gameState,
-  setDate,
-  clearInteractions
-} from '../world/controller';
+import { addNewItem, addNewMob, gameState, setDate } from '../world/controller';
 import { SpriteMob } from '../sprite/sprite_mob';
 import { publicCharacterId } from '../worldMetadata';
 import { SpriteItem } from '../sprite/sprite_item';
@@ -100,10 +94,8 @@ export function setupBroadcast(
     if (mob) {
       mob.destroy(world);
       if (data.id === publicCharacterId) {
-        console.log('Player is dead');
-        clearInteractions();
+        console.log('Player died');
         playerDead = true;
-        clearInteractions
 
         // wait until the window is focused before moving on
         const waitUntilFocused = new Promise<void>((resolve) => {

--- a/packages/client/src/world/controller.ts
+++ b/packages/client/src/world/controller.ts
@@ -110,7 +110,7 @@ export function mobRangeListener(mobs: Mob[]) {
     const filteredMobs = mobs.filter((mob) => mob.type !== 'player');
     filteredMobs.sort((a, b) => a.key.localeCompare(b.key));
     if (!areListsEqual(filteredMobs, lastChatCompanions)) {
-      console.log("filter: ", filteredMobs, "last:", lastChatCompanions);
+      console.log('filter: ', filteredMobs, 'last:', lastChatCompanions);
       chatCompanionCallback(filteredMobs);
       lastChatCompanions = filteredMobs;
     }
@@ -168,11 +168,14 @@ export function getCarriedItemInteractions(
   // unique carried item interactions
   item.itemType.interactions.forEach((interaction) => {
     if (interaction.while_carried) {
-      const requiredItem = interaction.requires_item 
+      const requiredItem = interaction.requires_item
         ? nearbyItems.find((i) => i.itemType.type === interaction.requires_item)
         : true;
-      
-      if ((!interaction.requires_item || requiredItem) && item.conditionMet(interaction)) {
+
+      if (
+        (!interaction.requires_item || requiredItem) &&
+        item.conditionMet(interaction)
+      ) {
         interactions.push({
           action: interaction.action,
           item: item as Item,
@@ -232,7 +235,9 @@ export function getClosestPhysical(physicals: Item[], playerPos: Coord): Item {
 
 function getItemsAtPosition(physicals: Item[], position: Coord): Item[] {
   return physicals.filter((physical) => {
-    return position.x === physical.position!.x && position.y === physical.position!.y;
+    return (
+      position.x === physical.position!.x && position.y === physical.position!.y
+    );
   });
 }
 
@@ -241,7 +246,7 @@ function getInteractablePhysicals(physicals: Item[], playerPos: Coord): Item[] {
   let onTopObjects = getItemsAtPosition(physicals, playerPos);
 
   // nearby non-walkable items
-  let nearbyObjects = physicals.filter(p => !p.itemType.walkable);
+  let nearbyObjects = physicals.filter((p) => !p.itemType.walkable);
   if (nearbyObjects.length > 1) {
     nearbyObjects = [getClosestPhysical(nearbyObjects, playerPos)];
   }
@@ -251,13 +256,13 @@ function getInteractablePhysicals(physicals: Item[], playerPos: Coord): Item[] {
 function collisionListener(physicals: Item[]) {
   const player = world.mobs[publicCharacterId] as SpriteMob;
   const playerPos = floor(player.position!);
-  
+
   // retrieves a list of all of the nearby and on top of objects
   const interactableObjects = getInteractablePhysicals(physicals, playerPos);
   let interactions: Interactions[] = [];
 
   // retrieves interactions for all relevant objects
-  interactableObjects.forEach(physical => {
+  interactableObjects.forEach((physical) => {
     interactions = [...interactions, ...getPhysicalInteractions(physical)];
   });
 
@@ -275,7 +280,10 @@ function collisionListener(physicals: Item[]) {
   }
 
   // updates client only if interactions changes
-  if (!areInteractionsEqual(lastInteractions, interactions) && interactionCallback) {
+  if (
+    !areInteractionsEqual(lastInteractions, interactions) &&
+    interactionCallback
+  ) {
     interactionCallback(interactions);
     lastInteractions = interactions;
   }
@@ -291,6 +299,10 @@ export function setInteractionCallback(
   callback: (interactions: Interactions[]) => void
 ) {
   interactionCallback = callback;
+}
+
+export function clearInteractions() {
+  interactionCallback([]);
 }
 
 export function addNewHouse(scene: WorldScene, house: HouseI) {

--- a/packages/client/src/world/controller.ts
+++ b/packages/client/src/world/controller.ts
@@ -241,16 +241,23 @@ function getItemsAtPosition(physicals: Item[], position: Coord): Item[] {
   });
 }
 
-export function getInteractablePhysicals(physicals: Item[], playerPos: Coord): Item[] {
+export function getInteractablePhysicals(
+  physicals: Item[],
+  playerPos: Coord
+): Item[] {
   // player is standing on
   let onTopObjects = getItemsAtPosition(physicals, playerPos);
 
   // nearby "openable" items
-  let nearbyOpenableObjects = physicals.filter(p => p.itemType.layout_type === "opens")
+  let nearbyOpenableObjects = physicals.filter(
+    (p) => p.itemType.layout_type === 'opens'
+  );
   if (nearbyOpenableObjects.length > 1) {
-    nearbyOpenableObjects = [getClosestPhysical(nearbyOpenableObjects, playerPos)];
+    nearbyOpenableObjects = [
+      getClosestPhysical(nearbyOpenableObjects, playerPos)
+    ];
   }
-  
+
   // nearby non-walkable items
   let nearbyObjects = physicals.filter((p) => !p.itemType.walkable);
   if (nearbyObjects.length > 1) {
@@ -305,10 +312,6 @@ export function setInteractionCallback(
   callback: (interactions: Interactions[]) => void
 ) {
   interactionCallback = callback;
-}
-
-export function clearInteractions() {
-  interactionCallback([]);
 }
 
 export function addNewHouse(scene: WorldScene, house: HouseI) {

--- a/packages/client/test/clearInteractions.test.ts
+++ b/packages/client/test/clearInteractions.test.ts
@@ -1,0 +1,52 @@
+import 'jest-canvas-mock';
+import { Button } from '../src/components/button';
+import { UxScene } from '../src/scenes/uxScene';
+export const BUTTON_WIDTH = 120;
+export const BUTTON_HEIGHT = 40;
+
+class MockButton {
+  scene;
+  constructor(scene: object) {
+    this.scene = scene;
+  }
+
+  destroy() {
+    // Mock the destroy method
+    jest.fn();
+  }
+
+}
+
+describe('Clear Interactions Tests', () => {
+  const mockScene = {
+    add: {
+      sprite: jest.fn()
+    },
+    input: {
+      keyboard: {
+        createCursorKeys: jest.fn()
+      }
+    }
+  };
+
+  test('test 1', () => {
+    let uxscene = new UxScene();
+
+    const button1 = new MockButton(mockScene) as Button;
+    const button2 = new MockButton(mockScene) as Button;
+
+    uxscene.interactButtons.push(button1);
+    uxscene.interactButtons.push(button2);
+    
+    const spy1 = jest.spyOn(button1, 'destroy');
+    const spy2 = jest.spyOn(button2, 'destroy');
+
+    expect(uxscene.interactButtons.length).toEqual(2);
+    uxscene.clearInteractions();
+
+    expect(spy1).toHaveBeenCalled();
+    expect(spy2).toHaveBeenCalled();
+
+    expect(uxscene.interactButtons.length).toEqual(0);
+  });
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -3863,7 +3863,7 @@ snapshots:
   '@jest/console@29.7.0':
     dependencies:
       '@jest/types': 29.6.3
-      '@types/node': 22.10.6
+      '@types/node': 20.17.12
       chalk: 4.1.2
       jest-message-util: 29.7.0
       jest-util: 29.7.0
@@ -3983,7 +3983,7 @@ snapshots:
       '@jest/transform': 29.7.0
       '@jest/types': 29.6.3
       '@jridgewell/trace-mapping': 0.3.25
-      '@types/node': 22.10.6
+      '@types/node': 20.17.12
       chalk: 4.1.2
       collect-v8-coverage: 1.0.2
       exit: 0.1.2
@@ -4270,7 +4270,7 @@ snapshots:
 
   '@types/graceful-fs@4.1.9':
     dependencies:
-      '@types/node': 22.10.6
+      '@types/node': 20.17.12
 
   '@types/http-cache-semantics@4.0.4': {}
 
@@ -5805,7 +5805,7 @@ snapshots:
       '@jest/expect': 29.7.0
       '@jest/test-result': 29.7.0
       '@jest/types': 29.6.3
-      '@types/node': 22.10.6
+      '@types/node': 20.17.12
       chalk: 4.1.2
       co: 4.6.0
       dedent: 1.5.3
@@ -5997,7 +5997,7 @@ snapshots:
       '@jest/environment': 29.7.0
       '@jest/fake-timers': 29.7.0
       '@jest/types': 29.6.3
-      '@types/node': 22.10.6
+      '@types/node': 20.17.12
       jest-mock: 29.7.0
       jest-util: 29.7.0
 
@@ -6007,7 +6007,7 @@ snapshots:
     dependencies:
       '@jest/types': 29.6.3
       '@types/graceful-fs': 4.1.9
-      '@types/node': 22.10.6
+      '@types/node': 20.17.12
       anymatch: 3.1.3
       fb-watchman: 2.0.2
       graceful-fs: 4.2.11
@@ -6081,7 +6081,7 @@ snapshots:
       '@jest/test-result': 29.7.0
       '@jest/transform': 29.7.0
       '@jest/types': 29.6.3
-      '@types/node': 22.10.6
+      '@types/node': 20.17.12
       chalk: 4.1.2
       emittery: 0.13.1
       graceful-fs: 4.2.11
@@ -6109,7 +6109,7 @@ snapshots:
       '@jest/test-result': 29.7.0
       '@jest/transform': 29.7.0
       '@jest/types': 29.6.3
-      '@types/node': 22.10.6
+      '@types/node': 20.17.12
       chalk: 4.1.2
       cjs-module-lexer: 1.4.1
       collect-v8-coverage: 1.0.2
@@ -6174,7 +6174,7 @@ snapshots:
     dependencies:
       '@jest/test-result': 29.7.0
       '@jest/types': 29.6.3
-      '@types/node': 22.10.6
+      '@types/node': 20.17.12
       ansi-escapes: 4.3.2
       chalk: 4.1.2
       emittery: 0.13.1
@@ -6183,13 +6183,13 @@ snapshots:
 
   jest-worker@27.5.1:
     dependencies:
-      '@types/node': 22.10.6
+      '@types/node': 20.17.12
       merge-stream: 2.0.0
       supports-color: 8.1.1
 
   jest-worker@29.7.0:
     dependencies:
-      '@types/node': 22.10.6
+      '@types/node': 20.17.12
       jest-util: 29.7.0
       merge-stream: 2.0.0
       supports-color: 8.1.1


### PR DESCRIPTION
Changes: 
* addressing bug - https://github.com/sloalchemist/potions/issues/64
* added clearInteractions() function in UxScene.ts that is called in worldScene.ts in the gameOver function.
* unit tested the clearInteractions function.

Test Results: 
<img width="875" alt="Screenshot 2025-01-15 at 8 18 40 PM" src="https://github.com/user-attachments/assets/e53d13d9-42bd-49a2-8682-a393e9bc3a43" />
