### PR TITLE
Refactor: Decouple Item and Physical Object

### DIFF
--- a/packages/client/src/world/controller.ts
+++ b/packages/client/src/world/controller.ts
@@ -138,7 +138,10 @@ interface Physical {
   itemType: ItemType;
   key: string;
   conditionMet: (interaction: ItemInteraction) => boolean;
-  attributes?: Record<string, any>;
+  attributes?: {
+    templateType?: string;
+    [key: string]: string | number | boolean | undefined;
+  };
   templateType?: string;
 }
 

--- a/packages/client/src/world/controller.ts
+++ b/packages/client/src/world/controller.ts
@@ -132,6 +132,7 @@ interface ItemInteraction {
   description: string;
 }
 
+// cast Item objects to Physical
 interface Physical {
   position: Coord | null;
   itemType: ItemType;


### PR DESCRIPTION
Physical was previously extending Item which still required Phaser elements, now should be completely separate and casts to it in the collisionListener

Has been tested in local... but should be tested even further