### PR TITLE
fix: end of line linter issue on windows

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -2,5 +2,6 @@
   "semi": true,
   "trailingComma": "none",
   "singleQuote": true,
-  "printWidth": 80
+  "printWidth": 80,
+  "endOfLine": "auto"
 }


### PR DESCRIPTION
This fixes a linter issue on windows where it complains about carriage returns.