### PR TITLE
Return to start/load game screen after death

### DIFF
--- a/packages/client/src/scenes/loadWorldScene.ts
+++ b/packages/client/src/scenes/loadWorldScene.ts
@@ -34,6 +34,15 @@ export class LoadWorldScene extends Phaser.Scene {
   paletteSwapper: PaletteSwapper = PaletteSwapper.getInstance();
   lastAnimationKey: string = '';
 
+  /* 
+    Reset lastAnimationKey to the empty string to ensure that in the update function below
+    the "if (this.lastAnimationKey === animationKey)" condition is not met.
+    This ensures this character rerenders on the screen after game over and restart.
+    */
+  init() {
+    this.lastAnimationKey = '';
+  }
+
   preload() {
     this.load.image('title', 'static/title.png');
     this.load.atlas(
@@ -42,6 +51,7 @@ export class LoadWorldScene extends Phaser.Scene {
       'static/global-atlas.json'
     );
   }
+
   create() {
     // Add background image
     const background = this.add.image(0, 0, 'title');
@@ -196,6 +206,12 @@ export class LoadWorldScene extends Phaser.Scene {
       }),
       frameRate: 5,
       repeat: -1
+    });
+
+    // Remove the animation from the animation manager when the scene is stopped
+    // so that on revive there is no warning for creation with a duplicate key.
+    this.events.once("shutdown", () => {
+      this.anims.remove(`test-idle`);
     });
 
     // Position the character sprite

--- a/packages/client/src/scenes/worldScene.ts
+++ b/packages/client/src/scenes/worldScene.ts
@@ -21,11 +21,13 @@ import {
   WorldDescription
 } from '../worldDescription';
 import { UxScene } from './uxScene';
+import { setGameState } from '../world/controller';
 
 export let world: World;
 let needsAnimationsLoaded: boolean = true;
 
 export const TILE_SIZE = 32;
+export const RESPAWN_DELAY = 3000;
 
 export class WorldScene extends Phaser.Scene {
   worldLayer!: Phaser.Tilemaps.TilemapLayer;
@@ -373,16 +375,16 @@ export class WorldScene extends Phaser.Scene {
         pointer.y >= cameraViewportY &&
         pointer.y <= cameraViewportY + cameraViewportHeight
       ) {
-          console.log(
-            'click',
-            pointer.worldX / TILE_SIZE,
-            pointer.worldY / TILE_SIZE
-          );
-    
-          publishPlayerPosition({
-            x: pointer.worldX / TILE_SIZE,
-            y: pointer.worldY / TILE_SIZE
-          });
+      console.log(
+        'click',
+        pointer.worldX / TILE_SIZE,
+        pointer.worldY / TILE_SIZE
+      );
+
+      publishPlayerPosition({
+        x: pointer.worldX / TILE_SIZE,
+        y: pointer.worldY / TILE_SIZE
+      });
         }
     });
 
@@ -457,4 +459,18 @@ export class WorldScene extends Phaser.Scene {
     text.setScrollFactor(0); // Make it stay static
     text.setDepth(100);
   }
+
+  /* Stop all scenes related to game play and go back to the LoadWordScene 
+     for character custmization and game restart.*/
+  resetToLoadWorldScene() {
+    this.time.delayedCall(RESPAWN_DELAY, () => {
+      setGameState('uninitialized');
+      this.scene.stop('PauseScene');
+      this.scene.stop('WorldScene');
+      this.scene.stop('UxScene');
+      this.scene.stop('FrameScene');
+      this.scene.start('LoadWorldScene');
+    });
+  }
+  
 }

--- a/packages/client/src/services/serverToBroadcast.ts
+++ b/packages/client/src/services/serverToBroadcast.ts
@@ -114,6 +114,7 @@ export function setupBroadcast(
         waitUntilFocused.then(() => {
           leaveWorld();
           scene.showGameOver();
+          scene.resetToLoadWorldScene()
         });
       }
     }


### PR DESCRIPTION
Group: Andrew Estrada, Ethan Handelman

**Bug Description**
After the player's health is reduced to zero causing death, the game-over screen appears but there is no way to respawn in-game without refreshing the page through the browser.

**Changes Made**
Created function resetToLoadWorldScene() which waits three seconds before stopping all scenes that are currently active and restarting the LoadWorldScene. This effectively returns the client to the start of the game.
Added RESPAWN_DELAY constant to set delay for start game scene to be shown (in ms)
`packages/client/src/scenes/worldScene.ts`

Added call to resetToLoadWorldScene() in handling of player death
`packages/client/src/services/serverToBroadcast.ts`

Added init() function to reset lastAnimationKey to blank, ensuring proper rendering of character on load screen
Added call to events to prevent duplicate key creation on revive
`packages/client/src/scenes/loadWorldScene.ts`

_Note: Not fit for unit tests as discussed, integration testing needed_