### PR TITLE
fix: doors and gates have no healthbar

### DIFF
--- a/packages/client/src/sprite/sprite_item.ts
+++ b/packages/client/src/sprite/sprite_item.ts
@@ -34,7 +34,7 @@ export class SpriteItem extends Item {
       this.attributes[key] = item.attributes[key];
     }
 
-    if(this.itemType.layout_type === 'fence' || this.itemType.layout_type === 'wall' || this.itemType.layout_type === 'opens') {
+    if(this.maxHealth) {
       this.healthBar = scene.add.graphics();
       this.maxHealth = Number(this.attributes['health']);
     }

--- a/packages/client/src/sprite/sprite_item.ts
+++ b/packages/client/src/sprite/sprite_item.ts
@@ -34,7 +34,7 @@ export class SpriteItem extends Item {
       this.attributes[key] = item.attributes[key];
     }
 
-    if(this.itemType.layout_type === 'fence' || this.itemType.layout_type === 'wall') {
+    if(this.itemType.layout_type === 'fence' || this.itemType.layout_type === 'wall' || this.itemType.layout_type === 'opens') {
       this.healthBar = scene.add.graphics();
       this.maxHealth = Number(this.attributes['health']);
     }

--- a/packages/client/test/sprite/healthbar/itemHealthBar.test.ts
+++ b/packages/client/test/sprite/healthbar/itemHealthBar.test.ts
@@ -77,7 +77,7 @@ describe('Fence health bar updates with state', () => {
                 maxHealth: undefined as number | undefined,
                 intialize() {
                     // Copied From SpriteItem Constructor
-                    if (itemType.layoutType === 'fence' || itemType.layoutType === 'wall') {
+                    if (itemType.layoutType === 'fence' || itemType.layoutType === 'wall' || itemType.layoutType === 'opens') {
                         this.healthBar = scene.add.graphics();
                         this.maxHealth = this.attributes['health'];
                     }
@@ -101,6 +101,11 @@ describe('Fence health bar updates with state', () => {
         expect(fullHealthGate.healthBar).not.toBeDefined();
         fullHealthGate.updateHealthBar();
         expect(fullHealthGate.healthBar).not.toBeDefined();
+
+        const halfHealthOpenable = new SpriteItem(maxHealth, maxHealth / 2, mockScene, {layoutType: 'opens'});
+        expect(halfHealthOpenable.healthBar).toBeDefined();
+        halfHealthOpenable.updateHealthBar();
+        expect(halfHealthOpenable.healthBar).toBeDefined();
 
     });
 });

--- a/packages/client/test/sprite/healthbar/itemHealthBar.test.ts
+++ b/packages/client/test/sprite/healthbar/itemHealthBar.test.ts
@@ -77,7 +77,7 @@ describe('Fence health bar updates with state', () => {
                 maxHealth: undefined as number | undefined,
                 intialize() {
                     // Copied From SpriteItem Constructor
-                    if (itemType.layoutType === 'fence' || itemType.layoutType === 'wall' || itemType.layoutType === 'opens') {
+                    if (maxHealth) {
                         this.healthBar = scene.add.graphics();
                         this.maxHealth = this.attributes['health'];
                     }
@@ -92,20 +92,10 @@ describe('Fence health bar updates with state', () => {
         const mockScene = new (jest.requireMock('phaser').Scene)({ key: 'test' });
         const maxHealth = 100;
 
-        const halfHealthFence = new SpriteItem(maxHealth, maxHealth / 2, mockScene, {layoutType: 'fence'});
+        const halfHealthFence = new SpriteItem(maxHealth, maxHealth / 2, mockScene);
         expect(halfHealthFence.healthBar).toBeDefined();
         halfHealthFence.updateHealthBar();
         expect(halfHealthFence.healthBar).toBeDefined();
-    
-        const fullHealthGate = new SpriteItem(maxHealth, maxHealth, mockScene, {layoutType: 'gate'});
-        expect(fullHealthGate.healthBar).not.toBeDefined();
-        fullHealthGate.updateHealthBar();
-        expect(fullHealthGate.healthBar).not.toBeDefined();
-
-        const halfHealthOpenable = new SpriteItem(maxHealth, maxHealth / 2, mockScene, {layoutType: 'opens'});
-        expect(halfHealthOpenable.healthBar).toBeDefined();
-        halfHealthOpenable.updateHealthBar();
-        expect(halfHealthOpenable.healthBar).toBeDefined();
 
     });
 });


### PR DESCRIPTION
Group: Darren Hong, Andrew Mei

**Bug Description** (Issue #104): When smashing the gate fence or the door, the health bar will not show. 

**What Changed**: We adjusted the if statement in `sprite_item.ts` and added `layout_type === 'open'`, representing both the gate and the door, allowing the health bar to be present when the player presses the smash command.

**Why**: This addition of the health bars allows the player to know the progress of getting rid of the door and gate. This also removes confusion on whether or not the gate and the door can be broken. It makes showing health bars consistent since fences also have this feature.

Before:
<img width="454" alt="image" src="https://github.com/user-attachments/assets/9046cbf8-01db-46b5-b697-7667b5f835ec" />

After:
<img width="454" alt="image" src="https://github.com/user-attachments/assets/ff4b7fa4-0f14-4b90-a365-722ecbf61325" />
