### PR TITLE
Bug Fix: Only 1 interaction when the player is on top of a non-walkable object

### DIFF
--- a/packages/client/src/world/controller.ts
+++ b/packages/client/src/world/controller.ts
@@ -253,7 +253,15 @@ export function getInteractablePhysicals(physicals: Item[], playerPos: Coord): I
   if (nearbyObjects.length > 1) {
     nearbyObjects = [getClosestPhysical(nearbyObjects, playerPos)];
   }
-  return [...onTopObjects, ...nearbyObjects, ...nearbyOpenableObjects];
+
+  // enforce unique items
+  let interactableObjects = [...onTopObjects, ...nearbyObjects, ...nearbyOpenableObjects];
+  interactableObjects = interactableObjects.filter(
+    (item, index, self) =>
+      index === self.findIndex((t) => t.key === item.key && t.position === item.position)
+  );
+
+  return interactableObjects;
 }
 
 function collisionListener(physicals: Item[]) {
@@ -261,10 +269,9 @@ function collisionListener(physicals: Item[]) {
   const playerPos = floor(player.position!);
   
   // retrieves a list of all of the nearby and on top of objects
-  const interactableObjects = getInteractablePhysicals(physicals, playerPos);
+  let interactableObjects = getInteractablePhysicals(physicals, playerPos);
   let interactions: Interactions[] = [];
 
-  
   let carriedItem = undefined
   // if player is carrying object, add its according interactions
   if (player.carrying) {

--- a/packages/client/test/items/uses/smashPartialWall.test.ts
+++ b/packages/client/test/items/uses/smashPartialWall.test.ts
@@ -1,4 +1,4 @@
-import { getInteractablePhysicals, getPhysicalInteractions } from "../../../src/world/controller";
+import { getInteractablePhysicals} from "../../../src/world/controller";
 import { Item } from "../../../src/world/item";
 import { World } from "../../../src/world/world";
 import { ItemType } from "../../../src/worldDescription";

--- a/packages/client/test/items/uses/smashPartialWall.test.ts
+++ b/packages/client/test/items/uses/smashPartialWall.test.ts
@@ -1,0 +1,69 @@
+import { getInteractablePhysicals, getPhysicalInteractions } from "../../../src/world/controller";
+import { Item } from "../../../src/world/item";
+import { World } from "../../../src/world/world";
+import { ItemType } from "../../../src/worldDescription";
+import { Coord } from '@rt-potion/common';
+
+describe('When on top of a non-walkable item, only one interaction is returned', () => {
+  let world: World | null = null;
+
+  beforeAll(() => {
+    world = new World();
+    world.load({
+      tiles: [
+        [0, 0, 0],
+        [0, 0, 0],
+        [0, 0, 0],
+      ],
+      terrain_types: [{ id: 0, name: 'Grass', walkable: true }],
+      item_types: [],
+      mob_types: [],
+    });
+    
+  });
+
+  test('On top of partial wall, only one interaction is returned', () => {
+    const partialWallType: ItemType = {
+        name: "Partial Wall",
+        type: "partial-wall",
+        carryable: false,
+        smashable: true,
+        walkable: false,
+        interactions: [],
+        attributes: [
+            {
+                "name": "health",
+                "value": 1
+            },
+            {
+                "name": "complete",
+                "value": 3
+            }
+        ],
+    };
+
+    // Instantiate the partial wall object  
+    const partialWall = new Item(world!, "partial-wall", { x: 1, y: 1 }, partialWallType)
+    const playerPos: Coord = { x: 1, y: 1 };
+
+    // Put partial wall into Item list form to be accepted as an input for getInteractablePhysicals
+    const physicals: Item[] = [partialWall];
+    
+    // Get interactable objects from the player position
+    const interactablePhysicals = getInteractablePhysicals(physicals, playerPos);
+
+    // Determine if the partial wall object appears as an interactable object
+    const partialWallExists = interactablePhysicals.some(
+        (item) => item.itemType.name === 'Partial Wall'
+      );
+
+    // There should only be one interactable object
+    expect(partialWallExists).toBe(true);
+    expect(interactablePhysicals.length).toBe(1);
+  });
+
+
+  afterAll(() => {
+    world = null;
+  });
+});


### PR DESCRIPTION
Previously when the player would place a partial wall(non-walkable object) it would register twice:

- once as a nearby object
- once as an object the player is on top

We now are enforcing that the list of objects that interactions are based on is unique so it will only prompt one interaction.