### PR TITLE
[Feature] Cheat CLI for spawning mobs and items (Ryan Hu, Ryan Chan, Kyle Taschek)

### DIFF
--- a/packages/server/cli/cheatHandler.ts
+++ b/packages/server/cli/cheatHandler.ts
@@ -71,8 +71,10 @@ export const handleCliCommand = (input: string) => {
     let attributes: Record<string, string | number>;
     try {
       attributes = parseCoordinates(args);
-    } catch (e: any) {
-      console.log(e.message);
+    } catch (e) {
+      if (e instanceof Error) {
+        console.log(e.message);
+      }
       rl.prompt();
       return;
     }

--- a/packages/server/cli/cheatHandler.ts
+++ b/packages/server/cli/cheatHandler.ts
@@ -14,6 +14,7 @@ export const HELP_PROMPT = `Available commands:
 
 export let rl: readline.Interface;
 
+// initialize the CLI on the server
 export const initializeCli = () => {
   rl = readline.createInterface({
     input: process.stdin,
@@ -28,6 +29,7 @@ export const initializeCli = () => {
   rl.prompt();
 };
 
+// close the CLI
 export const closeCli = () => {
   if (rl) {
     rl.close();
@@ -35,15 +37,40 @@ export const closeCli = () => {
   }
 };
 
+// parse the coordinate arguments
+const parseCoordinates = (args: Array<string>) => {
+  const attributes: Record<string, string | number> = {};
+  args.forEach((arg) => {
+    if (!arg.includes(':')) {
+      throw new Error(
+        `Invalid coordinate format: ${arg}. Expected format is key:value.`
+      );
+    }
+    const [key, value] = arg.split(':');
+    if (key !== 'x' && key !== 'y') {
+      throw new Error(`Invalid key: ${key}. Expected keys are 'x' or 'y'.`);
+    }
+    if (isNaN(Number(value))) {
+      throw new Error(`Invalid value for ${key}: ${value}. Expected a number.`);
+    }
+    attributes[key] = Number(value);
+  });
+  return attributes;
+};
+
+// handler for all CLI commands
 export const handleCliCommand = (input: string) => {
   const [command, entityType, name, ...args] = input.trim().split(' ');
 
   if (command === 'spawn') {
-    const attributes: Record<string, string | number> = {};
-    args.forEach((arg) => {
-      const [key, value] = arg.split(':');
-      attributes[key] = isNaN(Number(value)) ? value : Number(value);
-    });
+    let attributes: Record<string, string | number>;
+    try {
+      attributes = parseCoordinates(args);
+    } catch (e: any) {
+      console.log(e.message);
+      rl.prompt();
+      return;
+    }
     const { x, y } = attributes;
 
     switch (entityType) {

--- a/packages/server/cli/cheatHandler.ts
+++ b/packages/server/cli/cheatHandler.ts
@@ -21,10 +21,6 @@ export const initializeCli = () => {
     prompt: 'potions-server> '
   });
 
-  rl.on('close', () => {
-    console.log('Exiting CLI. Potions server still running.');
-  });
-
   rl.on('line', handleCliCommand);
 
   console.log('Potions server running...');
@@ -35,6 +31,7 @@ export const initializeCli = () => {
 export const closeCli = () => {
   if (rl) {
     rl.close();
+    console.log('Exiting CLI. Potions server still running.');
   }
 };
 

--- a/packages/server/cli/cheatHandler.ts
+++ b/packages/server/cli/cheatHandler.ts
@@ -14,8 +14,12 @@ export const HELP_PROMPT = `Available commands:
 
 export let rl: readline.Interface;
 
-// initialize the CLI on the server
-export const initializeCli = () => {
+/**
+ * Initialize the CLI for the server.
+ *
+ * @returns {void}
+ */
+export function initializeCli() {
   rl = readline.createInterface({
     input: process.stdin,
     output: process.stdout,
@@ -27,18 +31,29 @@ export const initializeCli = () => {
   console.log('Potions server running...');
   console.log("Potions Cheat CLI enabled. Type 'help' for commands.");
   rl.prompt();
-};
+}
 
-// close the CLI
-export const closeCli = () => {
+/**
+ * Close the CLI.
+ *
+ * @returns {void}
+ */
+export function closeCli() {
   if (rl) {
     rl.close();
     console.log('Exiting CLI. Potions server still running.');
   }
-};
+}
 
-// parse the coordinate arguments
-const parseCoordinates = (args: Array<string>) => {
+/**
+ * Parse the coordinates for the spawn command.
+ *
+ * @param {Array<string>} args - The arguments for the spawn command.
+ * @returns {Record<string, string | number>} - The parsed coordinates.
+ */
+function parseCoordinates(
+  args: Array<string>
+): Record<string, string | number> {
   const attributes: Record<string, string | number> = {};
   if (args.length !== 2) {
     throw new Error(
@@ -61,10 +76,15 @@ const parseCoordinates = (args: Array<string>) => {
     attributes[key] = Number(value);
   });
   return attributes;
-};
+}
 
-// handler for all CLI commands
-export const handleCliCommand = (input: string) => {
+/**
+ * Handle the CLI commands
+ *
+ * @param input
+ * @returns {void}
+ */
+export function handleCliCommand(input: string) {
   const [command, entityType, name, ...args] = input.trim().split(' ');
 
   if (command === 'spawn') {
@@ -127,4 +147,4 @@ export const handleCliCommand = (input: string) => {
   }
 
   rl.prompt();
-};
+}

--- a/packages/server/cli/cheatHandler.ts
+++ b/packages/server/cli/cheatHandler.ts
@@ -40,6 +40,11 @@ export const closeCli = () => {
 // parse the coordinate arguments
 const parseCoordinates = (args: Array<string>) => {
   const attributes: Record<string, string | number> = {};
+  if (args.length !== 2) {
+    throw new Error(
+      `Invalid number of coordinate arguments. Expected 2, got ${args.length}.`
+    );
+  }
   args.forEach((arg) => {
     if (!arg.includes(':')) {
       throw new Error(

--- a/packages/server/cli/index.ts
+++ b/packages/server/cli/index.ts
@@ -1,0 +1,85 @@
+const readline = require('readline');
+import { mobFactory } from "../src/mobs/mobFactory";
+import globalData from "../data/global.json";
+
+// if glo
+// import { itemGenerator } from "../src/items/itemGenerator";
+
+// Setup `readline` for interactive CLI
+const rl = readline.createInterface({
+    input: process.stdin,
+    output: process.stdout,
+    prompt: "game-server> ",
+});
+
+const handleCliCommand = (input: string) => {
+    const [command, entityType, name, ...args] = input.trim().split(" ");
+    console.log(input);
+    if (input.trim() === "exit") {
+        rl.close();
+        return;
+    } else if (input.trim() === "help") {
+        console.log(`
+Available commands:
+- spawn mob [type] x:[x-coord] y:[y-coord]
+- spawn item [type] count:[number]
+- exit: Quit CLI
+    `);
+  } else if (command === "spawn") {
+    const attributes: Record<string, string | number> = {};
+    args.forEach(arg => {
+        const [key, value] = arg.split(":");
+        attributes[key] = isNaN(Number(value)) ? value : Number(value);
+    });
+    console.log("args", args)
+    console.log("name", name)
+    console.log("attributes", attributes)
+    console.log("entityType", entityType)
+
+    switch (entityType) {
+
+        case "mob":
+            if (["blob", "villager", "fighter"].includes(name)) {
+                const { x, y } = attributes;
+                mobFactory.makeMob(name, { x: x as number, y: y as number });
+                
+                console.log(`Spawned mob: ${name} at (${x}, ${y})`);
+            } else {
+                console.log("Unknown mob type.");
+            }
+            break;
+        case "item":
+            if (["items"].includes(name)) {
+                const { count } = attributes;
+                // add spawn item logic
+                console.log(`Spawned ${count}x ${entityType}`);
+            } else {
+                console.log("Unknown entity type.");
+            }
+            break;
+    }
+
+  } else {
+        console.log("Invalid command. Type 'help' for available commands.");
+  }
+
+    rl.prompt();
+}
+
+rl.on("close", () => {
+  console.log("Exiting CLI. Game server still running.");
+});
+
+
+export const startCli = () => {
+    console.log("Game server running...");
+    
+    console.log("Game Cheat CLI enabled. Type 'help' for commands.");
+    rl.prompt();
+
+    rl.on("line", handleCliCommand);
+
+    rl.on("close", () => {
+        console.log("Exiting CLI.");
+    });
+}

--- a/packages/server/cli/index.ts
+++ b/packages/server/cli/index.ts
@@ -1,85 +1,79 @@
-const readline = require('readline');
-import { mobFactory } from "../src/mobs/mobFactory";
-import globalData from "../data/global.json";
-
-// if glo
+import readline from 'readline';
+import { mobFactory } from '../src/mobs/mobFactory';
+import globalData from '../data/global.json';
 // import { itemGenerator } from "../src/items/itemGenerator";
+
+const itemTypes: Array<string> = globalData.item_types.map((item) => item.type);
+const mobTypes: Array<string> = globalData.mob_types.map((mob) => mob.type);
 
 // Setup `readline` for interactive CLI
 const rl = readline.createInterface({
-    input: process.stdin,
-    output: process.stdout,
-    prompt: "game-server> ",
+  input: process.stdin,
+  output: process.stdout,
+  prompt: 'game-server> '
 });
 
 const handleCliCommand = (input: string) => {
-    const [command, entityType, name, ...args] = input.trim().split(" ");
-    console.log(input);
-    if (input.trim() === "exit") {
-        rl.close();
-        return;
-    } else if (input.trim() === "help") {
-        console.log(`
+  const [command, entityType, name, ...args] = input.trim().split(' ');
+  console.log(input);
+  if (input.trim() === 'exit') {
+    rl.close();
+    return;
+  } else if (input.trim() === 'help') {
+    console.log(`
 Available commands:
 - spawn mob [type] x:[x-coord] y:[y-coord]
 - spawn item [type] count:[number]
 - exit: Quit CLI
     `);
-  } else if (command === "spawn") {
+  } else if (command === 'spawn') {
     const attributes: Record<string, string | number> = {};
-    args.forEach(arg => {
-        const [key, value] = arg.split(":");
-        attributes[key] = isNaN(Number(value)) ? value : Number(value);
+    args.forEach((arg) => {
+      const [key, value] = arg.split(':');
+      attributes[key] = isNaN(Number(value)) ? value : Number(value);
     });
-    console.log("args", args)
-    console.log("name", name)
-    console.log("attributes", attributes)
-    console.log("entityType", entityType)
+    console.log('args', args);
+    console.log('name', name);
+    console.log('attributes', attributes);
+    console.log('entityType', entityType);
 
     switch (entityType) {
+      case 'mob':
+        if (mobTypes.includes(name)) {
+          const { x, y } = attributes;
+          mobFactory.makeMob(name, { x: x as number, y: y as number });
 
-        case "mob":
-            if (["blob", "villager", "fighter"].includes(name)) {
-                const { x, y } = attributes;
-                mobFactory.makeMob(name, { x: x as number, y: y as number });
-                
-                console.log(`Spawned mob: ${name} at (${x}, ${y})`);
-            } else {
-                console.log("Unknown mob type.");
-            }
-            break;
-        case "item":
-            if (["items"].includes(name)) {
-                const { count } = attributes;
-                // add spawn item logic
-                console.log(`Spawned ${count}x ${entityType}`);
-            } else {
-                console.log("Unknown entity type.");
-            }
-            break;
+          console.log(`Spawned mob: ${name} at (${x}, ${y})`);
+        } else {
+          console.log('Unknown mob type.');
+        }
+        break;
+      case 'item':
+        if (itemTypes.includes(name)) {
+          const { count } = attributes;
+          // add spawn item logic
+          console.log(`Spawned ${count}x ${entityType}`);
+        } else {
+          console.log('Unknown entity type.');
+        }
+        break;
     }
-
   } else {
-        console.log("Invalid command. Type 'help' for available commands.");
+    console.log("Invalid command. Type 'help' for available commands.");
   }
 
-    rl.prompt();
-}
+  rl.prompt();
+};
 
-rl.on("close", () => {
-  console.log("Exiting CLI. Game server still running.");
+rl.on('close', () => {
+  console.log('Exiting CLI. Game server still running.');
 });
 
-
 export const startCli = () => {
-    console.log("Game server running...");
-    
-    console.log("Game Cheat CLI enabled. Type 'help' for commands.");
-    rl.prompt();
+  console.log('Game server running...');
 
-    rl.on("line", handleCliCommand);
+  console.log("Game Cheat CLI enabled. Type 'help' for commands.");
+  rl.prompt();
 
-    rl.on("close", () => {
-        console.log("Exiting CLI.");
-    });
-}
+  rl.on('line', handleCliCommand);
+};

--- a/packages/server/src/server.ts
+++ b/packages/server/src/server.ts
@@ -1,3 +1,7 @@
 import { worldTimer } from './services/setup';
+import { startCli } from '../cli/index';
 
 setInterval(worldTimer, 500);
+
+// start listening for CLI commands
+startCli();

--- a/packages/server/src/server.ts
+++ b/packages/server/src/server.ts
@@ -1,5 +1,5 @@
 import { worldTimer } from './services/setup';
-import { startCli } from '../cli/index';
+import { startCli } from '../cli/cheatHandler';
 
 setInterval(worldTimer, 500);
 

--- a/packages/server/src/server.ts
+++ b/packages/server/src/server.ts
@@ -1,7 +1,7 @@
 import { worldTimer } from './services/setup';
-import { startCli } from '../cli/cheatHandler';
+import { initializeCli } from '../cli/cheatHandler';
 
 setInterval(worldTimer, 500);
 
 // start listening for CLI commands
-startCli();
+initializeCli();

--- a/packages/server/test/cli/cheatHandler.test.ts
+++ b/packages/server/test/cli/cheatHandler.test.ts
@@ -37,12 +37,14 @@ afterEach(() => {
 
 describe('Cheat Handler Tests', () => {
   describe('handleCliCommand', () => {
-    it('exit command should close the CLI', () => {
+    it('exit command should close the CLI', async () => {
       const closeSpy = jest.spyOn(rl, 'close');
-      // const logSpy = jest.spyOn(console, 'log');
+      const logSpy = jest.spyOn(console, 'log');
       handleCliCommand('exit');
       expect(closeSpy).toHaveBeenCalled();
-      // expect(logSpy).toHaveBeenCalledWith('Exiting CLI. Potions server still running.');
+      expect(logSpy).toHaveBeenCalledWith(
+        'Exiting CLI. Potions server still running.'
+      );
     });
 
     it('help command should print available commands', () => {
@@ -54,20 +56,26 @@ describe('Cheat Handler Tests', () => {
     describe('Spawn Mob Tests', () => {
       it('should spawn mob with type blob', () => {
         const makeMobSpy = jest.spyOn(mobFactory, 'makeMob');
+        const logSpy = jest.spyOn(console, 'log');
         handleCliCommand('spawn mob blob x:0 y:0');
         expect(makeMobSpy).toHaveBeenCalledWith('blob', { x: 0, y: 0 });
+        expect(logSpy).toHaveBeenCalledWith('Spawned mob: blob at (0, 0)');
       });
 
       it('should spawn mob with type fighter', () => {
         const makeMobSpy = jest.spyOn(mobFactory, 'makeMob');
+        const logSpy = jest.spyOn(console, 'log');
         handleCliCommand('spawn mob fighter x:0 y:0');
         expect(makeMobSpy).toHaveBeenCalledWith('fighter', { x: 0, y: 0 });
+        expect(logSpy).toHaveBeenCalledWith('Spawned mob: fighter at (0, 0)');
       });
 
       it('should spawn mob with type player', () => {
         const makeMobSpy = jest.spyOn(mobFactory, 'makeMob');
+        const logSpy = jest.spyOn(console, 'log');
         handleCliCommand('spawn mob player x:0 y:0');
         expect(makeMobSpy).toHaveBeenCalledWith('player', { x: 0, y: 0 });
+        expect(logSpy).toHaveBeenCalledWith('Spawned mob: player at (0, 0)');
       });
 
       it('should spawn mob with type villager', () => {

--- a/packages/server/test/cli/cheatHandler.test.ts
+++ b/packages/server/test/cli/cheatHandler.test.ts
@@ -148,7 +148,7 @@ describe('Cheat Handler Tests', () => {
         );
       });
 
-      it('invalid coordinate format', () => {
+      it('should error on invalid coordinate format', () => {
         const logSpy = jest.spyOn(console, 'log');
         handleCliCommand('spawn mob blob x:0 y');
         expect(logSpy).toHaveBeenCalledWith(
@@ -156,7 +156,7 @@ describe('Cheat Handler Tests', () => {
         );
       });
 
-      it('invalid key', () => {
+      it('should error on invalid key', () => {
         const logSpy = jest.spyOn(console, 'log');
         handleCliCommand('spawn mob blob z:0 y:0');
         expect(logSpy).toHaveBeenCalledWith(
@@ -164,7 +164,7 @@ describe('Cheat Handler Tests', () => {
         );
       });
 
-      it('invalid value', () => {
+      it('should error on invalid value', () => {
         const logSpy = jest.spyOn(console, 'log');
         handleCliCommand('spawn mob blob x:zero y:0');
         expect(logSpy).toHaveBeenCalledWith(

--- a/packages/server/test/cli/cheatHandler.test.ts
+++ b/packages/server/test/cli/cheatHandler.test.ts
@@ -93,35 +93,37 @@ describe('Cheat Handler Tests', () => {
       });
     });
 
-    it('should spawn item with valid item type', () => {
-      const createItemSpy = jest.spyOn(itemGenerator, 'createItem');
-      handleCliCommand('spawn item potion x:0 y:0');
-      expect(createItemSpy).toHaveBeenCalledWith({
-        type: 'potion',
-        position: { x: 0, y: 0 },
-        attributes: {
-          health: 1
-        }
+    describe('Spawn Item Tests', () => {
+      it('should spawn item with valid item type', () => {
+        const createItemSpy = jest.spyOn(itemGenerator, 'createItem');
+        handleCliCommand('spawn item potion x:0 y:0');
+        expect(createItemSpy).toHaveBeenCalledWith({
+          type: 'potion',
+          position: { x: 0, y: 0 },
+          attributes: {
+            health: 1
+          }
+        });
+      });
+
+      it('should spawn item with valid item type and no attributes', () => {
+        const createItemSpy = jest.spyOn(itemGenerator, 'createItem');
+        handleCliCommand('spawn item blueberry-bush x:0 y:0');
+        expect(createItemSpy).toHaveBeenCalledWith({
+          type: 'blueberry-bush',
+          position: { x: 0, y: 0 },
+          attributes: {}
+        });
+      });
+
+      it('should spawn item with invalid item type', () => {
+        const logSpy = jest.spyOn(console, 'log');
+        handleCliCommand('spawn item invalidItem x:0 y:0');
+        expect(logSpy).toHaveBeenCalledWith('Unknown item type: invalidItem');
       });
     });
 
-    it('should spawn item with valid item type and no attributes', () => {
-      const createItemSpy = jest.spyOn(itemGenerator, 'createItem');
-      handleCliCommand('spawn item blueberry-bush x:0 y:0');
-      expect(createItemSpy).toHaveBeenCalledWith({
-        type: 'blueberry-bush',
-        position: { x: 0, y: 0 },
-        attributes: {}
-      });
-    });
-
-    it('should spawn item with invalid item type', () => {
-      const logSpy = jest.spyOn(console, 'log');
-      handleCliCommand('spawn item invalidItem x:0 y:0');
-      expect(logSpy).toHaveBeenCalledWith('Unknown item type: invalidItem');
-    });
-
-    it('should spawn invalid entity type', () => {
+    it('should not spawn invalid entity type', () => {
       const logSpy = jest.spyOn(console, 'log');
       handleCliCommand('spawn invalidType invalid x:0 y:0');
       expect(logSpy).toHaveBeenCalledWith(
@@ -135,6 +137,32 @@ describe('Cheat Handler Tests', () => {
       expect(logSpy).toHaveBeenCalledWith(
         "Invalid command. Type 'help' for available commands."
       );
+    });
+
+    describe('Coordinate Validation Tests', () => {
+      it('invalid coordinate format', () => {
+        const logSpy = jest.spyOn(console, 'log');
+        handleCliCommand('spawn mob blob x:0 y');
+        expect(logSpy).toHaveBeenCalledWith(
+          'Invalid coordinate format: y. Expected format is key:value.'
+        );
+      });
+
+      it('invalid key', () => {
+        const logSpy = jest.spyOn(console, 'log');
+        handleCliCommand('spawn mob blob z:0 y:0');
+        expect(logSpy).toHaveBeenCalledWith(
+          "Invalid key: z. Expected keys are 'x' or 'y'."
+        );
+      });
+
+      it('invalid value', () => {
+        const logSpy = jest.spyOn(console, 'log');
+        handleCliCommand('spawn mob blob x:zero y:0');
+        expect(logSpy).toHaveBeenCalledWith(
+          'Invalid value for x: zero. Expected a number.'
+        );
+      });
     });
   });
 });

--- a/packages/server/test/cli/cheatHandler.test.ts
+++ b/packages/server/test/cli/cheatHandler.test.ts
@@ -1,0 +1,132 @@
+import { commonSetup, world } from '../testSetup';
+import { mobFactory } from '../../src/mobs/mobFactory';
+import { itemGenerator } from '../../src/items/itemGenerator';
+import { DB } from '../../src/services/database';
+import {
+  initializeCli,
+  closeCli,
+  handleCliCommand,
+  rl,
+  HELP_PROMPT
+} from '../../cli/cheatHandler';
+import { Community } from '../../src/community/community';
+
+jest.mock('readline', () => ({
+  createInterface: jest.fn(() => ({
+    close: jest.fn(),
+    prompt: jest.fn(),
+    on: jest.fn()
+  }))
+}));
+
+beforeEach(() => {
+  commonSetup();
+  Community.makeVillage('alchemists', 'Alchemists guild');
+  Community.makeVillage('blobs', 'Blobby Town');
+  Community.makeVillage('fighters', 'Fighters guild');
+  Community.makeVillage('silverclaw', 'Village of Silverclaw');
+  mobFactory.loadTemplates(world.mobTypes);
+  initializeCli();
+});
+
+afterEach(() => {
+  closeCli();
+  jest.clearAllMocks();
+  DB.close();
+});
+
+describe('Cheat Handler Tests', () => {
+  describe('handleCliCommand', () => {
+    it('exit command should close the CLI', () => {
+      const closeSpy = jest.spyOn(rl, 'close');
+      // const logSpy = jest.spyOn(console, 'log');
+      handleCliCommand('exit');
+      expect(closeSpy).toHaveBeenCalled();
+      // expect(logSpy).toHaveBeenCalledWith('Exiting CLI. Potions server still running.');
+    });
+
+    it('help command should print available commands', () => {
+      const logSpy = jest.spyOn(console, 'log');
+      handleCliCommand('help');
+      expect(logSpy).toHaveBeenCalledWith(HELP_PROMPT);
+    });
+
+    describe('Spawn Mob Tests', () => {
+      it('should spawn mob with type blob', () => {
+        const makeMobSpy = jest.spyOn(mobFactory, 'makeMob');
+        handleCliCommand('spawn mob blob x:0 y:0');
+        expect(makeMobSpy).toHaveBeenCalledWith('blob', { x: 0, y: 0 });
+      });
+
+      it('should spawn mob with type fighter', () => {
+        const makeMobSpy = jest.spyOn(mobFactory, 'makeMob');
+        handleCliCommand('spawn mob fighter x:0 y:0');
+        expect(makeMobSpy).toHaveBeenCalledWith('fighter', { x: 0, y: 0 });
+      });
+
+      it('should spawn mob with type player', () => {
+        const makeMobSpy = jest.spyOn(mobFactory, 'makeMob');
+        handleCliCommand('spawn mob player x:0 y:0');
+        expect(makeMobSpy).toHaveBeenCalledWith('player', { x: 0, y: 0 });
+      });
+
+      it('should spawn mob with type villager', () => {
+        const makeMobSpy = jest.spyOn(mobFactory, 'makeMob');
+        const logSpy = jest.spyOn(console, 'log');
+        handleCliCommand('spawn mob villager x:0 y:0');
+        expect(makeMobSpy).toHaveBeenCalledWith('villager', { x: 0, y: 0 });
+        expect(logSpy).toHaveBeenCalledWith('Spawned mob: villager at (0, 0)');
+      });
+
+      it('shold spawn mob with invalid mob type', () => {
+        const logSpy = jest.spyOn(console, 'log');
+        handleCliCommand('spawn mob invalidMob x:0 y:0');
+        expect(logSpy).toHaveBeenCalledWith('Unknown mob type: invalidMob');
+      });
+    });
+
+    it('should spawn item with valid item type', () => {
+      const createItemSpy = jest.spyOn(itemGenerator, 'createItem');
+      handleCliCommand('spawn item potion x:0 y:0');
+      expect(createItemSpy).toHaveBeenCalledWith({
+        type: 'potion',
+        position: { x: 0, y: 0 },
+        attributes: {
+          health: 1
+        }
+      });
+    });
+
+    it('should spawn item with valid item type and no attributes', () => {
+      const createItemSpy = jest.spyOn(itemGenerator, 'createItem');
+      handleCliCommand('spawn item blueberry-bush x:0 y:0');
+      expect(createItemSpy).toHaveBeenCalledWith({
+        type: 'blueberry-bush',
+        position: { x: 0, y: 0 },
+        attributes: {}
+      });
+    });
+
+    it('should spawn item with invalid item type', () => {
+      const logSpy = jest.spyOn(console, 'log');
+      handleCliCommand('spawn item invalidItem x:0 y:0');
+      expect(logSpy).toHaveBeenCalledWith('Unknown item type: invalidItem');
+    });
+
+    it('should spawn invalid entity type', () => {
+      const logSpy = jest.spyOn(console, 'log');
+      handleCliCommand('spawn invalidType invalid x:0 y:0');
+      expect(logSpy).toHaveBeenCalledWith(
+        "Invalid entity type. Spawn either 'mob' or 'item'."
+      );
+    });
+
+    it('invalid command', () => {
+      const logSpy = jest.spyOn(console, 'log');
+      handleCliCommand('invalid command');
+      expect(logSpy).toHaveBeenCalledWith(
+        "Invalid command. Type 'help' for available commands."
+      );
+    });
+  });
+});

--- a/packages/server/test/cli/cheatHandler.test.ts
+++ b/packages/server/test/cli/cheatHandler.test.ts
@@ -140,6 +140,14 @@ describe('Cheat Handler Tests', () => {
     });
 
     describe('Coordinate Validation Tests', () => {
+      it('should error on more than 2 coordinates', () => {
+        const logSpy = jest.spyOn(console, 'log');
+        handleCliCommand('spawn mob blob x:0 y:0 z:0');
+        expect(logSpy).toHaveBeenCalledWith(
+          'Invalid number of coordinate arguments. Expected 2, got 3.'
+        );
+      });
+
       it('invalid coordinate format', () => {
         const logSpy = jest.spyOn(console, 'log');
         handleCliCommand('spawn mob blob x:0 y');

--- a/packages/server/test/testSetup.ts
+++ b/packages/server/test/testSetup.ts
@@ -305,6 +305,26 @@ export const commonSetup = (worldSize: number = 2) => {
         sleepy: 80,
         extroversion: 50,
         speaker: true
+      },
+      {
+        name: 'Fighter',
+        name_style: 'french-roman',
+        type: 'fighter',
+        description: 'A brave combatant, loyal to the fighters guild.',
+        speaker: true,
+        health: 100,
+        speed: 0.75,
+        attack: 100,
+        gold: 0,
+        community: 'fighters',
+        stubbornness: 20,
+        bravery: 60,
+        aggression: 80,
+        industriousness: 40,
+        adventurousness: 20,
+        gluttony: 10,
+        sleepy: 10,
+        extroversion: 50
       }
     ],
     communities: [
@@ -324,6 +344,11 @@ export const commonSetup = (worldSize: number = 2) => {
         id: 'blobs',
         name: 'Blobs',
         description: 'Blobs who run around the map and cause havoc'
+      },
+      {
+        id: 'fighters',
+        name: 'Fighters guild',
+        description: 'A small village of fighters.'
       }
     ],
     alliances: [],


### PR DESCRIPTION
Closes #187 

**Summary**

This PR adds command line options to allow devs to test in the game environment through the same terminal they started the server in. 
The current commands implemented are:
- `spawn mob [type] x:[x-coord] y:[y-coord]`
- `spawn item [type] x:[x-coord] y:[y-coord]`
- `help: display command usage`
- `exit: quit CLI`

The work done is a starting point for the larger, more robust cheat framework we plan to develop in future PRs, which includes a standalone package for the cheat interface with an expanded list of commands and options for the future when servers are hosted in the cloud. 

**Changes**

`/server/src/server.ts`
- add cheat command listener

`/server/cli/cheatHandler.ts`
- async readline listener
- argument parsing and handling
- add help command to list usage of commands
- add exit command to close the cli
- add spawn entity command (mob and item)

`/server/test/testSetup.ts`
- add fighter mob and fighter community to the test world description


**Testing**

Tested CLI commands in the game environment locally, spawning different mobs and items in different places.

`/server/test/cli/cheatHandler.test.ts`
- Unit tests for cheatHandler
    - test for help command output
    - test for exit command
    - test for spawn mob command
        - test all mob types (fighter, blob, player, villager)
        - test for invalid mob type
    - test for spawn item command
        - test valid items with and without attributes
        - test for invalid item type
    - test invalid coordinates in spawn commands
    - test for invalid number of coordinate arguments in spawn commands
- 100% Branch and statement coverage

