### PR TITLE
Fix: Bug - Clicking on an unwalkable tile causes user to stop in the middle of their path

### DIFF
--- a/packages/common/src/pathFinder.ts
+++ b/packages/common/src/pathFinder.ts
@@ -243,6 +243,56 @@ export class PathFinder {
     return false;
   }
 
+  /**
+   * Finds the nearest walkable tile to the target coordinate.
+   * 
+   * The algorithm does a breadth-first search from the target coordinate, 
+   * checking all adjacent tiles in all 8 possible directions. If a walkable 
+   * tile is found, it is returned. If no walkable tile is found, an error is 
+   * thrown.
+   * 
+   * @param target - The target coordinate.
+   * 
+   * @returns The nearest walkable tile to the target coordinate.
+   * 
+   * @throws If no walkable tile is found.
+   */
+  private findNearestWalkableTile(target: Coord): Coord {
+    const directions = [
+      { x: 1, y: 0 },
+      { x: -1, y: 0 },
+      { x: 0, y: 1 },
+      { x: 0, y: -1 },
+      { x: 1, y: 1 },
+      { x: -1, y: -1 },
+      { x: 1, y: -1 },
+      { x: -1, y: 1 },
+    ];
+  
+    const queue: Coord[] = [target];
+    const visited: Set<string> = new Set();
+    visited.add(`${target.x},${target.y}`);
+  
+    while (queue.length > 0) {
+      const current = queue.shift()!;
+      if (this.isWalkable([], current.x, current.y)) {
+        return current;
+      }
+  
+      for (const direction of directions) {
+        const neighbor = { x: current.x + direction.x, y: current.y + direction.y };
+        const neighborKey = `${neighbor.x},${neighbor.y}`;
+  
+        if (!visited.has(neighborKey)) {
+          visited.add(neighborKey);
+          queue.push(neighbor);
+        }
+      }
+    }
+  
+    throw new Error("No walkable tile found");
+  }
+
   generatePath(
     unlocks: string[],
     start: Coord,
@@ -259,8 +309,7 @@ export class PathFinder {
     }
 
     if (!fuzzy && !this.isWalkable(unlocks, end.x, end.y)) {
-      // new Error(`End position (${JSON.stringify(end)}) is not walkable`);
-      return [];
+      end = this.findNearestWalkableTile(end);
     }
 
     const path = this.aStar(unlocks, start, end, fuzzy);

--- a/packages/common/src/pathFinder.ts
+++ b/packages/common/src/pathFinder.ts
@@ -247,7 +247,7 @@ export class PathFinder {
    * Finds the nearest walkable tile to the target coordinate.
    * 
    * The algorithm does a breadth-first search from the target coordinate, 
-   * checking all adjacent tiles in all 8 possible directions. If a walkable 
+   * checking all adjacent tiles in all 8 possible directions. If an walkable 
    * tile is found, it is returned. If no walkable tile is found, an error is 
    * thrown.
    * 
@@ -309,7 +309,12 @@ export class PathFinder {
     }
 
     if (!fuzzy && !this.isWalkable(unlocks, end.x, end.y)) {
-      end = this.findNearestWalkableTile(end);
+      try {
+        end = this.findNearestWalkableTile(end);
+      } catch {
+        // No walkable tile found
+        return [];
+      }
     }
 
     const path = this.aStar(unlocks, start, end, fuzzy);

--- a/packages/common/src/pathFinder.ts
+++ b/packages/common/src/pathFinder.ts
@@ -312,7 +312,7 @@ export class PathFinder {
       try {
         end = this.findNearestWalkableTile(end);
       } catch {
-        // No walkable tile found
+        // Return an empty path if no walkable tile is found
         return [];
       }
     }

--- a/packages/common/test/pathFinder.test.ts
+++ b/packages/common/test/pathFinder.test.ts
@@ -91,15 +91,6 @@ describe('PathFinder', () => {
     expect(path).toContainEqual(end);
   });
 
-  // FIX: This test is no longer needed since we want to walk to the closest walkable tile if the goal is not walkable
-  //
-  // test('generatePath should return an empty path if the goal is not walkable', () => {
-  //   const start = { x: 0, y: 0 };
-  //   const end = { x: 1, y: 1 }; // Blocked
-  //   const path = pathFinder.generatePath([], start, end, false);
-  //   expect(path).toEqual([]);
-  // });
-
   test('generatePath should not cut over unwalkable corners (#1)', () => {
     // check not cutting top left corner
     const start = { x: 0.75, y: 0 };

--- a/packages/common/test/pathFinder.test.ts
+++ b/packages/common/test/pathFinder.test.ts
@@ -3,6 +3,7 @@ import { PathFinder } from '../src/pathFinder';
 describe('PathFinder', () => {
   let pathFinder: PathFinder;
   let pathFinder2: PathFinder;
+  let pathFinder3: PathFinder;
 
   const tiles = [
     [0, 0, 0],
@@ -16,6 +17,12 @@ describe('PathFinder', () => {
     [0, 0, -1]
   ];
 
+  const tiles3 = [
+    [0, -1, -1],
+    [-1, -1, -1],
+    [-1, -1, -1]
+  ];
+
   const terrain_types = [
     { id: 0, name: 'Ground', walkable: true },
     { id: -1, name: 'Wall', walkable: false }
@@ -24,6 +31,7 @@ describe('PathFinder', () => {
   beforeEach(() => {
     pathFinder = new PathFinder(tiles, terrain_types);
     pathFinder2 = new PathFinder(tiles2, terrain_types);
+    pathFinder3 = new PathFinder(tiles3, terrain_types);
   });
 
   test('should initialize with correct walkable map', () => {
@@ -167,5 +175,12 @@ describe('PathFinder', () => {
     expect(path).not.toHaveLength(0);
     expect(path).toContainEqual(walkableEnd);
     expect(path).not.toContainEqual(end);
+  });
+
+  test('generatePath should return an empty path if no walkable tile is found', () => {
+    const start = { x: 0, y: 0 };
+    const end = { x: 1, y: 1 }; // unwalkable
+    const path = pathFinder3.generatePath([], start, end, false);
+    expect(path).toHaveLength(0);
   });
 });

--- a/packages/common/test/pathFinder.test.ts
+++ b/packages/common/test/pathFinder.test.ts
@@ -2,11 +2,18 @@ import { PathFinder } from '../src/pathFinder';
 
 describe('PathFinder', () => {
   let pathFinder: PathFinder;
+  let pathFinder2: PathFinder;
 
   const tiles = [
     [0, 0, 0],
     [0, -1, 0],
     [0, 0, 0]
+  ];
+
+  const tiles2 = [
+    [0, 0, -1],
+    [0, -1, -1],
+    [0, 0, -1]
   ];
 
   const terrain_types = [
@@ -16,6 +23,7 @@ describe('PathFinder', () => {
 
   beforeEach(() => {
     pathFinder = new PathFinder(tiles, terrain_types);
+    pathFinder2 = new PathFinder(tiles2, terrain_types);
   });
 
   test('should initialize with correct walkable map', () => {
@@ -75,12 +83,14 @@ describe('PathFinder', () => {
     expect(path).toContainEqual(end);
   });
 
-  test('generatePath should return an empty path if the goal is not walkable', () => {
-    const start = { x: 0, y: 0 };
-    const end = { x: 1, y: 1 }; // Blocked
-    const path = pathFinder.generatePath([], start, end, false);
-    expect(path).toEqual([]);
-  });
+  // FIX: This test is no longer needed since we want to walk to the closest walkable tile if the goal is not walkable
+  //
+  // test('generatePath should return an empty path if the goal is not walkable', () => {
+  //   const start = { x: 0, y: 0 };
+  //   const end = { x: 1, y: 1 }; // Blocked
+  //   const path = pathFinder.generatePath([], start, end, false);
+  //   expect(path).toEqual([]);
+  // });
 
   test('generatePath should not cut over unwalkable corners (#1)', () => {
     // check not cutting top left corner
@@ -135,5 +145,27 @@ describe('PathFinder', () => {
     expect(path).not.toHaveLength(0);
     expect(path).toContainEqual(cornerPoint);
     expect(path).toContainEqual(end);
+  });
+
+  // add test for function for finding closest walkable tile
+
+  test('generatePath should return path to closest walkable tile if the goal is not walkable (#1)', () => {
+    const start = { x: 1, y: 0 };
+    const end = { x: 0, y: 2 }; // unwalkable
+    const walkableEnd = { x: 0, y: 1 }; // closest walkable tile
+    const path = pathFinder2.generatePath([], start, end, false);
+    expect(path).not.toHaveLength(0);
+    expect(path).toContainEqual(walkableEnd);
+    expect(path).not.toContainEqual(end);
+  });
+
+  test('generatePath should return path to closest walkable tile if the goal is not walkable (#2)', () => {
+    const start = { x: 1, y: 0 };
+    const end = { x: 2, y: 2 }; // unwalkable
+    const walkableEnd = { x: 2, y: 1 }; // closest walkable tile
+    const path = pathFinder2.generatePath([], start, end, false);
+    expect(path).not.toHaveLength(0);
+    expect(path).toContainEqual(walkableEnd);
+    expect(path).not.toContainEqual(end);
   });
 });


### PR DESCRIPTION
## **Problem:**

In general, when trying to move to an unwalkable tile, the user does not move anywhere. So, the fix to this would be to get to the closest walkable location/tile to the point that they originally clicked.

Another issue that stems from this is that when the user is already moving along a path and then clicks on an unwalkable tile, the user character just stops in place (no matter where it is, even if in between tiles; the character simply freezes and feels awkward on the user side. So, we want to eliminate this by allowing the user to walk as close as they can to the unwalkable tile.

## **Solution:**

- Implemented a new function called findNearestWalkableTile() that performs a breadth-first search from the unwalkable end coordinate by checking all 8 of its adjacent tiles, and finds the first walkable tile. If no such tile can be found, then it throws an error
- generatePath() calls findNearestWalkableTile() to replace the end coordinate if it's unwalkable. If no walkable tile can be found, then an empty path is returned, which was the default behavior of the function prior to our modifications.

## **Tests:**

- Added 2 test cases in the pathFinder.test.ts file to test the behavior of generatePath(), ensuring that the user walks to the closest walkable tile if the original end point is unwalkable
- To test for coverage, we added another test case if there is no walkable tile the user could move to. The expected default behavior is that the user stays in place.

**Fixes** [#116 ](https://github.com/sloalchemist/potions/issues/116)
