### PR TITLE
fix(client): Increased the depth of health bars to the top

### DIFF
--- a/packages/client/src/sprite/sprite_item.ts
+++ b/packages/client/src/sprite/sprite_item.ts
@@ -35,7 +35,7 @@ export class SpriteItem extends Item {
     }
 
     if (this.maxHealth) {
-      this.healthBar = scene.add.graphics();
+      this.healthBar = scene.add.graphics().setDepth(101);
       this.maxHealth = Number(this.attributes['health']);
     }
 

--- a/packages/client/src/sprite/sprite_mob.ts
+++ b/packages/client/src/sprite/sprite_mob.ts
@@ -139,7 +139,7 @@ export class SpriteMob extends Mob {
     this.doingText.setDepth(1);
 
     // Initialize the health bar graphic
-    this.healthBar = scene.add.graphics();
+    this.healthBar = scene.add.graphics().setDepth(101);
     this.maxHealth = mob.maxHealth; // Set the max health to the mob's starting health
     if (!mob || !mob.attributes) {
       throw new Error(`Mob has no attributes ${mob} ${mob.attributes}`);


### PR DESCRIPTION
Changes
- Add drawing depth for sprite_items and sprite_mobs to the top
- Closes #172 