### PR TITLE
Feature: Create item and mob test templates

### DIFF
--- a/packages/server/test/template/itemTemplate.test.ts
+++ b/packages/server/test/template/itemTemplate.test.ts
@@ -1,0 +1,64 @@
+// copy of itemGiving.test.ts
+
+import { commonSetup, world, itemGenerator } from '../testSetup';
+import { mobFactory } from '../../src/mobs/mobFactory';
+import { Mob } from '../../src/mobs/mob';
+import { DB } from '../../src/services/database';
+import { Community } from '../../src/community/community';
+import { Carryable } from '../../src/items/carryable';
+import { Item } from '../../src/items/item';
+import { Coord } from '@rt-potion/common';
+
+beforeEach(() => {
+  commonSetup();
+  Community.makeVillage('alchemists', 'Alchemists guild');
+  Community.makeVillage('blobs', 'Blobs');
+  mobFactory.loadTemplates(world.mobTypes);
+});
+
+describe('Item Giving Tests', () => {
+  describe('Unallied Mobs Item Exchange', () => {
+    test('Should not allow item exchange between unallied mobs', () => {
+      const position1: Coord = { x: 0, y: 0 };
+      const position2: Coord = { x: 1, y: 1 };
+      const potionPosition: Coord = { x: 2, y: 2 };
+
+      // Create player mob
+      mobFactory.makeMob('player', position1, '1', 'testPlayer');
+      const playerMob = Mob.getMob('1');
+      expect(playerMob).toBeDefined();
+
+      // Create blob mob
+      mobFactory.makeMob('blob', position2, '2', 'testBlob');
+      const blobMob = Mob.getMob('2');
+      expect(blobMob).toBeDefined();
+
+      // Create potion
+      itemGenerator.createItem({ type: 'potion', position: potionPosition });
+      const potionID = Item.getItemIDAt(potionPosition);
+      expect(potionID).not.toBeNull();
+
+      const potion = Item.getItem(potionID!);
+      expect(potion).toBeDefined();
+
+      const carryablePotion = Carryable.fromItem(potion!);
+      expect(carryablePotion).toBeDefined();
+
+      // Player picks up the potion
+      carryablePotion!.pickup(playerMob!);
+      expect(playerMob!.carrying).toBeDefined();
+
+      // Attempt to give the potion to blob mob
+      const result = carryablePotion!.giveItem(playerMob!, blobMob!);
+
+      // Assertions
+      expect(result).toBe(false); // Item should not be passed
+      expect(playerMob!.carrying).toBeDefined(); // Player should still have the potion
+      expect(blobMob!.carrying).toBeUndefined(); // Blob should not have the potion
+    });
+  });
+});
+
+afterEach(() => {
+  DB.close();
+});

--- a/packages/server/test/template/mobTemplate.test.ts
+++ b/packages/server/test/template/mobTemplate.test.ts
@@ -1,16 +1,16 @@
 // Taken from mob.test.ts
 
-import { commonSetup, world } from "../testSetup";
-import { Mob } from "../../src/mobs/mob";
-import { mobFactory } from "../../src/mobs/mobFactory";
-import { Coord } from "@rt-potion/common";
-import { Community } from "../../src/community/community";
-import { DB } from "../../src/services/database";
+import { commonSetup, world } from '../testSetup';
+import { Mob } from '../../src/mobs/mob';
+import { mobFactory } from '../../src/mobs/mobFactory';
+import { Coord } from '@rt-potion/common';
+import { Community } from '../../src/community/community';
+import { DB } from '../../src/services/database';
 
 beforeEach(() => {
   commonSetup();
   Community.makeVillage('alchemists', 'Alchemists guild');
-  mobFactory.loadTemplates(world.mobTypes)
+  mobFactory.loadTemplates(world.mobTypes);
 });
 
 describe('Mob Tests', () => {
@@ -19,17 +19,17 @@ describe('Mob Tests', () => {
       const position: Coord = { x: 0, y: 0 };
       const mobId = 'testmob';
 
-      mobFactory.makeMob('player', position, mobId, 'testPlayer') // Create mob
+      mobFactory.makeMob('player', position, mobId, 'testPlayer'); // Create mob
       const testMob = Mob.getMob(mobId); // get mob
 
       expect(testMob).toBeDefined(); // do tests on the mob here...
     });
-  })
+  });
 
   describe('Mob Health Behavior', () => {
-    test("Health decreases correctly and does not drop below zero", () => {
+    test('Health decreases correctly and does not drop below zero', () => {
       const mobId = 'testmob-health';
-      const playerPosition: Coord = { x: 0, y: 0 }
+      const playerPosition: Coord = { x: 0, y: 0 };
 
       mobFactory.makeMob('player', playerPosition, mobId, 'testPlayer'); // make mob
       const testMob = Mob.getMob(mobId); // get mob
@@ -38,10 +38,9 @@ describe('Mob Tests', () => {
       testMob?.changeHealth(-50); // decrease mob health
       expect(testMob?.health).toBe(50);
 
-      //health 50 - 60 is < 0, so should be 0. 
+      //health 50 - 60 is < 0, so should be 0
       testMob?.changeHealth(-60);
       expect(testMob?.health).toBe(0);
-
     });
   });
 });

--- a/packages/server/test/template/mobTemplate.test.ts
+++ b/packages/server/test/template/mobTemplate.test.ts
@@ -1,0 +1,51 @@
+// Taken from mob.test.ts
+
+import { commonSetup, world } from "../testSetup";
+import { Mob } from "../../src/mobs/mob";
+import { mobFactory } from "../../src/mobs/mobFactory";
+import { Coord } from "@rt-potion/common";
+import { Community } from "../../src/community/community";
+import { DB } from "../../src/services/database";
+
+beforeEach(() => {
+  commonSetup();
+  Community.makeVillage('alchemists', 'Alchemists guild');
+  mobFactory.loadTemplates(world.mobTypes)
+});
+
+describe('Mob Tests', () => {
+  describe('Mob Initialization', () => {
+    test('Mob is created with correct attributes', () => {
+      const position: Coord = { x: 0, y: 0 };
+      const mobId = 'testmob';
+
+      mobFactory.makeMob('player', position, mobId, 'testPlayer') // Create mob
+      const testMob = Mob.getMob(mobId); // get mob
+
+      expect(testMob).toBeDefined(); // do tests on the mob here...
+    });
+  })
+
+  describe('Mob Health Behavior', () => {
+    test("Health decreases correctly and does not drop below zero", () => {
+      const mobId = 'testmob-health';
+      const playerPosition: Coord = { x: 0, y: 0 }
+
+      mobFactory.makeMob('player', playerPosition, mobId, 'testPlayer'); // make mob
+      const testMob = Mob.getMob(mobId); // get mob
+
+      // health init is 100. -50 should be 50 health.
+      testMob?.changeHealth(-50); // decrease mob health
+      expect(testMob?.health).toBe(50);
+
+      //health 50 - 60 is < 0, so should be 0. 
+      testMob?.changeHealth(-60);
+      expect(testMob?.health).toBe(0);
+
+    });
+  });
+});
+
+afterEach(() => {
+  DB.close();
+});


### PR DESCRIPTION
Linking issue #221  - Adding item and mob server test templates. This will prevent the need to create boiler plate in the future for server tests. 