### PR TITLE
Bug Fix Cannot Walk Through Open Gates

### DIFF
--- a/packages/client/src/sprite/sprite_item.ts
+++ b/packages/client/src/sprite/sprite_item.ts
@@ -204,8 +204,10 @@ export class SpriteItem extends Item {
         if (nearbyMobs.some((mob) => mob.unlocks.includes(this.lock!))) {
           //console.log('Gate open');
           this.sprite.setFrame(`${this.type}-open`);
+          this.itemType.open = true;
         } else {
           this.sprite.setFrame(`${this.type}-closed`);
+          this.itemType.open = false;
         }
       }
     } else if (this.itemType.layout_type === 'fence') {

--- a/packages/client/src/world/item.ts
+++ b/packages/client/src/world/item.ts
@@ -31,6 +31,9 @@ export class Item extends Physical {
 
   isWalkable(unlocks: string[]): boolean {
     if (this.lock) {
+      if(this.itemType.layout_type == "opens" && this.itemType.open) {
+        return true;
+      }
       //console.log('checking if walkable', mob.unlocks, this.lock);
       return unlocks.includes(this.lock);
     }

--- a/packages/client/src/world/world.ts
+++ b/packages/client/src/world/world.ts
@@ -213,7 +213,7 @@ export class World {
       if (!item) {
         continue;
       }
-      if ((!item.itemType.walkable || item.lock) && item.position) {
+      if ((!item.itemType.walkable || (item.lock && !item.itemType.open)) && item.position) {
         this.pathFinder.setBlockingItem(
           item.position.x,
           item.position.y,

--- a/packages/client/src/worldDescription.ts
+++ b/packages/client/src/worldDescription.ts
@@ -51,6 +51,7 @@ export interface ItemType {
   show_price_at?: TextureLocation;
   show_template_at?: TextureLocation;
   attributes?: Attribute[];
+  open?: boolean;
 }
 
 export interface MobType {

--- a/packages/client/static/global.json
+++ b/packages/client/static/global.json
@@ -164,7 +164,8 @@
                 "value": 100
             }
         ],
-        "interactions": []
+        "interactions": [],
+        "open": false
     },
     {
         "name": "Door",

--- a/packages/client/test/tsconfig.json
+++ b/packages/client/test/tsconfig.json
@@ -2,7 +2,7 @@
   "extends": "../tsconfig.json",
   "compilerOptions": {
     "types": ["jest", "node"],
-    "rootDir": ".."
+    "rootDir": "../../../"
   },
   "include": [
     "**/*.ts",

--- a/packages/client/test/world/mob.test.ts
+++ b/packages/client/test/world/mob.test.ts
@@ -17,8 +17,7 @@ const mockWorld = {
   addMobToGrid: jest.fn(),
   getItemAt: jest.fn(),
   generatePath: jest.fn().mockReturnValue(TEST_NEW_PATH),
-  moveMob: jest.fn(),
-  addItemToGrid: jest.fn(),
+  moveMob: jest.fn()
 };
 
 const createTestMob = (): Mob => {

--- a/packages/client/test/world/mob.test.ts
+++ b/packages/client/test/world/mob.test.ts
@@ -1,0 +1,88 @@
+import { Mob } from '../../src/world/mob';
+import { World } from '../../src/world/world';
+import { Item } from '../../src/world/item';
+
+const TEST_UNWALKABLE_ITEM = { isWalkable: () => false } as unknown as Item;
+const TEST_WALKABLE_ITEM = { isWalkable: () => true } as unknown as Item;
+const TEST_OLD_PATH = [
+  { x: 1, y: 1 },
+  { x: 2, y: 2 }
+];
+const TEST_NEW_PATH = [
+  { x: 2, y: 2 },
+  { x: 3, y: 3 }
+];
+
+const mockWorld = {
+  addMobToGrid: jest.fn(),
+  getItemAt: jest.fn(),
+  generatePath: jest.fn().mockReturnValue(TEST_NEW_PATH),
+  moveMob: jest.fn(),
+  addItemToGrid: jest.fn(),
+};
+
+const createTestMob = (): Mob => {
+  const mob = new Mob(
+    mockWorld as unknown as World,
+    'test',
+    'test',
+    'test',
+    1,
+    { x: 0, y: 0 },
+    {}
+  );
+  mob.path = TEST_OLD_PATH;
+  return mob;
+};
+
+describe('Mob', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('should be created in world', () => {
+    const mob = createTestMob();
+
+    expect(mob).toBeDefined();
+    expect(mockWorld.addMobToGrid).toHaveBeenCalledWith(mob);
+  });
+
+  describe('tick', () => {
+    it('should recalculate path if next step has unwalkable item', () => {
+      mockWorld.getItemAt.mockReturnValue(TEST_UNWALKABLE_ITEM);
+
+      const mob = createTestMob();
+      mob.tick(mockWorld as unknown as World, 1);
+
+      expect(mockWorld.generatePath).toHaveBeenCalledWith(
+        mob.unlocks,
+        expect.any(Object),
+        TEST_OLD_PATH[TEST_OLD_PATH.length - 1]
+      );
+      // Need to do separate floating point comparison for mob position
+      expect(mockWorld.generatePath.mock.calls[0][1].x).toBeCloseTo(0);
+      expect(mockWorld.generatePath.mock.calls[0][1].y).toBeCloseTo(0);
+      expect(mob.path).toEqual(TEST_NEW_PATH);
+    });
+
+    it('should not recalculate path if next step has walkable item', () => {
+      mockWorld.getItemAt.mockReturnValue(TEST_WALKABLE_ITEM);
+
+      const mob = createTestMob();
+      mob.tick(mockWorld as unknown as World, 1);
+
+      expect(mockWorld.generatePath).not.toHaveBeenCalled();
+      expect(mob.path).toEqual(TEST_OLD_PATH);
+    });
+
+    it('should not recalculate path if next step has no item', () => {
+      mockWorld.getItemAt.mockReturnValue(undefined);
+
+      const mob = createTestMob();
+      mob.tick(mockWorld as unknown as World, 1);
+
+      expect(mockWorld.generatePath).not.toHaveBeenCalled();
+      expect(mob.path).toEqual(TEST_OLD_PATH);
+    });
+  });
+});

--- a/packages/client/test/world/pathing.test.ts
+++ b/packages/client/test/world/pathing.test.ts
@@ -12,7 +12,7 @@ const TEST_OLD_PATH = [
 ];
 const TEST_NEW_PATH = [
   { x: 2, y: 2 },
-  { x: 4, y: 4 }
+  { x: 3, y: 3 }
 ];
 
 const gateItemType: ItemType = {

--- a/packages/client/test/world/pathing.test.ts
+++ b/packages/client/test/world/pathing.test.ts
@@ -1,19 +1,7 @@
-import { Mob } from '../../src/world/mob';
 import { World } from '../../src/world/world';
 import { Item } from '../../src/world/item';
 import { ItemType } from "../../src/worldDescription";
-import { Coord } from "../../../common/src/coord"; 
-
-const TEST_UNWALKABLE_ITEM = { isWalkable: () => false } as unknown as Item;
-const TEST_WALKABLE_ITEM = { isWalkable: () => true } as unknown as Item;
-const TEST_OLD_PATH = [
-  { x: 1, y: 1 },
-  { x: 2, y: 2 }
-];
-const TEST_NEW_PATH = [
-  { x: 2, y: 2 },
-  { x: 3, y: 3 }
-];
+import { Coord } from "@rt-potion/common/src/coord"; 
 
 const gateItemType: ItemType = {
   name: "Gate",
@@ -33,128 +21,52 @@ const gateItemType: ItemType = {
   open: false
 };
 
-const mockWorld = {
-  addMobToGrid: jest.fn(),
-  getItemAt: jest.fn(),
-  generatePath: jest.fn().mockReturnValue(TEST_NEW_PATH),
-  moveMob: jest.fn(),
-  items : {} as Record<string, Item>,
-  addItemToGrid: jest.fn(),
-  pathFinder: {
-    clearBlockingItems: jest.fn(),
-    setBlockingItem: jest.fn(),
-    generatePath: jest.fn().mockReturnValue(TEST_NEW_PATH),
-  },
-};
-
-const createTestMob = (): Mob => {
-  const mob = new Mob(
-    mockWorld as unknown as World,
-    'test',
-    'test',
-    'test',
-    1,
-    { x: 0, y: 0 },
-    {}
-  );
-  mob.path = TEST_OLD_PATH;
-  return mob;
-};
-
-describe('Mob', () => {
-  beforeEach(() => {
-    jest.clearAllMocks();
-  });
-
-  it('should be created in world', () => {
-    const mob = createTestMob();
-
-    expect(mob).toBeDefined();
-    expect(mockWorld.addMobToGrid).toHaveBeenCalledWith(mob);
-  });
-
-  describe('tick', () => {
-    it('should recalculate path if next step has unwalkable item', () => {
-      mockWorld.getItemAt.mockReturnValue(TEST_UNWALKABLE_ITEM);
-
-      const mob = createTestMob();
-      mob.tick(mockWorld as unknown as World, 1);
-
-      expect(mockWorld.generatePath).toHaveBeenCalledWith(
-        mob.unlocks,
-        expect.any(Object),
-        TEST_OLD_PATH[TEST_OLD_PATH.length - 1]
-      );
-      // Need to do separate floating point comparison for mob position
-      expect(mockWorld.generatePath.mock.calls[0][1].x).toBeCloseTo(0);
-      expect(mockWorld.generatePath.mock.calls[0][1].y).toBeCloseTo(0);
-      expect(mob.path).toEqual(TEST_NEW_PATH);
-    });
-
-    it('should not recalculate path if next step has walkable item', () => {
-      mockWorld.getItemAt.mockReturnValue(TEST_WALKABLE_ITEM);
-
-      const mob = createTestMob();
-      mob.tick(mockWorld as unknown as World, 1);
-
-      expect(mockWorld.generatePath).not.toHaveBeenCalled();
-      expect(mob.path).toEqual(TEST_OLD_PATH);
-    });
-
-    it('should not recalculate path if next step has no item', () => {
-      mockWorld.getItemAt.mockReturnValue(undefined);
-
-      const mob = createTestMob();
-      mob.tick(mockWorld as unknown as World, 1);
-
-      expect(mockWorld.generatePath).not.toHaveBeenCalled();
-      expect(mob.path).toEqual(TEST_OLD_PATH);
-    });
-  });
-});
-
 describe("Items and Path Blocking", () => {
-  let world: World;
+    let world: World;
 
-  beforeAll(() => {
-    world = new World();
-    world.load({
-      tiles: [
+    beforeAll(() => {
+      world = new World();
+      let tiles = [
         [0, 0, 0],
         [0, 0, 0],
         [0, 0, 0],
-      ],
-      terrain_types: [{ id: 0, name: 'Grass', walkable: true }],
-      item_types: [],
-      mob_types: [],
+      ]
+      let terrain_types = [{ id: 0, name: 'Grass', walkable: true }]
+      world.load({
+        tiles: tiles,
+        terrain_types: terrain_types,
+        item_types: [gateItemType],
+        mob_types: [],
+      });
+    });
+  
+    test('Pathing Correct When Gate is Open/Closed', () => {
+      let start_coord: Coord = {x: 0, y: 0};
+      let gate_coord: Coord = {x: 1, y: 1};
+      let end_coord: Coord = {x: 2, y: 2};
+      let detour_coord: Coord = {x: 2, y:0};
+
+      const gate = new Item(world, "gate1", gate_coord, gateItemType);
+      gate.lock = "block";
+  
+      world.addItemToGrid(gate);
+      world.items["gate1"] = gate;
+
+      // create path attempt one -- closed gate
+      let path1 = world.generatePath([], start_coord, end_coord)
+      expect(path1).toEqual([detour_coord, end_coord])
+  
+      world.items["gate1"].itemType.open = true;
+  
+      // create path attempt two -- open gate
+      let path2 = world.generatePath([], start_coord, end_coord)
+      expect(path2).toEqual([end_coord])
+  
+      world.items["gate1"].itemType.open = false;
+  
+      // create path attempt three -- closed gate
+      let path3 = world.generatePath([], start_coord, end_coord)
+      expect(path3).toEqual([detour_coord, end_coord])
     });
   });
 
-  test('Pathing Correct When Gate is Open/Closed', () => {
-    let c1: Coord = {x: 2, y: 2};
-    let c2: Coord = {x: 4, y: 4};
-
-    const gate = new Item(world, "gate1", { x: 3, y: 3 }, gateItemType);
-    gate.lock = "lock";
-
-    world.addItemToGrid(gate);
-    world.items["gate1"] = gate;
-
-    jest.spyOn(world['pathFinder']!, "setBlockingItem")
-    
-    // create path attempt one -- closed gate
-    world.generatePath([], c1, c2)
-    expect(world['pathFinder']!.setBlockingItem).toHaveBeenCalledTimes(1);
-
-    gate.itemType.open = true;
-
-    // create path attempt two -- open gate
-    world.generatePath([], c1, c2)
-    expect(world['pathFinder']!.setBlockingItem).toHaveBeenCalledTimes(1);
-    gate.itemType.open = false;
-
-    // create path attempt three -- closed gate
-    world.generatePath([], c1, c2)
-    expect(world['pathFinder']!.setBlockingItem).toHaveBeenCalledTimes(2);
-  });
-});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -3863,7 +3863,7 @@ snapshots:
   '@jest/console@29.7.0':
     dependencies:
       '@jest/types': 29.6.3
-      '@types/node': 22.10.6
+      '@types/node': 20.17.12
       chalk: 4.1.2
       jest-message-util: 29.7.0
       jest-util: 29.7.0
@@ -3876,14 +3876,14 @@ snapshots:
       '@jest/test-result': 29.7.0
       '@jest/transform': 29.7.0
       '@jest/types': 29.6.3
-      '@types/node': 22.10.6
+      '@types/node': 20.17.12
       ansi-escapes: 4.3.2
       chalk: 4.1.2
       ci-info: 3.9.0
       exit: 0.1.2
       graceful-fs: 4.2.11
       jest-changed-files: 29.7.0
-      jest-config: 29.7.0(@types/node@22.10.6)(ts-node@10.9.2(@types/node@20.17.12)(typescript@5.7.3))
+      jest-config: 29.7.0(@types/node@20.17.12)(ts-node@10.9.2(@types/node@20.17.12)(typescript@5.7.3))
       jest-haste-map: 29.7.0
       jest-message-util: 29.7.0
       jest-regex-util: 29.6.3
@@ -3911,14 +3911,14 @@ snapshots:
       '@jest/test-result': 29.7.0
       '@jest/transform': 29.7.0
       '@jest/types': 29.6.3
-      '@types/node': 22.10.6
+      '@types/node': 20.17.12
       ansi-escapes: 4.3.2
       chalk: 4.1.2
       ci-info: 3.9.0
       exit: 0.1.2
       graceful-fs: 4.2.11
       jest-changed-files: 29.7.0
-      jest-config: 29.7.0(@types/node@22.10.6)(ts-node@10.9.2(@types/node@22.10.6)(typescript@5.7.3))
+      jest-config: 29.7.0(@types/node@20.17.12)(ts-node@10.9.2(@types/node@22.10.6)(typescript@5.7.3))
       jest-haste-map: 29.7.0
       jest-message-util: 29.7.0
       jest-regex-util: 29.6.3
@@ -3983,7 +3983,7 @@ snapshots:
       '@jest/transform': 29.7.0
       '@jest/types': 29.6.3
       '@jridgewell/trace-mapping': 0.3.25
-      '@types/node': 22.10.6
+      '@types/node': 20.17.12
       chalk: 4.1.2
       collect-v8-coverage: 1.0.2
       exit: 0.1.2
@@ -4270,7 +4270,7 @@ snapshots:
 
   '@types/graceful-fs@4.1.9':
     dependencies:
-      '@types/node': 22.10.6
+      '@types/node': 20.17.12
 
   '@types/http-cache-semantics@4.0.4': {}
 
@@ -5805,7 +5805,7 @@ snapshots:
       '@jest/expect': 29.7.0
       '@jest/test-result': 29.7.0
       '@jest/types': 29.6.3
-      '@types/node': 22.10.6
+      '@types/node': 20.17.12
       chalk: 4.1.2
       co: 4.6.0
       dedent: 1.5.3
@@ -5894,7 +5894,7 @@ snapshots:
       - babel-plugin-macros
       - supports-color
 
-  jest-config@29.7.0(@types/node@22.10.6)(ts-node@10.9.2(@types/node@20.17.12)(typescript@5.7.3)):
+  jest-config@29.7.0(@types/node@20.17.12)(ts-node@10.9.2(@types/node@22.10.6)(typescript@5.7.3)):
     dependencies:
       '@babel/core': 7.26.0
       '@jest/test-sequencer': 29.7.0
@@ -5919,8 +5919,8 @@ snapshots:
       slash: 3.0.0
       strip-json-comments: 3.1.1
     optionalDependencies:
-      '@types/node': 22.10.6
-      ts-node: 10.9.2(@types/node@20.17.12)(typescript@5.7.3)
+      '@types/node': 20.17.12
+      ts-node: 10.9.2(@types/node@22.10.6)(typescript@5.7.3)
     transitivePeerDependencies:
       - babel-plugin-macros
       - supports-color
@@ -5997,7 +5997,7 @@ snapshots:
       '@jest/environment': 29.7.0
       '@jest/fake-timers': 29.7.0
       '@jest/types': 29.6.3
-      '@types/node': 22.10.6
+      '@types/node': 20.17.12
       jest-mock: 29.7.0
       jest-util: 29.7.0
 
@@ -6007,7 +6007,7 @@ snapshots:
     dependencies:
       '@jest/types': 29.6.3
       '@types/graceful-fs': 4.1.9
-      '@types/node': 22.10.6
+      '@types/node': 20.17.12
       anymatch: 3.1.3
       fb-watchman: 2.0.2
       graceful-fs: 4.2.11
@@ -6081,7 +6081,7 @@ snapshots:
       '@jest/test-result': 29.7.0
       '@jest/transform': 29.7.0
       '@jest/types': 29.6.3
-      '@types/node': 22.10.6
+      '@types/node': 20.17.12
       chalk: 4.1.2
       emittery: 0.13.1
       graceful-fs: 4.2.11
@@ -6109,7 +6109,7 @@ snapshots:
       '@jest/test-result': 29.7.0
       '@jest/transform': 29.7.0
       '@jest/types': 29.6.3
-      '@types/node': 22.10.6
+      '@types/node': 20.17.12
       chalk: 4.1.2
       cjs-module-lexer: 1.4.1
       collect-v8-coverage: 1.0.2
@@ -6174,7 +6174,7 @@ snapshots:
     dependencies:
       '@jest/test-result': 29.7.0
       '@jest/types': 29.6.3
-      '@types/node': 22.10.6
+      '@types/node': 20.17.12
       ansi-escapes: 4.3.2
       chalk: 4.1.2
       emittery: 0.13.1
@@ -6183,13 +6183,13 @@ snapshots:
 
   jest-worker@27.5.1:
     dependencies:
-      '@types/node': 22.10.6
+      '@types/node': 20.17.12
       merge-stream: 2.0.0
       supports-color: 8.1.1
 
   jest-worker@29.7.0:
     dependencies:
-      '@types/node': 22.10.6
+      '@types/node': 20.17.12
       jest-util: 29.7.0
       merge-stream: 2.0.0
       supports-color: 8.1.1


### PR DESCRIPTION
Problem Statement:
Currently player cannot move through gate, even when it is open.

Solution Overview:
Added attribute to openable item type to check if item has been opened during pathing. Open gates shouldn't block pathing. 

Testing:
Created a new unit test and manually tested