### PR TITLE
fix: players now able to give items to villagers

### DIFF
--- a/packages/server/src/community/community.ts
+++ b/packages/server/src/community/community.ts
@@ -70,7 +70,9 @@ export class Community {
           SELECT 
               community_1_id, community_2_id
           FROM alliances
-          WHERE alliances.community_1_id = :id_1 AND alliances.community_2_id = :id_2
+          WHERE 
+            (alliances.community_1_id = :id_1 AND alliances.community_2_id = :id_2) OR
+            (alliances.community_1_id = :id_2 AND alliances.community_2_id = :id_1)
       `
     ).get({ id_1: id_1, id_2: id_2 }) as { id_1: string; id_2: string };
 

--- a/packages/server/test/items/giveItemToVillager.test.ts
+++ b/packages/server/test/items/giveItemToVillager.test.ts
@@ -11,7 +11,7 @@ beforeEach(() => {
   commonSetup();
   const alchemistVil = Community.makeVillage('alchemists', 'Alchemists guild');
   const silVil = Community.makeVillage('silverclaw', 'Village of Silverclaw');
-  Community.makeAlliance(alchemistVil, silVil)
+  Community.makeAlliance(alchemistVil, silVil);
   mobFactory.loadTemplates(world.mobTypes);
 });
 

--- a/packages/server/test/items/giveItemToVillager.test.ts
+++ b/packages/server/test/items/giveItemToVillager.test.ts
@@ -10,7 +10,7 @@ import { Coord } from '@rt-potion/common';
 beforeEach(() => {
   commonSetup();
   const alchemistVil = Community.makeVillage('alchemists', 'Alchemists guild');
-  const silVil = Community.makeVillage('silverclaw', 'Village of the Silverclaw');
+  const silVil = Community.makeVillage('silverclaw', 'Village of Silverclaw');
   Community.makeAlliance(alchemistVil, silVil)
   mobFactory.loadTemplates(world.mobTypes);
 });

--- a/packages/server/test/items/giveItemToVillager.test.ts
+++ b/packages/server/test/items/giveItemToVillager.test.ts
@@ -1,0 +1,64 @@
+import { commonSetup, world, itemGenerator } from '../testSetup';
+import { mobFactory } from '../../src/mobs/mobFactory';
+import { Mob } from '../../src/mobs/mob';
+import { DB } from '../../src/services/database';
+import { Community } from '../../src/community/community';
+import { Carryable } from '../../src/items/carryable';
+import { Item } from '../../src/items/item';
+import { Coord } from '@rt-potion/common';
+
+beforeEach(() => {
+  commonSetup();
+  const alchemistVil = Community.makeVillage('alchemists', 'Alchemists guild');
+  const silVil = Community.makeVillage('silverclaw', 'Village of the Silverclaw');
+  // One of the four alliances in the game
+  Community.makeAlliance(alchemistVil, silVil)
+  mobFactory.loadTemplates(world.mobTypes);
+});
+
+describe('Item Giving Tests', () => {
+  describe('Player and Villager Mob Item Exchange', () => {
+    test('Should  allow item exchange between player and villager mob', () => {
+      const position1: Coord = { x: 0, y: 0 };
+      const position2: Coord = { x: 1, y: 1 };
+      const potionPosition: Coord = { x: 2, y: 2 };
+
+      // Create player mob
+      mobFactory.makeMob('player', position1, '1', 'testPlayer');
+      const playerMob = Mob.getMob('1');
+      expect(playerMob).toBeDefined();
+
+      // Create villager mob
+      mobFactory.makeMob('villager', position2, '3', 'testVillager');
+      const villagerMob = Mob.getMob('3');
+      expect(villagerMob).toBeDefined();
+
+      // Create potion
+      itemGenerator.createItem({ type: 'potion', position: potionPosition });
+      const potionID = Item.getItemIDAt(potionPosition);
+      expect(potionID).not.toBeNull();
+
+      const potion = Item.getItem(potionID!);
+      expect(potion).toBeDefined();
+
+      const carryablePotion = Carryable.fromItem(potion!);
+      expect(carryablePotion).toBeDefined();
+
+      // Player picks up the potion
+      carryablePotion!.pickup(playerMob!);
+      expect(playerMob!.carrying).toBeDefined();
+
+      // Attempt to give the potion to villager mob
+      const result = carryablePotion!.giveItem(playerMob!, villagerMob!);
+
+      // Assertions
+      expect(result).toBe(true); // Item should be passed
+      expect(playerMob!.carrying).toBeUndefined(); // Player should not have the potion
+      expect(villagerMob!.carrying).toBeDefined(); // Villager should  have the potion
+    });
+  });
+});
+
+afterEach(() => {
+  DB.close();
+});

--- a/packages/server/test/items/giveItemToVillager.test.ts
+++ b/packages/server/test/items/giveItemToVillager.test.ts
@@ -10,7 +10,9 @@ import { Coord } from '@rt-potion/common';
 beforeEach(() => {
   commonSetup();
   const alchemistVil = Community.makeVillage('alchemists', 'Alchemists guild');
-  const silVil = Community.makeVillage('silverclaw', 'Village of the Silverclaw');
+  const silVil = Community.makeVillage(
+    'silverclaw', 
+    'Village of the Silverclaw');
   // One of the four alliances in the game
   Community.makeAlliance(alchemistVil, silVil)
   mobFactory.loadTemplates(world.mobTypes);

--- a/packages/server/test/items/giveItemToVillager.test.ts
+++ b/packages/server/test/items/giveItemToVillager.test.ts
@@ -10,8 +10,7 @@ import { Coord } from '@rt-potion/common';
 beforeEach(() => {
   commonSetup();
   const alchemistVil = Community.makeVillage('alchemists', 'Alchemists guild');
-  const silVil = Community.makeVillage('silverclaw', 
-                                        'Village of the Silverclaw');
+  const silVil = Community.makeVillage('silverclaw', 'Village of the Silverclaw');
   // One of the four alliances in the game
   Community.makeAlliance(alchemistVil, silVil)
   mobFactory.loadTemplates(world.mobTypes);

--- a/packages/server/test/items/giveItemToVillager.test.ts
+++ b/packages/server/test/items/giveItemToVillager.test.ts
@@ -10,9 +10,7 @@ import { Coord } from '@rt-potion/common';
 beforeEach(() => {
   commonSetup();
   const alchemistVil = Community.makeVillage('alchemists', 'Alchemists guild');
-  const silVil = Community.makeVillage(
-    'silverclaw', 
-    'Village of the Silverclaw');
+  const silVil = Community.makeVillage('silverclaw', 'Village of Silverclaw');
   // One of the four alliances in the game
   Community.makeAlliance(alchemistVil, silVil)
   mobFactory.loadTemplates(world.mobTypes);

--- a/packages/server/test/items/giveItemToVillager.test.ts
+++ b/packages/server/test/items/giveItemToVillager.test.ts
@@ -10,8 +10,7 @@ import { Coord } from '@rt-potion/common';
 beforeEach(() => {
   commonSetup();
   const alchemistVil = Community.makeVillage('alchemists', 'Alchemists guild');
-  const silVil = Community.makeVillage('silverclaw', 'Village of Silverclaw');
-  // One of the four alliances in the game
+  const silVil = Community.makeVillage('silverclaw', 'Village of the Silverclaw');
   Community.makeAlliance(alchemistVil, silVil)
   mobFactory.loadTemplates(world.mobTypes);
 });

--- a/packages/server/test/items/giveItemToVillager.test.ts
+++ b/packages/server/test/items/giveItemToVillager.test.ts
@@ -10,7 +10,8 @@ import { Coord } from '@rt-potion/common';
 beforeEach(() => {
   commonSetup();
   const alchemistVil = Community.makeVillage('alchemists', 'Alchemists guild');
-  const silVil = Community.makeVillage('silverclaw', 'Village of the Silverclaw');
+  const silVil = Community.makeVillage('silverclaw', 
+                                        'Village of the Silverclaw');
   // One of the four alliances in the game
   Community.makeAlliance(alchemistVil, silVil)
   mobFactory.loadTemplates(world.mobTypes);

--- a/packages/server/test/testSetup.ts
+++ b/packages/server/test/testSetup.ts
@@ -324,10 +324,6 @@ export const commonSetup = (worldSize: number = 2) => {
         id: 'blobs',
         name: 'Blobs',
         description: 'Blobs who run around the map and cause havoc'
-      },
-      { id: "silverclaw", 
-        name: "Village of the Silverclaw", 
-        description: "The Silverclaw Tribe, descendants of the silver-souled, known for their resilience and independence." 
       }
     ],
     alliances: [],

--- a/packages/server/test/testSetup.ts
+++ b/packages/server/test/testSetup.ts
@@ -324,6 +324,10 @@ export const commonSetup = (worldSize: number = 2) => {
         id: 'blobs',
         name: 'Blobs',
         description: 'Blobs who run around the map and cause havoc'
+      },
+      { id: "silverclaw", 
+        name: "Village of the Silverclaw", 
+        description: "The Silverclaw Tribe, descendants of the silver-souled, known for their resilience and independence." 
       }
     ],
     alliances: [],


### PR DESCRIPTION
Fixed logic that prevented players and villagers from giving each other items despite having an alliance. Wrote a tests case and added logic to testSetup to support the test case.