### PR TITLE
248 annotate converse package with jsdoc

### DIFF
--- a/packages/converse/src/library/converse.ts
+++ b/packages/converse/src/library/converse.ts
@@ -5,10 +5,18 @@ import { constructGraph } from './knowledge_graph/people/graphable';
 import { Person } from './knowledge_graph/people/person';
 import { Region } from './knowledge_graph/people/region';
 
+/**
+ * Adds a person to the knowledge graph.
+ * @param {Person} person - The person to add.
+ */
 export function addPerson(person: Person): void {
   addGraph(constructGraph([person]));
 }
 
+/**
+ * Adds a player to the database.
+ * @param {string} id - The ID of the player.
+ */
 export function addPlayer(id: string): void {
   DB.prepare(
     `
@@ -18,14 +26,27 @@ export function addPlayer(id: string): void {
   ).run({ id });
 }
 
+/**
+ * Initializes an in-memory test knowledge database.
+ */
 export function intializeTestKnowledgeDB(): void {
   initializeInMemoryDatabase();
 }
 
+/**
+ * Initializes the knowledge database from a file.
+ * @param {string} dbPath - The path to the database file.
+ * @param {boolean} rebuild - Whether to rebuild the database if it already exists.
+ */
 export function initializeKnowledgeDB(dbPath: string, rebuild: boolean): void {
   initializeDatabase(dbPath, rebuild);
 }
 
+/**
+ * Finds a community by name.
+ * @param {string} name - The name of the community.
+ * @returns {Community | undefined} The community if found, otherwise undefined.
+ */
 export function findCommunity(name: string): Community | undefined {
   const communityData = DB.prepare(
     `

--- a/packages/converse/src/library/converse.ts
+++ b/packages/converse/src/library/converse.ts
@@ -7,7 +7,8 @@ import { Region } from './knowledge_graph/people/region';
 
 /**
  * Adds a person to the knowledge graph.
- * @param {Person} person - The person to add.
+ *
+ * @param person - The person to add.
  */
 export function addPerson(person: Person): void {
   addGraph(constructGraph([person]));
@@ -15,7 +16,8 @@ export function addPerson(person: Person): void {
 
 /**
  * Adds a player to the database.
- * @param {string} id - The ID of the player.
+ *
+ * @param id - The ID of the player.
  */
 export function addPlayer(id: string): void {
   DB.prepare(
@@ -35,8 +37,9 @@ export function intializeTestKnowledgeDB(): void {
 
 /**
  * Initializes the knowledge database from a file.
- * @param {string} dbPath - The path to the database file.
- * @param {boolean} rebuild - Whether to rebuild the database if it already exists.
+ *
+ * @param dbPath - The path to the database file.
+ * @param rebuild - Whether to rebuild the database if it already exists.
  */
 export function initializeKnowledgeDB(dbPath: string, rebuild: boolean): void {
   initializeDatabase(dbPath, rebuild);
@@ -44,8 +47,9 @@ export function initializeKnowledgeDB(dbPath: string, rebuild: boolean): void {
 
 /**
  * Finds a community by name.
- * @param {string} name - The name of the community.
- * @returns {Community | undefined} The community if found, otherwise undefined.
+ *
+ * @param name - The name of the community.
+ * @returns The community if found, otherwise undefined.
  */
 export function findCommunity(name: string): Community | undefined {
   const communityData = DB.prepare(

--- a/packages/converse/src/library/database.ts
+++ b/packages/converse/src/library/database.ts
@@ -18,8 +18,9 @@ export function initializeInMemoryDatabase() {
 
 /**
  * Initializes an SQLite database from a file.
- * @param {string} dbPath - The path to the database file.
- * @param {boolean} [rebuild=false] - Whether to rebuild the database if it already exists.
+ *
+ * @param dbPath - The path to the database file.
+ * @param rebuild - Whether to rebuild the database if it already exists.
  */
 export function initializeDatabase(dbPath: string, rebuild: boolean = false) {
   const absolutePath = path.resolve(dbPath);

--- a/packages/converse/src/library/database.ts
+++ b/packages/converse/src/library/database.ts
@@ -9,10 +9,18 @@ dotenv.config();
 
 let DB: Database;
 
+/**
+ * Initializes an instance of the SQLite database.
+ */
 export function initializeInMemoryDatabase() {
   DB = new DatabaseConstructor(':memory:');
 }
 
+/**
+ * Initializes an SQLite database from a file.
+ * @param {string} dbPath - The path to the database file.
+ * @param {boolean} [rebuild=false] - Whether to rebuild the database if it already exists.
+ */
 export function initializeDatabase(dbPath: string, rebuild: boolean = false) {
   const absolutePath = path.resolve(dbPath);
 
@@ -26,8 +34,10 @@ export function initializeDatabase(dbPath: string, rebuild: boolean = false) {
   DB = new DatabaseConstructor(absolutePath);
   DB.pragma('journal_mode = WAL');
 
-  // Close the database on process exit
-  process.on('exit', () => DB.close());
+  // Close the database connection
+  process.on('exit', () => {
+    DB.close();
+  });
 }
 
 // Export the initialized database

--- a/packages/converse/src/library/knowledge_graph/belief.ts
+++ b/packages/converse/src/library/knowledge_graph/belief.ts
@@ -1,5 +1,8 @@
 import { Noun } from './noun';
 
+/**
+ * Represents a belief in the knowledge graph.
+ */
 export interface Belief {
   id?: string;
   subject: Noun;

--- a/packages/converse/src/library/knowledge_graph/buildDB.ts
+++ b/packages/converse/src/library/knowledge_graph/buildDB.ts
@@ -148,6 +148,10 @@ CREATE VIEW noun_knowledge AS
 
 `;
 
+/**
+ * Creates the database schema, and inserts all the concept hierarchies from
+ * the code into the database.
+ */
 function buildSQL(): void {
   // Execute the schema from the external file
   DB.exec(schema);
@@ -188,6 +192,55 @@ function buildSQL(): void {
   }
 }
 
+  /**
+   * Add a knowledge graph to the database
+   *
+   * @param graph - the knowledge graph to add
+   *
+   * This function adds a knowledge graph to the database. It is a low-level
+   * function that simply inserts into the database without any additional
+   * processing. It does not perform any validation or error checking.
+   *
+   * @example
+   * addGraph({
+   *   concepts: [],
+   *   nouns: [
+   *     { id: '1', name: 'Alice', type: 'person' },
+   *     { id: '2', name: 'Bob', type: 'person' },
+   *     { id: '3', name: 'Carrot', type: 'item' }
+   *   ],
+   *   beliefs: [
+   *     {
+   *       subject: { id: '1' },
+   *       related_to: { id: '2' },
+   *       concept: { id: 'Likes' },
+   *       name: 'Alice likes Bob',
+   *       description: 'Alice likes Bob',
+   *       trust: 0.5
+   *     },
+   *     {
+   *       subject: { id: '2' },
+   *       related_to: { id: '3' },
+   *       concept: { id: 'Desires' },
+   *       name: 'Bob desires Carrot',
+   *       description: 'Bob desires Carrot',
+   *       trust: 0.5
+   *     }
+   *   ],
+   *   desires: [
+   *     {
+   *       person: { id: '1' },
+   *       item: { id: '3' },
+   *       benefit: 'like'
+   *     },
+   *     {
+   *       person: { id: '2' },
+   *       item: { id: '3' },
+   *       benefit: 'like'
+   *     }
+   *   ]
+   * });
+   */
 export function addGraph(graph: KnowledgeGraph) {
   const insertNoun = DB.prepare(`
     INSERT OR IGNORE INTO nouns (id, name, type)
@@ -259,6 +312,16 @@ export function addGraph(graph: KnowledgeGraph) {
   }
 }
 
+/**
+ * @description
+ * Build a knowledge graph database from the given graph and create a
+ * database file at the default location.
+ *
+ * @param {KnowledgeGraph} graph The knowledge graph to build into the database.
+ *
+ * @see {@link module:converse/library/knowledge_graph/buildDB~addGraph|addGraph}
+ * @see {@link module:converse/library/knowledge_graph/buildDB~buildSQL|buildSQL}
+ */
 export function buildGraph(graph: KnowledgeGraph) {
   // Delete the database file if it already exists
   buildSQL();

--- a/packages/converse/src/library/knowledge_graph/buildDB.ts
+++ b/packages/converse/src/library/knowledge_graph/buildDB.ts
@@ -192,55 +192,55 @@ function buildSQL(): void {
   }
 }
 
-  /**
-   * Add a knowledge graph to the database
-   *
-   * @param graph - the knowledge graph to add
-   *
-   * This function adds a knowledge graph to the database. It is a low-level
-   * function that simply inserts into the database without any additional
-   * processing. It does not perform any validation or error checking.
-   *
-   * @example
-   * addGraph({
-   *   concepts: [],
-   *   nouns: [
-   *     { id: '1', name: 'Alice', type: 'person' },
-   *     { id: '2', name: 'Bob', type: 'person' },
-   *     { id: '3', name: 'Carrot', type: 'item' }
-   *   ],
-   *   beliefs: [
-   *     {
-   *       subject: { id: '1' },
-   *       related_to: { id: '2' },
-   *       concept: { id: 'Likes' },
-   *       name: 'Alice likes Bob',
-   *       description: 'Alice likes Bob',
-   *       trust: 0.5
-   *     },
-   *     {
-   *       subject: { id: '2' },
-   *       related_to: { id: '3' },
-   *       concept: { id: 'Desires' },
-   *       name: 'Bob desires Carrot',
-   *       description: 'Bob desires Carrot',
-   *       trust: 0.5
-   *     }
-   *   ],
-   *   desires: [
-   *     {
-   *       person: { id: '1' },
-   *       item: { id: '3' },
-   *       benefit: 'like'
-   *     },
-   *     {
-   *       person: { id: '2' },
-   *       item: { id: '3' },
-   *       benefit: 'like'
-   *     }
-   *   ]
-   * });
-   */
+/**
+ * Add a knowledge graph to the database
+ *
+ * @param graph - the knowledge graph to add
+ *
+ * This function adds a knowledge graph to the database. It is a low-level
+ * function that simply inserts into the database without any additional
+ * processing. It does not perform any validation or error checking.
+ *
+ * @example
+ * addGraph({
+ *   concepts: [],
+ *   nouns: [
+ *     { id: '1', name: 'Alice', type: 'person' },
+ *     { id: '2', name: 'Bob', type: 'person' },
+ *     { id: '3', name: 'Carrot', type: 'item' }
+ *   ],
+ *   beliefs: [
+ *     {
+ *       subject: { id: '1' },
+ *       related_to: { id: '2' },
+ *       concept: { id: 'Likes' },
+ *       name: 'Alice likes Bob',
+ *       description: 'Alice likes Bob',
+ *       trust: 0.5
+ *     },
+ *     {
+ *       subject: { id: '2' },
+ *       related_to: { id: '3' },
+ *       concept: { id: 'Desires' },
+ *       name: 'Bob desires Carrot',
+ *       description: 'Bob desires Carrot',
+ *       trust: 0.5
+ *     }
+ *   ],
+ *   desires: [
+ *     {
+ *       person: { id: '1' },
+ *       item: { id: '3' },
+ *       benefit: 'like'
+ *     },
+ *     {
+ *       person: { id: '2' },
+ *       item: { id: '3' },
+ *       benefit: 'like'
+ *     }
+ *   ]
+ * });
+ */
 export function addGraph(graph: KnowledgeGraph) {
   const insertNoun = DB.prepare(`
     INSERT OR IGNORE INTO nouns (id, name, type)

--- a/packages/converse/src/library/knowledge_graph/concepts/communities.ts
+++ b/packages/converse/src/library/knowledge_graph/concepts/communities.ts
@@ -1,6 +1,12 @@
 import { Concept, ConceptHierarchy } from './concept';
 
 export class Communities implements ConceptHierarchy {
+  /**
+   * Retrieves concepts related to communities.
+   *
+   * @returns An array of community-related concepts, including options such as
+   *          village, town, city, tribe, and guild.
+   */
   getConcepts(): Concept[] {
     const topLevelConcept = {
       id: 'community',

--- a/packages/converse/src/library/knowledge_graph/concepts/communities.ts
+++ b/packages/converse/src/library/knowledge_graph/concepts/communities.ts
@@ -1,5 +1,8 @@
 import { Concept, ConceptHierarchy } from './concept';
 
+/**
+ * Represents a hierarchy of community-related concepts.
+ */
 export class Communities implements ConceptHierarchy {
   /**
    * Retrieves concepts related to communities.

--- a/packages/converse/src/library/knowledge_graph/concepts/concept.ts
+++ b/packages/converse/src/library/knowledge_graph/concepts/concept.ts
@@ -1,3 +1,6 @@
+/**
+ * Represents a concept in the knowledge graph.
+ */
 export interface Concept {
   id: string;
   name: string;
@@ -5,6 +8,9 @@ export interface Concept {
   parent_concept?: Concept;
 }
 
+/**
+ * Represents a hierarchy of concepts.
+ */
 export interface ConceptHierarchy {
   getConcepts(): Concept[];
 }

--- a/packages/converse/src/library/knowledge_graph/concepts/description.ts
+++ b/packages/converse/src/library/knowledge_graph/concepts/description.ts
@@ -1,5 +1,8 @@
 import { Concept, ConceptHierarchy } from './concept';
 
+/**
+ * Represents a hierarchy of description-related concepts.
+ */
 export class Description implements ConceptHierarchy {
   /**
    * Gets concepts related to the description of a subject.

--- a/packages/converse/src/library/knowledge_graph/concepts/description.ts
+++ b/packages/converse/src/library/knowledge_graph/concepts/description.ts
@@ -1,6 +1,11 @@
 import { Concept, ConceptHierarchy } from './concept';
 
 export class Description implements ConceptHierarchy {
+  /**
+   * Gets concepts related to the description of a subject.
+   *
+   * @returns A list of description-related concepts.
+   */
   getConcepts(): Concept[] {
     const topLevelConcept = {
       id: 'description',

--- a/packages/converse/src/library/knowledge_graph/concepts/desires.ts
+++ b/packages/converse/src/library/knowledge_graph/concepts/desires.ts
@@ -1,5 +1,8 @@
 import { Concept, ConceptHierarchy } from './concept';
 
+/**
+ * Represents a hierarchy of desire-related concepts.
+ */
 export class Desires implements ConceptHierarchy {
   /**
    * Retrieves concepts related to the desires of a subject.

--- a/packages/converse/src/library/knowledge_graph/concepts/desires.ts
+++ b/packages/converse/src/library/knowledge_graph/concepts/desires.ts
@@ -1,6 +1,12 @@
 import { Concept, ConceptHierarchy } from './concept';
 
 export class Desires implements ConceptHierarchy {
+  /**
+   * Retrieves concepts related to the desires of a subject.
+   *
+   * @returns An array of desire-related concepts, including options such as
+   *          like and dislike.
+   */
   getConcepts(): Concept[] {
     const topLevelConcept = {
       id: 'desire',

--- a/packages/converse/src/library/knowledge_graph/concepts/events.ts
+++ b/packages/converse/src/library/knowledge_graph/concepts/events.ts
@@ -1,6 +1,12 @@
 import { Concept, ConceptHierarchy } from './concept';
 
 export class Events implements ConceptHierarchy {
+  /**
+   * Gets concepts related to the events of a subject.
+   * 
+   * @returns A list of event-related concepts, including options such as
+   *          festival, battle, harvest, hunt, marriage, and death.
+   */
   getConcepts(): Concept[] {
     const topLevelConcept = {
       id: 'event',

--- a/packages/converse/src/library/knowledge_graph/concepts/events.ts
+++ b/packages/converse/src/library/knowledge_graph/concepts/events.ts
@@ -1,9 +1,12 @@
 import { Concept, ConceptHierarchy } from './concept';
 
+/**
+ * Represents a hierarchy of event-related concepts.
+ */
 export class Events implements ConceptHierarchy {
   /**
    * Gets concepts related to the events of a subject.
-   * 
+   *
    * @returns A list of event-related concepts, including options such as
    *          festival, battle, harvest, hunt, marriage, and death.
    */

--- a/packages/converse/src/library/knowledge_graph/concepts/feelings.ts
+++ b/packages/converse/src/library/knowledge_graph/concepts/feelings.ts
@@ -1,9 +1,12 @@
 import { Concept, ConceptHierarchy } from './concept';
 
+/**
+ * Represents a hierarchy of feeling-related concepts.
+ */
 export class Feelings implements ConceptHierarchy {
   /**
    * Gets concepts related to the emotions of a subject.
-   * 
+   *
    * @returns A list of emotion-related concepts, including options such as
    *          happy, sad, angry, excited, scared, love, hate, and fear.
    */

--- a/packages/converse/src/library/knowledge_graph/concepts/feelings.ts
+++ b/packages/converse/src/library/knowledge_graph/concepts/feelings.ts
@@ -1,6 +1,12 @@
 import { Concept, ConceptHierarchy } from './concept';
 
 export class Feelings implements ConceptHierarchy {
+  /**
+   * Gets concepts related to the emotions of a subject.
+   * 
+   * @returns A list of emotion-related concepts, including options such as
+   *          happy, sad, angry, excited, scared, love, hate, and fear.
+   */
   getConcepts(): Concept[] {
     const topLevelConcept = {
       id: 'feeling',

--- a/packages/converse/src/library/knowledge_graph/concepts/lore.ts
+++ b/packages/converse/src/library/knowledge_graph/concepts/lore.ts
@@ -1,6 +1,11 @@
 import { Concept, ConceptHierarchy } from './concept';
 
 export class Lore implements ConceptHierarchy {
+  /**
+   * Gets concepts related to the lore of a subject.
+   *
+   * @returns A list of concepts.
+   */
   getConcepts(): Concept[] {
     const topLevelConcept = {
       id: 'lore',

--- a/packages/converse/src/library/knowledge_graph/concepts/lore.ts
+++ b/packages/converse/src/library/knowledge_graph/concepts/lore.ts
@@ -1,5 +1,8 @@
 import { Concept, ConceptHierarchy } from './concept';
 
+/**
+ * Represents a hierarchy of lore-related concepts.
+ */
 export class Lore implements ConceptHierarchy {
   /**
    * Gets concepts related to the lore of a subject.

--- a/packages/converse/src/library/knowledge_graph/concepts/personality.ts
+++ b/packages/converse/src/library/knowledge_graph/concepts/personality.ts
@@ -1,5 +1,8 @@
 import { Concept, ConceptHierarchy } from './concept';
 
+/**
+ * Represents a hierarchy of personality-related concepts.
+ */
 export class Personality implements ConceptHierarchy {
   /**
    * Gets concepts related to the personality of a subject.

--- a/packages/converse/src/library/knowledge_graph/concepts/personality.ts
+++ b/packages/converse/src/library/knowledge_graph/concepts/personality.ts
@@ -1,6 +1,11 @@
 import { Concept, ConceptHierarchy } from './concept';
 
 export class Personality implements ConceptHierarchy {
+  /**
+   * Gets concepts related to the personality of a subject.
+   *
+   * @returns A list of personality-related concepts.
+   */
   getConcepts(): Concept[] {
     const topLevelConcept = {
       id: 'personality',

--- a/packages/converse/src/library/knowledge_graph/concepts/professions.ts
+++ b/packages/converse/src/library/knowledge_graph/concepts/professions.ts
@@ -1,5 +1,8 @@
 import { Concept, ConceptHierarchy } from './concept';
 
+/**
+ * Represents a hierarchy of profession-related concepts.
+ */
 export class Professions implements ConceptHierarchy {
   /**
    * Gets concepts related to the professions of a subject.

--- a/packages/converse/src/library/knowledge_graph/concepts/professions.ts
+++ b/packages/converse/src/library/knowledge_graph/concepts/professions.ts
@@ -1,6 +1,12 @@
 import { Concept, ConceptHierarchy } from './concept';
 
 export class Professions implements ConceptHierarchy {
+  /**
+   * Gets concepts related to the professions of a subject.
+   *
+   * @returns A list of profession-related concepts, including options such as
+   *          villager, adventurer, and alchemist.
+   */
   getConcepts(): Concept[] {
     const topLevelConcept = {
       id: 'profession',

--- a/packages/converse/src/library/knowledge_graph/concepts/regions.ts
+++ b/packages/converse/src/library/knowledge_graph/concepts/regions.ts
@@ -1,5 +1,8 @@
 import { Concept, ConceptHierarchy } from './concept';
 
+/**
+ * Represents a hierarchy of region-related concepts.
+ */
 export class Regions implements ConceptHierarchy {
   /**
    * Gets concepts related to the region of a subject.

--- a/packages/converse/src/library/knowledge_graph/concepts/regions.ts
+++ b/packages/converse/src/library/knowledge_graph/concepts/regions.ts
@@ -1,6 +1,11 @@
 import { Concept, ConceptHierarchy } from './concept';
 
 export class Regions implements ConceptHierarchy {
+  /**
+   * Gets concepts related to the region of a subject.
+   *
+   * @returns A list of region-related concepts.
+   */
   getConcepts(): Concept[] {
     const topLevelConcept = {
       id: 'region',

--- a/packages/converse/src/library/knowledge_graph/concepts/relationships.ts
+++ b/packages/converse/src/library/knowledge_graph/concepts/relationships.ts
@@ -1,5 +1,8 @@
 import { Concept, ConceptHierarchy } from './concept';
 
+/**
+ * Represents a hierarchy of relationship-related concepts.
+ */
 export class Relationships implements ConceptHierarchy {
   /**
    * Retrieves concepts related to relationships.

--- a/packages/converse/src/library/knowledge_graph/concepts/relationships.ts
+++ b/packages/converse/src/library/knowledge_graph/concepts/relationships.ts
@@ -1,6 +1,12 @@
 import { Concept, ConceptHierarchy } from './concept';
 
 export class Relationships implements ConceptHierarchy {
+  /**
+   * Retrieves concepts related to relationships.
+   *
+   * @returns An array of relationship-related concepts, including options such as
+   *          sibling, spouse, parent, child, grandparent, grandchild, and friend.
+   */
   getConcepts(): Concept[] {
     const topLevelConcept = {
       id: 'relationship',

--- a/packages/converse/src/library/knowledge_graph/concepts/time.ts
+++ b/packages/converse/src/library/knowledge_graph/concepts/time.ts
@@ -1,6 +1,12 @@
 import { Concept, ConceptHierarchy } from './concept';
 
 export class Time implements ConceptHierarchy {
+  /**
+   * Gets concepts related to the time of a subject.
+   * 
+   * @returns A list of time-related concepts, including options such as
+   *          distant past, past, present, future, and distant future.
+   */
   getConcepts(): Concept[] {
     const topLevelConcept = {
       id: 'time',

--- a/packages/converse/src/library/knowledge_graph/concepts/time.ts
+++ b/packages/converse/src/library/knowledge_graph/concepts/time.ts
@@ -1,9 +1,12 @@
 import { Concept, ConceptHierarchy } from './concept';
 
+/**
+ * Represents a hierarchy of time-related concepts.
+ */
 export class Time implements ConceptHierarchy {
   /**
    * Gets concepts related to the time of a subject.
-   * 
+   *
    * @returns A list of time-related concepts, including options such as
    *          distant past, past, present, future, and distant future.
    */

--- a/packages/converse/src/library/knowledge_graph/desire.ts
+++ b/packages/converse/src/library/knowledge_graph/desire.ts
@@ -1,7 +1,13 @@
 import { Noun } from './noun';
 
+/**
+ * Represents the type of a desire.
+ */
 export type DesireType = 'like' | 'dislike' | 'love';
 
+/**
+ * Represents a desire in the knowledge graph.
+ */
 export interface Desire {
   person?: Noun;
   item: Noun;

--- a/packages/converse/src/library/knowledge_graph/existingKnowledge/existingKnowledge.ts
+++ b/packages/converse/src/library/knowledge_graph/existingKnowledge/existingKnowledge.ts
@@ -1,5 +1,8 @@
 import { Belief } from '../belief';
 
+/**
+ * Represents existing knowledge in the knowledge graph.
+ */
 export interface ExistingKnowledge {
   getConcept(): string;
   getKnowledge(): Belief[];

--- a/packages/converse/src/library/knowledge_graph/existingKnowledge/knownLore.ts
+++ b/packages/converse/src/library/knowledge_graph/existingKnowledge/knownLore.ts
@@ -1,6 +1,9 @@
 import { Belief } from '../belief';
 import { ExistingKnowledge } from './existingKnowledge';
 
+/**
+ * Represents known lore in the knowledge graph.
+ */
 export class KnownLore implements ExistingKnowledge {
   /**
    * @returns The concept ID associated with knowledge of lore (e.g. "concept_lore").
@@ -21,7 +24,7 @@ export interface Belief {
     */
 
   /**
-   * Returns an array of {@link Belief} objects representing the concepts of lore that are present in this world. 
+   * Returns an array of {@link Belief} objects representing the concepts of lore that are present in this world.
    * The `fact` property being set to `true` indicates that the lore is known to be true.
    *
    * @returns An array of {@link Belief} objects.

--- a/packages/converse/src/library/knowledge_graph/existingKnowledge/knownLore.ts
+++ b/packages/converse/src/library/knowledge_graph/existingKnowledge/knownLore.ts
@@ -2,6 +2,9 @@ import { Belief } from '../belief';
 import { ExistingKnowledge } from './existingKnowledge';
 
 export class KnownLore implements ExistingKnowledge {
+  /**
+   * @returns The concept ID associated with knowledge of lore (e.g. "concept_lore").
+   */
   getConcept(): string {
     return 'concept_lore';
   }
@@ -16,6 +19,13 @@ export interface Belief {
     trust: number
 }
     */
+
+  /**
+   * Returns an array of {@link Belief} objects representing the concepts of lore that are present in this world. 
+   * The `fact` property being set to `true` indicates that the lore is known to be true.
+   *
+   * @returns An array of {@link Belief} objects.
+   */
   getKnowledge(): Belief[] {
     return [];
     /*

--- a/packages/converse/src/library/knowledge_graph/existingKnowledge/knownRegions.ts
+++ b/packages/converse/src/library/knowledge_graph/existingKnowledge/knownRegions.ts
@@ -2,6 +2,9 @@ import { Belief } from '../belief';
 import { ExistingKnowledge } from './existingKnowledge';
 
 export class KnownRegions implements ExistingKnowledge {
+  /**
+   * @returns The concept ID associated with knowledge of regions (e.g. "concept_region").
+   */
   getConcept(): string {
     return 'concept_region';
   }
@@ -15,6 +18,10 @@ export interface Belief {
     trust: number
 }*/
 
+  /**
+   * @returns An array of {@link Belief} objects representing the knowledge this
+   * character has of the world's regions.
+   */  
   getKnowledge(): Belief[] {
     return [];
     /*

--- a/packages/converse/src/library/knowledge_graph/existingKnowledge/knownRegions.ts
+++ b/packages/converse/src/library/knowledge_graph/existingKnowledge/knownRegions.ts
@@ -1,6 +1,9 @@
 import { Belief } from '../belief';
 import { ExistingKnowledge } from './existingKnowledge';
 
+/**
+ * Represents known regions in the knowledge graph.
+ */
 export class KnownRegions implements ExistingKnowledge {
   /**
    * @returns The concept ID associated with knowledge of regions (e.g. "concept_region").
@@ -21,7 +24,7 @@ export interface Belief {
   /**
    * @returns An array of {@link Belief} objects representing the knowledge this
    * character has of the world's regions.
-   */  
+   */
   getKnowledge(): Belief[] {
     return [];
     /*

--- a/packages/converse/src/library/knowledge_graph/knowledgeGraph.ts
+++ b/packages/converse/src/library/knowledge_graph/knowledgeGraph.ts
@@ -3,6 +3,9 @@ import { Concept } from './concepts/concept';
 import { Desire } from './desire';
 import { Noun } from './noun';
 
+/**
+ * Represents a knowledge graph.
+ */
 export interface KnowledgeGraph {
   concepts: Concept[];
   beliefs: Belief[];

--- a/packages/converse/src/library/knowledge_graph/noun.ts
+++ b/packages/converse/src/library/knowledge_graph/noun.ts
@@ -1,3 +1,6 @@
+/**
+ * Represents a noun in the knowledge graph.
+ */
 export interface Noun {
   id?: string;
   name: string;

--- a/packages/converse/src/library/knowledge_graph/people/community.ts
+++ b/packages/converse/src/library/knowledge_graph/people/community.ts
@@ -4,6 +4,9 @@ import { Noun } from '../noun';
 import { Graphable } from './graphable';
 import { Region } from './region';
 
+/**
+ * Represents a community in the knowledge graph.
+ */
 export class Community implements Graphable {
   id: string;
   name: string;

--- a/packages/converse/src/library/knowledge_graph/people/community.ts
+++ b/packages/converse/src/library/knowledge_graph/people/community.ts
@@ -12,6 +12,16 @@ export class Community implements Graphable {
   lore?: string[];
   noun: Noun;
 
+  /**
+   * Constructs a new community object.
+   *
+   * @param id - the unique identifier of the community
+   * @param name - the name of the community
+   * @param description - a description of the community
+   * @param region - the region in which the community is located
+   * @param lore - a list of interesting stories or facts about the community.
+   * @throws Error if the region is not provided.
+   */
   constructor(
     id: string,
     name: string,
@@ -31,14 +41,35 @@ export class Community implements Graphable {
     }
   }
 
+  /**
+   * Gets the desires of this community.
+   *
+   * Returns an empty array, because a community does not have desires.
+   * @returns An empty array.
+   */
   getDesires(): Desire[] {
     return [];
   }
 
+  /**
+   * Returns the noun representing the community.
+   *
+   * @returns The noun representing the community.
+   */
   getNoun(): Noun {
     return this.noun;
   }
 
+  /**
+   * Retrieves an array of beliefs associated with the community.
+   *
+   * This function returns beliefs that describe the community's description and
+   * its association with a region. Throws an error if the lore is not provided.
+   *
+   * @throws Error if the community does not have lore.
+   * @returns An array of Belief objects representing the community's attributes,
+   *          including its description and regional association.
+   */
   getBeliefs(): Belief[] {
     if (!this.lore) {
       throw new Error('Community must have a description and region');

--- a/packages/converse/src/library/knowledge_graph/people/event.ts
+++ b/packages/converse/src/library/knowledge_graph/people/event.ts
@@ -5,6 +5,9 @@ import { Community } from './community';
 import { Graphable } from './graphable';
 import { Person } from './person';
 
+/**
+ * Represents an Eventy in the knowledge graph.
+ */
 export class Eventy implements Graphable {
   public readonly name: string;
   public readonly type: string;
@@ -58,7 +61,7 @@ export class Eventy implements Graphable {
   getNoun(): Noun {
     return this.noun;
   }
-  
+
   /**
    * Retrieves an array of beliefs associated with the event.
    *

--- a/packages/converse/src/library/knowledge_graph/people/event.ts
+++ b/packages/converse/src/library/knowledge_graph/people/event.ts
@@ -14,6 +14,15 @@ export class Eventy implements Graphable {
   public readonly peopleInvolved: Person[];
   private readonly noun: Noun;
 
+  /**
+   * Construct an Eventy. An Eventy is an event that is connected to a Community and may have people involved.
+   * @param {string} name The name of the event.
+   * @param {string} type The type of the event.
+   * @param {string} time The time of the event.
+   * @param {string} description The description of the event.
+   * @param {Community} community The community that the event is connected to.
+   * @param {Person[]} peopleInvolved The people that are involved in the event.
+   */
   constructor(
     name: string,
     type: string,
@@ -31,13 +40,35 @@ export class Eventy implements Graphable {
     this.noun = { name: this.name, type: 'event' };
   }
 
+  /**
+   * Get the desires of this event.
+   *
+   * Returns an empty array, because an event does not have desires.
+   * @returns {Desire[]} An empty array.
+   */
   getDesires(): Desire[] {
     return [];
   }
 
+  /**
+   * Gets the noun for this event.
+   *
+   * @returns {Noun} The noun for this event.
+   */
   getNoun(): Noun {
     return this.noun;
   }
+  
+  /**
+   * Retrieves an array of beliefs associated with the event.
+   *
+   * This function returns beliefs that describe the event's description
+   * and its association with a community.
+   *
+   * @returns {Belief[]} An array of Belief objects representing the
+   *          event's attributes, including its description and community
+   *          association.
+   */
   getBeliefs(): Belief[] {
     return [
       {

--- a/packages/converse/src/library/knowledge_graph/people/graphable.ts
+++ b/packages/converse/src/library/knowledge_graph/people/graphable.ts
@@ -3,6 +3,9 @@ import { Desire } from '../desire';
 import { KnowledgeGraph } from '../knowledgeGraph';
 import { Noun } from '../noun';
 
+/**
+ * Represents an entity that can be graphed in the knowledge graph.
+ */
 export interface Graphable {
   getNoun(): Noun;
   getBeliefs(): Belief[];
@@ -12,7 +15,7 @@ export interface Graphable {
 /**
  * Construct a knowledge graph from a list of graphable objects.
  *
- * @param graphables List of graphable objects to construct the graph from.
+ * @param graphables - List of graphable objects to construct the graph from.
  * @returns The constructed knowledge graph.
  *
  * This function constructs a knowledge graph by iterating over the list of

--- a/packages/converse/src/library/knowledge_graph/people/graphable.ts
+++ b/packages/converse/src/library/knowledge_graph/people/graphable.ts
@@ -9,6 +9,16 @@ export interface Graphable {
   getDesires(): Desire[];
 }
 
+/**
+ * Construct a knowledge graph from a list of graphable objects.
+ *
+ * @param graphables List of graphable objects to construct the graph from.
+ * @returns The constructed knowledge graph.
+ *
+ * This function constructs a knowledge graph by iterating over the list of
+ * graphable objects and adding their respective nouns, beliefs, and desires to
+ * the graph.
+ */
 export function constructGraph(graphables: Graphable[]): KnowledgeGraph {
   const beliefs: Belief[] = [];
   const nouns: Noun[] = [];

--- a/packages/converse/src/library/knowledge_graph/people/item.ts
+++ b/packages/converse/src/library/knowledge_graph/people/item.ts
@@ -4,6 +4,9 @@ import { Noun } from '../noun';
 import { Graphable } from './graphable';
 import { Region } from './region';
 
+/**
+ * Represents an item in the knowledge graph.
+ */
 export class Item implements Graphable {
   private readonly noun: Noun;
 

--- a/packages/converse/src/library/knowledge_graph/people/item.ts
+++ b/packages/converse/src/library/knowledge_graph/people/item.ts
@@ -7,6 +7,14 @@ import { Region } from './region';
 export class Item implements Graphable {
   private readonly noun: Noun;
 
+  /**
+   * Creates a new item.
+   *
+   * @param name - the name of the item
+   * @param description - a description of the item
+   * @param region - the region that the item is located in
+   * @throws Error if `region` is not provided
+   */
   constructor(
     public readonly name: string,
     public description: string,
@@ -22,14 +30,34 @@ export class Item implements Graphable {
     }
   }
 
+  /**
+   * Gets the desires of this item.
+   *
+   * Returns an empty array, because an item does not have desires.
+   * @returns An empty array.
+   */
   getDesires(): Desire[] {
     return [];
   }
 
+  /**
+   * Retrieves the noun representation of this item.
+   *
+   * @returns {Noun} The noun associated with this item.
+   */
   getNoun(): Noun {
     return this.noun;
   }
 
+  /**
+   * Retrieves an array of beliefs associated with the item.
+   *
+   * This function returns beliefs that describe the item's description and
+   * its association with a region.
+   *
+   * @returns An array of Belief objects representing the item's attributes,
+   *          including its description and regional association.
+   */
   getBeliefs(): Belief[] {
     return [
       {

--- a/packages/converse/src/library/knowledge_graph/people/person.ts
+++ b/packages/converse/src/library/knowledge_graph/people/person.ts
@@ -5,6 +5,12 @@ import { Community } from './community';
 import { Graphable } from './graphable';
 
 class FeelingsAbout {
+  /**
+   * Construct a new instance of the FeelingsAbout class.
+   *
+   * @param feeling The feeling that the person has (e.g., 'love', 'hate', etc.).
+   * @param about The person or thing about which the feeling is felt.
+   */
   constructor(
     public feeling: string,
     public about: string
@@ -16,6 +22,18 @@ export class Person implements Graphable {
   public feelingsAbout: FeelingsAbout[] = [];
   public noun: Noun;
 
+  /**
+   * Constructs a new instance of the Person class.
+   *
+   * @param id - The unique identifier for the person, which can be undefined.
+   * @param name - The name of the person.
+   * @param profession - The profession of the person.
+   * @param description - A textual description of the person.
+   * @param personality - A description of the person's personality.
+   * @param community - The community to which the person belongs.
+   * @param children - An array of the person's children, each being a Person instance.
+   * @param desire - An array of Desires that the person has.
+   */
   constructor(
     public readonly id: string | undefined,
     public readonly name: string,
@@ -37,14 +55,34 @@ export class Person implements Graphable {
     this.noun = { id: id, name: this.name, type: 'person' };
   }
 
+  /**
+   * Retrieves the desires of the person.
+   *
+   * The desires are copied and include the person as the desiree.
+   *
+   * @returns An array of desires associated with the person.
+   */
   getDesires(): Desire[] {
     return this.desire.map((d) => ({ ...d, person: this.noun }));
   }
 
+  /**
+   * Retrieves the noun representation of the person.
+   *
+   * @returns {Noun} The noun associated with this person.
+   */
   getNoun(): Noun {
     return this.noun;
   }
 
+  /**
+   * Retrieves an array of beliefs associated with the person.
+   *
+   * The method returns the person's description, profession, community, region,
+   * personality, desires, and feelings as beliefs.
+   *
+   * @returns An array of Belief objects representing the person's attributes.
+   */
   getBeliefs(): Belief[] {
     const beliefs: Belief[] = [];
 
@@ -131,10 +169,24 @@ export class Person implements Graphable {
     return beliefs;
   }
 
+  /**
+   * Records a feeling about a person, place, or thing.
+   *
+   * @param feeling The feeling verb (e.g. "likes", "hates", "admires")
+   * @param about The thing being felt about. Can be a person, place, or thing.
+   */
   addFeeling(feeling: string, about: string) {
     this.feelingsAbout.push(new FeelingsAbout(feeling, about));
   }
 
+  /**
+   * Build a set of beliefs that represent the family tree of a given set of
+   * people. This method will generate beliefs for each person's relationships
+   * with their spouse, children, siblings, grandparents, and uncles/aunts.
+   *
+   * @param people The people for which to generate the family tree.
+   * @returns A set of beliefs that represent the family tree.
+   */
   static buildFamilyTree(people: Person[]): Belief[] {
     const beliefs: Belief[] = [];
 

--- a/packages/converse/src/library/knowledge_graph/people/person.ts
+++ b/packages/converse/src/library/knowledge_graph/people/person.ts
@@ -4,6 +4,9 @@ import { Noun } from '../noun';
 import { Community } from './community';
 import { Graphable } from './graphable';
 
+/**
+ * Represents a person's feelings about another person or thing.
+ */
 class FeelingsAbout {
   /**
    * Construct a new instance of the FeelingsAbout class.
@@ -17,6 +20,9 @@ class FeelingsAbout {
   ) {}
 }
 
+/**
+ * Represents a person in the knowledge graph.
+ */
 export class Person implements Graphable {
   public spouse: Person | null = null;
   public feelingsAbout: FeelingsAbout[] = [];

--- a/packages/converse/src/library/knowledge_graph/people/region.ts
+++ b/packages/converse/src/library/knowledge_graph/people/region.ts
@@ -11,6 +11,15 @@ export class Region implements Graphable {
   lore?: string[];
   noun: Noun;
 
+  /**
+   * Creates a new region object.
+   *
+   * @param id - the unique identifier of the region
+   * @param name - the name of the region
+   * @param description - a description of the region
+   * @param parent_region - the parent region of the region
+   * @param lore - a list of interesting stories or facts about the region
+   */
   constructor(
     id: string,
     name: string,
@@ -26,13 +35,36 @@ export class Region implements Graphable {
     this.noun = { id: this.id, name: this.name, type: 'region' };
   }
 
+  /**
+   * Retrieves an array of desires associated with the region.
+   *
+   * Returns an empty array, as a region does not have desires.
+   * @returns An empty array.
+   */
   getDesires(): Desire[] {
     return [];
   }
 
+  /**
+   * Returns the noun associated with this region.
+   *
+   * @returns The noun associated with the region.
+   */
   getNoun(): Noun {
     return this.noun;
   }
+  
+  /**
+   * Retrieves an array of beliefs associated with the region.
+   *
+   * This function returns beliefs that describe the region's description and
+   * its association with a parent region. Throws an error if the region does not
+   * have a description or lore.
+   *
+   * @throws Error if the region does not have a description or lore.
+   * @returns An array of Belief objects representing the region's attributes,
+   *          including its description and parent region.
+   */
   getBeliefs(): Belief[] {
     if (!this.description || !this.lore) {
       throw new Error('Region must have a description and lore');

--- a/packages/converse/src/library/knowledge_graph/people/region.ts
+++ b/packages/converse/src/library/knowledge_graph/people/region.ts
@@ -3,6 +3,9 @@ import { Belief } from '../belief';
 import { Noun } from '../noun';
 import { Desire } from '../desire';
 
+/**
+ * Represents a region in the knowledge graph.
+ */
 export class Region implements Graphable {
   id: string;
   name: string;
@@ -53,7 +56,7 @@ export class Region implements Graphable {
   getNoun(): Noun {
     return this.noun;
   }
-  
+
   /**
    * Retrieves an array of beliefs associated with the region.
    *

--- a/packages/converse/src/library/social/conversation.ts
+++ b/packages/converse/src/library/social/conversation.ts
@@ -15,7 +15,6 @@ import { SpeakerService } from './speaker/speakerService';
 
 /**
  * Enum representing the state of a conversation.
- * @enum {number}
  */
 enum ConversationState {
   PROCESSING,
@@ -44,10 +43,11 @@ export class Conversation {
 
   /**
    * Creates a new Conversation instance.
-   * @param {Speaker} initiator - The speaker who initiates the conversation.
-   * @param {Speaker} respondent - The speaker who responds to the conversation.
-   * @param {SpeakerService} speakerService - The service managing speakers.
-   * @param {boolean} usesLLM - Whether the conversation uses a large language model.
+   *
+   * @param initiator - The speaker who initiates the conversation.
+   * @param respondent - The speaker who responds to the conversation.
+   * @param speakerService - The service managing speakers.
+   * @param usesLLM - Whether the conversation uses a large language model.
    */
   constructor(
     initator: Speaker,
@@ -76,7 +76,8 @@ export class Conversation {
 
   /**
    * Returns the participants of the conversation.
-   * @returns {Speaker[]} An array containing the initiator and respondent.
+   *
+   * @returns An array containing the initiator and respondent.
    */
   public participants(): Speaker[] {
     return [this.initiator, this.respondent];
@@ -102,8 +103,9 @@ export class Conversation {
 
   /**
    * Selects a speech option from the available options.
-   * @param {number} option - The index of the selected option.
-   * @returns {SpeechAct} The selected speech act.
+   *
+   * @param option - The index of the selected option.
+   * @returns The selected speech act.
    * @throws Will throw an error if the option is invalid.
    */
   selectFromOptions(option: number): SpeechAct {
@@ -126,7 +128,8 @@ export class Conversation {
 
   /**
    * Checks if the conversation is finished.
-   * @returns {boolean} True if the conversation is finished, false otherwise.
+   *
+   * @returns True if the conversation is finished, false otherwise.
    */
   isFinished(): boolean {
     return this.state === ConversationState.FINISHED;
@@ -134,7 +137,8 @@ export class Conversation {
 
   /**
    * Gets the chat history as a single string.
-   * @returns {string} The chat history.
+   *
+   * @returns The chat history.
    */
   getChats(): string {
     return this.chatHistory
@@ -145,8 +149,8 @@ export class Conversation {
 
   /**
    * Prepares the next response for an NPC.
-   * @param {Speaker} npc - The NPC speaker.
-   * @private
+   *
+   * @param npc - The NPC speaker.
    */
   private prepareNPCResponse(npc: Speaker): void {
     const speechAct = this.generateSpeechAct(npc);
@@ -183,8 +187,8 @@ export class Conversation {
 
   /**
    * Prepares the next response for a player.
-   * @param {Speaker} player - The player speaker.
-   * @private
+   *
+   * @param player - The player speaker.
    */
   private preparePlayerResponse(player: Speaker): void {
     this.speechOptions = this.getPotentialSpeechActs(player);
@@ -230,9 +234,9 @@ export class Conversation {
 
   /**
    * Gets the other participant in the conversation.
-   * @param {Speaker} person - The current speaker.
-   * @returns {Speaker} The other speaker.
-   * @private
+   *
+   * @param person - The current speaker.
+   * @returns The other speaker.
    */
   private other(person: Speaker): Speaker {
     return this.initiator === person ? this.respondent : this.initiator;
@@ -240,8 +244,8 @@ export class Conversation {
 
   /**
    * Gets the last speech act in the conversation.
-   * @returns {SpeechAct | null} The last speech act, or null if there is none.
-   * @private
+   *
+   * @returns The last speech act, or null if there is none.
    */
   private lastSpeechAct(): SpeechAct | null {
     const lastTurn = this.chatHistory[this.chatHistory.length - 1];
@@ -253,10 +257,10 @@ export class Conversation {
 
   /**
    * Selects the top N highest value speech acts.
-   * @param {SpeechAct[]} speechActs - The array of speech acts to select from.
-   * @param {number} n - The number of speech acts to select.
-   * @returns {SpeechAct[]} The selected speech acts.
-   * @private
+   *
+   * @param speechActs - The array of speech acts to select from.
+   * @param n - The number of speech acts to select.
+   * @returns The selected speech acts.
    */
   private selectNHighestValueSpeechAct(
     speechActs: SpeechAct[],
@@ -270,9 +274,9 @@ export class Conversation {
 
   /**
    * Generates the next speech act for the current speaker.
-   * @param {Speaker} currentSpeaker - The current speaker.
-   * @returns {SpeechAct} The generated speech act.
-   * @private
+   *
+   * @param currentSpeaker - The current speaker.
+   * @returns The generated speech act.
    */
   private generateSpeechAct(currentSpeaker: Speaker): SpeechAct {
     const lastAct = this.lastSpeechAct();
@@ -293,8 +297,8 @@ export class Conversation {
 
   /**
    * Determines whose turn it is in the conversation.
-   * @returns {Speaker} The speaker whose turn it is.
-   * @private
+   *
+   * @returns The speaker whose turn it is.
    */
   private whoseTurn(): Speaker {
     return this.chatHistory.length % 2 === 0 ? this.initiator : this.respondent;
@@ -303,9 +307,9 @@ export class Conversation {
   /**
    * Gets the potential speech acts for the current speaker.
    * This function generates a list of possible speech acts that the current speaker can perform based on the last speech act, the current speaker, and the topics covered in the conversation.
-   * @param {Speaker} currentSpeaker - The current speaker.
-   * @returns {SpeechAct[]} The potential speech acts.
-   * @private
+   *
+   * @param currentSpeaker - The current speaker.
+   * @returns The potential speech acts.
    */
   private getPotentialSpeechActs(currentSpeaker: Speaker): SpeechAct[] {
     const lastAct = this.lastSpeechAct();
@@ -323,9 +327,9 @@ export class Conversation {
 
   /**
    * Summarizes the conversation between two speakers.
-   * @param {Speaker} subject - The subject speaker.
-   * @param {Speaker} other - The other speaker.
-   * @private
+   *
+   * @param subject - The subject speaker.
+   * @param other - The other speaker.
    */
   private summarize(subject: Speaker, other: Speaker): void {
     const prompt = summarizeConversation(subject, other);
@@ -347,7 +351,6 @@ export class Conversation {
 
   /**
    * Finishes the conversation.
-   * @private
    */
   private finishConversation(): void {
     if (this.state === ConversationState.FINISHED) {
@@ -377,9 +380,9 @@ export class Conversation {
 
   /**
    * Adds a turn to the conversation.
-   * @param {Speaker} participant - The participant of the turn.
-   * @param {SpeechAct} speechAct - The speech act of the turn.
-   * @private
+   *
+   * @param participant - The participant of the turn.
+   * @param speechAct - The speech act of the turn.
    */
   private addTurn(participant: Speaker, speechAct: SpeechAct): void {
     this.chatHistory.push(new Turn(participant, speechAct));
@@ -396,9 +399,9 @@ export class Conversation {
 
   /**
    * Adds traits to the list of traits used by a speaker.
-   * @param {Speaker} speaker - The speaker.
-   * @param {PersonalityTraits[]} traits - The traits to add.
-   * @private
+   *
+   * @param speaker - The speaker.
+   * @param traits - The traits to add.
    */
   private addToTraitsUsed(speaker: Speaker, traits: PersonalityTraits[]): void {
     for (const trait of traits) {

--- a/packages/converse/src/library/social/conversation.ts
+++ b/packages/converse/src/library/social/conversation.ts
@@ -302,6 +302,7 @@ export class Conversation {
 
   /**
    * Gets the potential speech acts for the current speaker.
+   * This function generates a list of possible speech acts that the current speaker can perform based on the last speech act, the current speaker, and the topics covered in the conversation.
    * @param {Speaker} currentSpeaker - The current speaker.
    * @returns {SpeechAct[]} The potential speech acts.
    * @private

--- a/packages/converse/src/library/social/desires/desire.ts
+++ b/packages/converse/src/library/social/desires/desire.ts
@@ -1,6 +1,9 @@
 import { Item } from '../speaker/item';
 import { Speaker } from '../speaker/speaker';
 
+/**
+ * Interface representing a desire.
+ */
 export interface Desire {
   desiree: Speaker;
   desired: Item;

--- a/packages/converse/src/library/social/desires/proposal.ts
+++ b/packages/converse/src/library/social/desires/proposal.ts
@@ -6,20 +6,44 @@ export class Offer {
   quantity: number;
   value: Record<string, number> = {};
 
+  /**
+   * Constructs an instance of the Offer class.
+   *
+   * @param item - The item being offered.
+   * @param quantity - The quantity of the item being offered.
+   * @param value - A record mapping speaker IDs to the value they associate with the offer.
+   */
   constructor(item: Item, quantity: number, value: Record<string, number>) {
     this.item = item;
     this.quantity = quantity;
     this.value = value;
   }
 
+  /**
+   * Evaluates the offer for the given mob by returning the value associated with the mob's ID.
+   *
+   * @param mob - The speaker for whom the offer is being evaluated.
+   * @returns The numerical value of the offer for the specified mob.
+   */
   evaluate(mob: Speaker): number {
     return this.value[mob.id];
   }
 
+  /**
+   * Compares two offers by their item and quantity. Returns true if both items and quantities are equal, false otherwise.
+   * 
+   * @param other - The offer to compare with.
+   * @returns True if the offers are equal, false otherwise.
+   */
   equals(other: Offer): boolean {
     return this.item.id === other.item.id && this.quantity === other.quantity;
   }
 
+  /**
+   * Generates a string representation of the offer suitable for display to the user.
+   *
+   * @returns A string representation of the offer.
+   */
   prompt(): string {
     return `${this.quantity} ${this.item.name}`;
   }
@@ -36,15 +60,34 @@ export class Proposal {
   rejected = false;
   latestChange: string = '';
 
+  /**
+   * Constructs an instance of the Proposal class.
+   *
+   * @param initiator - The speaker making the proposal.
+   * @param respondent - The speaker to whom the proposal is being made.
+   */
   constructor(initiator: Speaker, respondent: Speaker) {
     this.initiator = initiator;
     this.respondent = respondent;
   }
 
+  /**
+   * Rejects the proposal.
+   *
+   * This can be used to mark the proposal as failed. It is typically invoked
+   * after a negotiation has failed.
+   */
   reject() {
     this.rejected = true;
   }
 
+  /**
+   * Processes the acceptance of a proposal by creating obligations.
+   *
+   * Converts the offers from both the initiator and respondent into obligations
+   * that each party must fulfill within a specified time frame. The obligations
+   * are established for each offer by the respective parties.
+   */
   processAcceptance() {
     // turn proposal into obligations
     const timeToComplete = 60 * 2; // 60 seconds to complete
@@ -67,6 +110,15 @@ export class Proposal {
     }
   }
 
+  /**
+   * Generates a unique hash string for the proposal.
+   *
+   * The hash is composed of the initiator's ID, the respondent's ID, and the IDs
+   * of the items in both the initiator's and respondent's offers. This provides
+   * a unique identifier for the proposal based on the involved parties and items.
+   *
+   * @returns A string representing the unique hash of the proposal.
+   */
   hash(): string {
     return `${this.initiator.id}-${this.respondent.id}-${Array.from(
       this.initiatorOffers
@@ -77,7 +129,21 @@ export class Proposal {
       .join('-')}`;
   }
 
+  /**
+   * Evaluates the proposal for the given speaker by calculating the difference between their offers and the offers of the other speaker.
+   *
+   * The evaluation is done by summing the values of all the offers made by the given speaker, and then subtracting the sum of the values of all the offers made by the other speaker.
+   *
+   * @param evaluator - The speaker for whom the proposal is being evaluated.
+   * @returns The numerical value of the proposal for the specified speaker.
+   */
   evaluate(evaluator: Speaker): number {
+    /**
+     * Calculates the total value of a set of offers for a given evaluator.
+     *
+     * @param offers - The set of offers to evaluate.
+     * @returns The total value of the offers for the evaluator.
+     */
     const evaluate = (offers: Set<Offer>) =>
       Array.from(offers).reduce(
         (sum, offer) => sum + offer.evaluate(evaluator),
@@ -91,10 +157,28 @@ export class Proposal {
     }
   }
 
+  /**
+   * Returns the speaker that is not the given mob.
+   *
+   * If the given mob is the initiator, this method returns the respondent.
+   * If the given mob is the respondent, this method returns the initiator.
+   *
+   * @param mob - The speaker to check.
+   * @returns The other speaker.
+   */
   private other(mob: Speaker): Speaker {
     return mob === this.initiator ? this.respondent : this.initiator;
   }
 
+  /**
+   * Returns true if the proposal has substance, i.e. if it has offers that are not the same on both sides.
+   *
+   * A proposal is considered to have substance if it has at least one offer that is not the same on both sides, i.e. if the initiator and the respondent have different items being offered.
+   *
+   * If the proposal has no offers, or if all the offers are the same on both sides, this method returns false.
+   *
+   * @returns true if the proposal has substance, false otherwise.
+   */
   hasSubtance(): boolean {
     // Reject if offer has the same items on both sides
     for (const offer of this.initiatorOffers) {
@@ -108,6 +192,11 @@ export class Proposal {
     return this.initiatorOffers.size > 0 || this.respondentOffers.size > 0;
   }
 
+  /**
+   * Returns a deep copy of the proposal.
+   *
+   * @returns a new Proposal that is a deep copy of the current proposal.
+   */
   clone(): Proposal {
     const clone = new Proposal(this.initiator, this.respondent);
     clone.initiatorOffers = new Set(this.initiatorOffers);
@@ -115,7 +204,26 @@ export class Proposal {
     return clone;
   }
 
+  /**
+   * Compares this proposal with another proposal to determine if they are equal.
+   *
+   * Two proposals are considered equal if they have the same initiator and respondent,
+   * and if the sets of offers from both the initiator and respondent are identical.
+   *
+   * @param other - The proposal to compare with.
+   * @returns True if the proposals are equal, false otherwise.
+   */
   equals(other: Proposal): boolean {
+    /**
+     * Checks if two sets of offers contain the same elements.
+     *
+     * Two sets of offers are considered the same if they have the same size
+     * and every offer in the first set has an equivalent offer in the second set.
+     *
+     * @param setA - The first set of offers to compare.
+     * @param setB - The second set of offers to compare.
+     * @returns True if the two sets contain the same offers, false otherwise.
+     */
     const hasSameOffers = (setA: Set<Offer>, setB: Set<Offer>) =>
       setA.size === setB.size &&
       Array.from(setA).every((offerA) =>
@@ -130,6 +238,14 @@ export class Proposal {
     );
   }
 
+  /**
+   * Adds an initial ask to the proposal, from the respondent to the initiator.
+   * The benefit of the offer for both the initiator and respondent is calculated
+   * automatically.
+   *
+   * @param item - The item to be offered.
+   * @param quantity - The quantity of the item to be offered.
+   */
   addInitialAsk(item: Item, quantity: number) {
     this.respondentOffers.add(
       new Offer(item, quantity, {
@@ -139,6 +255,23 @@ export class Proposal {
     );
   }
 
+  /**
+   * Adds a random benefit to the proposal, from the benefiter to the giver, of
+   * at least the given minimum value.
+   *
+   * If the benefiter has a desire for an item that is already being offered,
+   * the quantity of the offer is increased by one.
+   *
+   * Otherwise, a new offer is added to the proposal, with a quantity of one.
+   *
+   * The benefit of the offer for both the benefiter and the giver is calculated
+   * automatically.
+   *
+   * @param benefiter - The speaker to whom the benefit is being added.
+   * @param giver - The speaker who is giving the benefit.
+   * @param minimumValue - The minimum value of the benefit to be added.
+   * @returns True if a benefit was added, false otherwise.
+   */
   addRandomBenefit(
     benefiter: Speaker,
     giver: Speaker,
@@ -177,6 +310,16 @@ export class Proposal {
     return false;
   }
 
+  /**
+   * Randomly mutates a proposal to be better for the other party.
+   *
+   * With 30% chance, takes away a random item from the other party's side.
+   * With 30% chance, adds a random desire to the other party's side.
+   * If the proposal is unchanged or has no substance, returns null.
+   *
+   * @param mutator - The speaker to mutate the proposal for.
+   * @returns The mutated proposal or null if no change was made.
+   */
   mutateBetterForOther(mutator: Speaker): Proposal | null {
     const newProposal = this.clone();
     // either take away something from my side or add something to your side
@@ -204,6 +347,16 @@ export class Proposal {
     return newProposal;
   }
 
+  /**
+   * Randomly mutates a proposal to be more favorable for the mutator.
+   *
+   * With 50% chance, removes a random item from the mutator's side of the proposal.
+   * Otherwise, adds a random benefit to the other party's side.
+   * If the mutated proposal is unchanged or lacks substance, returns null.
+   *
+   * @param mutator - The speaker for whom the proposal is being mutated.
+   * @returns The mutated proposal or null if no change was made.
+   */
   mutateBetterForMe(mutator: Speaker): Proposal | null {
     const newProposal = this.clone();
     // either take away something from my side or add something to your side
@@ -231,6 +384,16 @@ export class Proposal {
     return newProposal;
   }
 
+  /**
+   * Builds a prompt string from the proposal.
+   *
+   * The prompt will be in one of three forms:
+   * 1. I demand [list of things] from you.
+   * 2. I offer [list of things] to you as a gift.
+   * 3. I offer [list of things] in exchange for you giving me [list of things].
+   *
+   * @returns The prompt string
+   */
   prompt(): string {
     let prompt = '';
 
@@ -255,6 +418,14 @@ export class Proposal {
     return prompt;
   }
 
+  /**
+   * A string representation of the proposal.
+   *
+   * The string will have the form "Offers: [...initiator offers...], Offers: [...respondent offers...]"
+   * where each offer is a JSON string.
+   *
+   * @returns A string representation of the proposal.
+   */
   toString(): string {
     return `Offers: ${JSON.stringify(Array.from(this.initiatorOffers))} 
         Offers: ${JSON.stringify(Array.from(this.respondentOffers))}`;

--- a/packages/converse/src/library/social/desires/proposal.ts
+++ b/packages/converse/src/library/social/desires/proposal.ts
@@ -31,7 +31,7 @@ export class Offer {
 
   /**
    * Compares two offers by their item and quantity. Returns true if both items and quantities are equal, false otherwise.
-   * 
+   *
    * @param other - The offer to compare with.
    * @returns True if the offers are equal, false otherwise.
    */

--- a/packages/converse/src/library/social/fantasyDate.ts
+++ b/packages/converse/src/library/social/fantasyDate.ts
@@ -5,6 +5,10 @@ interface FantasyDate {
   tick: number;
 }
 
+/**
+ * Gets the current fantasy date from the database.
+ * @returns {FantasyDate} The current fantasy date.
+ */
 export function current_date(): FantasyDate {
   return DB.prepare(
     `
@@ -16,7 +20,11 @@ export function current_date(): FantasyDate {
   ).get() as FantasyDate;
 }
 
-export function set_current_date(date: FantasyDate) {
+/**
+ * Sets the current fantasy date in the database.
+ * @param {FantasyDate} date - The fantasy date to set.
+ */
+export function set_current_date(date: FantasyDate): void {
   DB.prepare(
     `
         UPDATE fantasy_date

--- a/packages/converse/src/library/social/fantasyDate.ts
+++ b/packages/converse/src/library/social/fantasyDate.ts
@@ -6,7 +6,7 @@ interface FantasyDate {
 }
 
 /**
- * Gets the current fantasy date from the database.
+ * Gets the current in-game fantasy date from the database.
  * @returns {FantasyDate} The current fantasy date.
  */
 export function current_date(): FantasyDate {

--- a/packages/converse/src/library/social/fantasyDate.ts
+++ b/packages/converse/src/library/social/fantasyDate.ts
@@ -7,7 +7,8 @@ interface FantasyDate {
 
 /**
  * Gets the current in-game fantasy date from the database.
- * @returns {FantasyDate} The current fantasy date.
+ *
+ * @returns The current fantasy date.
  */
 export function current_date(): FantasyDate {
   return DB.prepare(
@@ -22,7 +23,8 @@ export function current_date(): FantasyDate {
 
 /**
  * Sets the current fantasy date in the database.
- * @param {FantasyDate} date - The fantasy date to set.
+ *
+ * @param date - The fantasy date to set.
  */
 export function set_current_date(date: FantasyDate): void {
   DB.prepare(

--- a/packages/converse/src/library/social/memories/goal.ts
+++ b/packages/converse/src/library/social/memories/goal.ts
@@ -18,7 +18,7 @@ export class Goal {
    * Prepares a goal by randomly selecting an interest_id from
    * the 'nouns' table and inserting it into the 'goals' table
    * if it does not already exist for the given owner.
-   * 
+   *
    * @param owner - The Speaker who owns this goal.
    */
   constructor(owner: Speaker) {

--- a/packages/converse/src/library/social/memories/goal.ts
+++ b/packages/converse/src/library/social/memories/goal.ts
@@ -13,6 +13,14 @@ import { Speaker } from '../speaker/speaker';
 export class Goal {
   owner: Speaker;
 
+  /**
+   * Initializes a new Goal instance for the specified owner.
+   * Prepares a goal by randomly selecting an interest_id from
+   * the 'nouns' table and inserting it into the 'goals' table
+   * if it does not already exist for the given owner.
+   * 
+   * @param owner - The Speaker who owns this goal.
+   */
   constructor(owner: Speaker) {
     this.owner = owner;
 
@@ -29,6 +37,10 @@ export class Goal {
     // Add goal to beliefs?
   }
 
+  /**
+   * Returns the id of the person this mob is interested in for their current goal.
+   * @returns the id of the person, or undefined if no goal exists.
+   */
   getGoalTarget(): string | undefined {
     // Specify the parameter type and inline type for the returned row
     const stmt = DB.prepare<{ mob_key: string }, { interest_id: string }>(`

--- a/packages/converse/src/library/social/memories/memoryFormation.ts
+++ b/packages/converse/src/library/social/memories/memoryFormation.ts
@@ -9,6 +9,7 @@ class PotentialMemory {
   private connections: string[] = [];
 
   /**
+   * Constructs a new instance of PotentialMemory with the provided key, name, and description.
    * @param key Unique identifier for the potential memory.
    * @param name Display name for the potential memory.
    * @param description Description for the potential memory.

--- a/packages/converse/src/library/social/memories/memoryFormation.ts
+++ b/packages/converse/src/library/social/memories/memoryFormation.ts
@@ -8,12 +8,22 @@ class PotentialMemory {
   private description: string;
   private connections: string[] = [];
 
+  /**
+   * @param key Unique identifier for the potential memory.
+   * @param name Display name for the potential memory.
+   * @param description Description for the potential memory.
+   */
   constructor(key: string, name: string, description: string) {
     this.key = key;
     this.name = name;
     this.description = description;
   }
 
+  /**
+   * Add a connection to this potential memory.
+   *
+   * @param key The key of the concept to add a connection to.
+   */
   addConnection(key: string) {
     this.connections.push(key);
   }
@@ -22,6 +32,11 @@ class PotentialMemory {
 class MemoryChoice {
   private choices: PotentialMemory[];
 
+  /**
+   * Constructs a new instance of MemoryChoice with the provided potential memories.
+   *
+   * @param choices - An array of PotentialMemory instances to initialize the MemoryChoice with.
+   */
   constructor(choices: PotentialMemory[]) {
     this.choices = choices;
   }
@@ -30,6 +45,11 @@ class MemoryChoice {
 export class MemoryFormation {
   private mob: Speaker;
 
+  /**
+   * Creates a new MemoryFormation instance for the given mob.
+   *
+   * @param mob - The mob to create the memory formation for.
+   */
   constructor(mob: Speaker) {
     this.mob = mob;
   }
@@ -45,6 +65,11 @@ export class MemoryFormation {
   //     { "id": "fear", "name": "fear", "as_question": "is <subject> feeling fear?", "parent_concept": topLevelConcept }
   // ];
 
+  /**
+   * Creates memories for the given mob based on their relationships.
+   *
+   * @returns an empty array of MemoryChoice (for now)
+   */
   formMemoriesFromRelationships(): MemoryChoice[] {
     DB.prepare(
       `
@@ -155,6 +180,14 @@ export class MemoryFormation {
     return [];
   }
 
+  /**
+   * Aggregates potential memory choices for the mob by combining memories
+   * formed from various sources such as relationships, calendar events,
+   * today's events, and goals.
+   *
+   * @returns An array of MemoryChoice objects representing the collective
+   *          potential memories for the mob.
+   */
   gatherPotentialMemoryChoices(): MemoryChoice[] {
     const memoryChoices = [];
     memoryChoices.push(...this.formMemoriesFromRelationships());

--- a/packages/converse/src/library/social/memories/memoryService.ts
+++ b/packages/converse/src/library/social/memories/memoryService.ts
@@ -1,14 +1,25 @@
 import { DB } from '../../database';
 
+/**
+ * Represents a belief in the system.
+ */
 export type Belief = {
   id: string;
   description: string;
   name: string;
   trust: number;
 };
+
+/**
+ * Represents a row containing distance information.
+ */
 export interface DistanceRow {
   distance: number;
 }
+
+/**
+ * Represents a question in the system.
+ */
 export interface Question {
   concept_id: string;
   as_question: string;
@@ -16,10 +27,13 @@ export interface Question {
   name: string;
 }
 
+/**
+ * Represents a service for managing memories.
+ */
 export class MemoryService {
   /**
    * Creates a knowledge link from observer to observed for the description concept if it doesn't exist.
-   * 
+   *
    * @param observer_id The id of the observer.
    * @param observed_id The id of the observed.
    */
@@ -36,7 +50,7 @@ export class MemoryService {
 
   /**
    * Add multiple beliefs to a mob's knowledge.
-   * 
+   *
    * @param noun_id The id of the mob to have the beliefs.
    * @param belief_ids The ids of the beliefs to add.
    */
@@ -52,10 +66,10 @@ export class MemoryService {
 
   /**
    * Find the most recently learned fact about a mob.
-   * 
+   *
    * @param known_by_mob_key The id of the mob that knows the fact.
    * @param about_mob_key The id of the mob that the fact is about.
-   * 
+   *
    * @returns The most recently learned fact about the mob.
    */
   findFactAbout(known_by_mob_key: string, about_mob_key: string): Belief {
@@ -71,9 +85,9 @@ export class MemoryService {
 
   /**
    * Get the most recently learned fact by the mob with the given id.
-   * 
+   *
    * @param knower_id The id of the mob that learned the fact.
-   * 
+   *
    * @returns The most recently learned fact by the mob.
    */
   getLastLearned(knower_id: string): Belief {
@@ -89,11 +103,11 @@ export class MemoryService {
   /**
    * Gets a random fact that is not known by the mob with the given id,
    * but is related to the given noun id, and is known by the mob with the given asked_of_id.
-   * 
+   *
    * @param knower_id The id of the mob that doesn't know the fact.
    * @param asked_of_id The id of the mob that knows the fact.
    * @param noun_id The id of the noun that the fact is related to.
-   * 
+   *
    * @returns The id of the fact, or undefined if no such fact exists.
    */
   getRandomUnknownFactRelatedTo(
@@ -123,14 +137,14 @@ export class MemoryService {
   }
 
   /**
-   * Gets a question about a fact that the mob with id `not_known_by_mob_id` does not know, but that is related to the mob with id `related_to_id`, 
-   * and that is asked of the mob with id `asked_of_id`. If the mob with id `asked_of_id` also knows some fact about the mob with id 
+   * Gets a question about a fact that the mob with id `not_known_by_mob_id` does not know, but that is related to the mob with id `related_to_id`,
+   * and that is asked of the mob with id `asked_of_id`. If the mob with id `asked_of_id` also knows some fact about the mob with id
    * `related_to_id`, then it should be preferred.
-   * 
+   *
    * @param not_known_by_mob_id The id of the mob that does not know the fact.
    * @param asked_of_id The id of the mob that the fact is being asked of.
    * @param related_to_id The id of the mob that the fact is about.
-   * 
+   *
    * @returns A question about the fact, or undefined if none could be found.
    */
   getQuestionAbout(
@@ -165,11 +179,11 @@ export class MemoryService {
 
   /**
    * Get a random fact known by the mob with id `known_by_mob_id` under the concept with id `concept_id` that is not known by the mob with id `not_known_by_mob_id`.
-   * 
+   *
    * @param known_by_mob_id The id of the mob that knows the fact.
    * @param not_known_by_mob_id The id of the mob that does not know the fact.
    * @param concept_id The id of the concept that the fact is under.
-   * 
+   *
    * @returns A random fact that is known by `known_by_mob_id` under the concept with id `concept_id` that is not known by `not_known_by_mob_id`, or undefined if no such fact exists.
    */
   getRandomMemoryGap(
@@ -197,13 +211,13 @@ export class MemoryService {
   }
 
   /**
-   * Gets the most recently learned fact known by the mob with id `known_by_mob_id` under the concept 
+   * Gets the most recently learned fact known by the mob with id `known_by_mob_id` under the concept
    * with id `concept_id` that is about the mob with id `known_by_mob_id`.
-   * 
+   *
    * @param known_by_mob_id The id of the mob that knows the fact.
    * @param concept_id The id of the concept that the fact is under.
-   * 
-   * @returns The most recently learned fact that is known by `known_by_mob_id` under the concept with id `concept_id` 
+   *
+   * @returns The most recently learned fact that is known by `known_by_mob_id` under the concept with id `concept_id`
    * that is about `known_by_mob_id`, or undefined if no such fact exists.
    */
   getBeliefAbout(known_by_mob_id: string, concept_id: string): Belief {
@@ -219,14 +233,14 @@ export class MemoryService {
   }
 
   /**
-   * Gets the most recently learned fact known by the mob with id `known_by_mob_id` under the concept with id `concept_id` that 
+   * Gets the most recently learned fact known by the mob with id `known_by_mob_id` under the concept with id `concept_id` that
    * is about the mob with id `known_by_mob_id` and is related to the mob with id `related_to_id`.
-   * 
+   *
    * @param known_by_mob_id The id of the mob that knows the fact.
    * @param related_to_id The id of the mob that the fact is related to.
    * @param concept_id The id of the concept that the fact is under.
-   * 
-   * @returns The most recently learned fact that is known by `known_by_mob_id` under the concept with id `concept_id` that is about 
+   *
+   * @returns The most recently learned fact that is known by `known_by_mob_id` under the concept with id `concept_id` that is about
    * `known_by_mob_id` and is related to `related_to_id`, or undefined if no such fact exists.
    */
   getBeliefRelatedTo(
@@ -248,11 +262,11 @@ export class MemoryService {
 
   /**
    * Finds an answer to a question that is known by the mob with id `known_by_mob_id` but not known by the mob with id `not_known_by_mob_id`.
-   * 
+   *
    * @param known_by_mob_id The id of the mob that knows the fact.
    * @param not_known_by_mob_id The id of the mob that does not know the fact.
    * @param question The question that we want to find an answer to.
-   * 
+   *
    * @returns The answer to the question, or undefined if no such fact exists.
    */
   findAnswer(
@@ -281,10 +295,10 @@ export class MemoryService {
 
   /**
    * Finds a fact that is known by the mob with id `subject_id` that is related to the mob with id `related_to_id`.
-   * 
+   *
    * @param subject_id The id of the mob that knows the fact.
    * @param related_to_id The id of the mob that the fact is related to.
-   * 
+   *
    * @returns The fact that is known by `subject_id` that is related to `related_to_id`, or undefined if no such fact exists.
    */
   findConnectionBetweenNouns(
@@ -302,9 +316,9 @@ export class MemoryService {
 
   /**
    * Finds a random noun that is related to the given fact.
-   * 
+   *
    * @param fact The id of the fact that we want to find a related noun to.
-   * 
+   *
    * @returns A random noun that is related to the given fact, or undefined if no such noun exists.
    */
   findRelatedNoun(fact: string): Belief {

--- a/packages/converse/src/library/social/memories/memoryService.ts
+++ b/packages/converse/src/library/social/memories/memoryService.ts
@@ -17,6 +17,12 @@ export interface Question {
 }
 
 export class MemoryService {
+  /**
+   * Creates a knowledge link from observer to observed for the description concept if it doesn't exist.
+   * 
+   * @param observer_id The id of the observer.
+   * @param observed_id The id of the observed.
+   */
   observe(observer_id: string, observed_id: string) {
     const observeSQL = DB.prepare(`
             INSERT OR IGNORE INTO 
@@ -28,6 +34,12 @@ export class MemoryService {
     observeSQL.run({ observer_id: observer_id, observed_id: observed_id });
   }
 
+  /**
+   * Add multiple beliefs to a mob's knowledge.
+   * 
+   * @param noun_id The id of the mob to have the beliefs.
+   * @param belief_ids The ids of the beliefs to add.
+   */
   addKnowledge(noun_id: string, belief_ids: string[]) {
     const stmt = DB.prepare(`
             INSERT OR IGNORE INTO knowledge (noun_id, belief_id) VALUES (:noun_id, :belief_id)
@@ -38,6 +50,14 @@ export class MemoryService {
     })();
   }
 
+  /**
+   * Find the most recently learned fact about a mob.
+   * 
+   * @param known_by_mob_key The id of the mob that knows the fact.
+   * @param about_mob_key The id of the mob that the fact is about.
+   * 
+   * @returns The most recently learned fact about the mob.
+   */
   findFactAbout(known_by_mob_key: string, about_mob_key: string): Belief {
     const stmt = DB.prepare(`
             SELECT id, name, description, trust
@@ -49,6 +69,13 @@ export class MemoryService {
     return stmt.get({ known_by_mob_key, about_mob_key }) as Belief;
   }
 
+  /**
+   * Get the most recently learned fact by the mob with the given id.
+   * 
+   * @param knower_id The id of the mob that learned the fact.
+   * 
+   * @returns The most recently learned fact by the mob.
+   */
   getLastLearned(knower_id: string): Belief {
     const stmt = DB.prepare(`
             SELECT beliefs.id, beliefs.name, beliefs.description, beliefs.trust
@@ -59,6 +86,16 @@ export class MemoryService {
     return stmt.get({ knower_id }) as Belief;
   }
 
+  /**
+   * Gets a random fact that is not known by the mob with the given id,
+   * but is related to the given noun id, and is known by the mob with the given asked_of_id.
+   * 
+   * @param knower_id The id of the mob that doesn't know the fact.
+   * @param asked_of_id The id of the mob that knows the fact.
+   * @param noun_id The id of the noun that the fact is related to.
+   * 
+   * @returns The id of the fact, or undefined if no such fact exists.
+   */
   getRandomUnknownFactRelatedTo(
     knower_id: string,
     asked_of_id: string,
@@ -85,6 +122,17 @@ export class MemoryService {
     return result.id;
   }
 
+  /**
+   * Gets a question about a fact that the mob with id `not_known_by_mob_id` does not know, but that is related to the mob with id `related_to_id`, 
+   * and that is asked of the mob with id `asked_of_id`. If the mob with id `asked_of_id` also knows some fact about the mob with id 
+   * `related_to_id`, then it should be preferred.
+   * 
+   * @param not_known_by_mob_id The id of the mob that does not know the fact.
+   * @param asked_of_id The id of the mob that the fact is being asked of.
+   * @param related_to_id The id of the mob that the fact is about.
+   * 
+   * @returns A question about the fact, or undefined if none could be found.
+   */
   getQuestionAbout(
     not_known_by_mob_id: string,
     asked_of_id: string,
@@ -115,6 +163,15 @@ export class MemoryService {
     return question;
   }
 
+  /**
+   * Get a random fact known by the mob with id `known_by_mob_id` under the concept with id `concept_id` that is not known by the mob with id `not_known_by_mob_id`.
+   * 
+   * @param known_by_mob_id The id of the mob that knows the fact.
+   * @param not_known_by_mob_id The id of the mob that does not know the fact.
+   * @param concept_id The id of the concept that the fact is under.
+   * 
+   * @returns A random fact that is known by `known_by_mob_id` under the concept with id `concept_id` that is not known by `not_known_by_mob_id`, or undefined if no such fact exists.
+   */
   getRandomMemoryGap(
     known_by_mob_id: string,
     not_known_by_mob_id: string,
@@ -139,6 +196,16 @@ export class MemoryService {
     }) as Belief;
   }
 
+  /**
+   * Gets the most recently learned fact known by the mob with id `known_by_mob_id` under the concept 
+   * with id `concept_id` that is about the mob with id `known_by_mob_id`.
+   * 
+   * @param known_by_mob_id The id of the mob that knows the fact.
+   * @param concept_id The id of the concept that the fact is under.
+   * 
+   * @returns The most recently learned fact that is known by `known_by_mob_id` under the concept with id `concept_id` 
+   * that is about `known_by_mob_id`, or undefined if no such fact exists.
+   */
   getBeliefAbout(known_by_mob_id: string, concept_id: string): Belief {
     const stmt = DB.prepare(`
             SELECT beliefs.id, beliefs.name, beliefs.description, beliefs.trust
@@ -151,6 +218,17 @@ export class MemoryService {
     return stmt.get({ known_by_mob_id, concept_id }) as Belief;
   }
 
+  /**
+   * Gets the most recently learned fact known by the mob with id `known_by_mob_id` under the concept with id `concept_id` that 
+   * is about the mob with id `known_by_mob_id` and is related to the mob with id `related_to_id`.
+   * 
+   * @param known_by_mob_id The id of the mob that knows the fact.
+   * @param related_to_id The id of the mob that the fact is related to.
+   * @param concept_id The id of the concept that the fact is under.
+   * 
+   * @returns The most recently learned fact that is known by `known_by_mob_id` under the concept with id `concept_id` that is about 
+   * `known_by_mob_id` and is related to `related_to_id`, or undefined if no such fact exists.
+   */
   getBeliefRelatedTo(
     known_by_mob_id: string,
     related_to_id: string,
@@ -168,6 +246,15 @@ export class MemoryService {
     return stmt.get({ known_by_mob_id, related_to_id, concept_id }) as Belief;
   }
 
+  /**
+   * Finds an answer to a question that is known by the mob with id `known_by_mob_id` but not known by the mob with id `not_known_by_mob_id`.
+   * 
+   * @param known_by_mob_id The id of the mob that knows the fact.
+   * @param not_known_by_mob_id The id of the mob that does not know the fact.
+   * @param question The question that we want to find an answer to.
+   * 
+   * @returns The answer to the question, or undefined if no such fact exists.
+   */
   findAnswer(
     known_by_mob_id: string,
     not_known_by_mob_id: string,
@@ -192,6 +279,14 @@ export class MemoryService {
     }) as Belief;
   }
 
+  /**
+   * Finds a fact that is known by the mob with id `subject_id` that is related to the mob with id `related_to_id`.
+   * 
+   * @param subject_id The id of the mob that knows the fact.
+   * @param related_to_id The id of the mob that the fact is related to.
+   * 
+   * @returns The fact that is known by `subject_id` that is related to `related_to_id`, or undefined if no such fact exists.
+   */
   findConnectionBetweenNouns(
     subject_id: string,
     related_to_id: string
@@ -205,6 +300,13 @@ export class MemoryService {
     return stmt.get({ subject_id, related_to_id }) as Belief;
   }
 
+  /**
+   * Finds a random noun that is related to the given fact.
+   * 
+   * @param fact The id of the fact that we want to find a related noun to.
+   * 
+   * @returns A random noun that is related to the given fact, or undefined if no such noun exists.
+   */
   findRelatedNoun(fact: string): Belief {
     const stmt = DB.prepare(`
         SELECT key, name, description, fact, concept, noun

--- a/packages/converse/src/library/social/personality.ts
+++ b/packages/converse/src/library/social/personality.ts
@@ -26,7 +26,8 @@ export class Personality {
 
   /**
    * Creates a new Personality instance.
-   * @param {Speaker} me - The speaker whose personality is being managed.
+   *
+   * @param me - The speaker whose personality is being managed.
    */
   constructor(me: Speaker) {
     this.me = me;
@@ -71,8 +72,9 @@ export class Personality {
 
   /**
    * Gets the value of the specified personality trait for the speaker from the database.
-   * @param {PersonalityTraits} trait - The trait to get the value of.
-   * @returns {number} The value of the trait.
+   *
+   * @param trait - The trait to get the value of.
+   * @returns The value of the trait.
    */
   getTrait(trait: PersonalityTraits): number {
     const traitSQL = DB.prepare(
@@ -83,6 +85,7 @@ export class Personality {
 
   /**
    * Normalizes the values of the personality traits.
+   *
    * This method adjusts the values of all personality traits (except 'immaturity')
    * so that their sum equals 1. The 'immaturity' trait is reduced by 10% in each normalization.
    */
@@ -125,8 +128,10 @@ export class Personality {
 
   /**
    * Increases the values of the specified personality traits for the speaker.
+   *
    * The 'immaturity' trait is reduced by 10% in each reinforcement.
-   * @param {PersonalityTraits[]} traits - The traits to reinforce.
+   *
+   * @param traits - The traits to reinforce.
    */
   reinforceTraits(traits: PersonalityTraits[]): void {
     if (traits.length === 0) {
@@ -156,7 +161,8 @@ export class Personality {
 
   /**
    * Gets the description of the speaker's personality.
-   * @returns {string} The description of the personality.
+   *
+   * @returns The description of the personality.
    */
   description(): string {
     return memoryService.getBeliefAbout(this.me.id, 'personality').description;

--- a/packages/converse/src/library/social/personality.ts
+++ b/packages/converse/src/library/social/personality.ts
@@ -18,83 +18,16 @@ export type PersonalityTraits =
   | 'demanding'
   | 'negotiator';
 
+/**
+ * Represents the personality of a speaker.
+ */
 export class Personality {
   me: Speaker;
 
-  getTrait(trait: PersonalityTraits): number {
-    const traitSQL = DB.prepare(
-      `SELECT ${trait} FROM personality WHERE noun_id = ?`
-    ).get(this.me.id) as { [id: string]: number };
-    return traitSQL[trait];
-  }
-
-  normalizeTraits() {
-    // Get all traits except 'immaturity' for normalization
-    const traits = [
-      'curiosity',
-      'chitChatter',
-      'openness',
-      'complimentary',
-      'insulting',
-      'funny',
-      'neutral',
-      'helpfulness',
-      'extroversion',
-      'generous',
-      'demanding',
-      'negotiator'
-    ] as const satisfies PersonalityTraits[];
-
-    const traitsSQL = traits
-      .map((trait) => `${trait} = ${trait} / (SELECT sum_val FROM total)`)
-      .join(', ');
-
-    const sql = `
-            WITH total AS (
-                SELECT (${traits.map((trait) => `${trait}`).join(' + ')}) AS sum_val
-                FROM personality
-                WHERE noun_id = :me_id
-            )
-            UPDATE personality
-            SET ${traitsSQL}, immaturity = immaturity * 0.9
-            WHERE noun_id = :me_id
-        `;
-
-    DB.prepare(sql).run({ me_id: this.me.id });
-  }
-
-  static traitsEverUsed: PersonalityTraits[] = [];
-
-  reinforceTraits(traits: PersonalityTraits[]) {
-    if (traits.length === 0) {
-      return;
-    }
-    for (const trait of traits) {
-      if (!Personality.traitsEverUsed.includes(trait)) {
-        Personality.traitsEverUsed.push(trait);
-      }
-    }
-
-    // Construct the part of the SQL that increments each trait by 0.1
-    const increments = traits
-      .map((trait) => `${trait} = ${trait} + immaturity`)
-      .join(', ');
-
-    // Add the immaturity multiplication to the end of the SET clause
-    const sql = `
-            UPDATE personality
-            SET ${increments}, immaturity = immaturity * 0.9
-            WHERE noun_id = :me_id
-        `;
-
-    DB.prepare(sql).run({ me_id: this.me.id });
-    this.normalizeTraits();
-  }
-
-  description() {
-    return memoryService.getBeliefAbout(this.me.id, 'personality').description;
-  }
-
+  /**
+   * Creates a new Personality instance.
+   * @param {Speaker} me - The speaker whose personality is being managed.
+   */
   constructor(me: Speaker) {
     this.me = me;
 
@@ -134,5 +67,97 @@ export class Personality {
     personalitySQL.run({ noun_id: me.id, ...defaultValues });
 
     this.normalizeTraits();
+  }
+
+  /**
+   * Gets the value of a specific personality trait.
+   * @param {PersonalityTraits} trait - The trait to get the value of.
+   * @returns {number} The value of the trait.
+   */
+  getTrait(trait: PersonalityTraits): number {
+    const traitSQL = DB.prepare(
+      `SELECT ${trait} FROM personality WHERE noun_id = ?`
+    ).get(this.me.id) as { [id: string]: number };
+    return traitSQL[trait];
+  }
+
+  /**
+   * Normalizes the values of the personality traits.
+   * This method adjusts the values of all personality traits (except 'immaturity')
+   * so that their sum equals 1. The 'immaturity' trait is reduced by 10% in each normalization.
+   */
+  normalizeTraits(): void {
+    // Get all traits except 'immaturity' for normalization
+    const traits = [
+      'curiosity',
+      'chitChatter',
+      'openness',
+      'complimentary',
+      'insulting',
+      'funny',
+      'neutral',
+      'helpfulness',
+      'extroversion',
+      'generous',
+      'demanding',
+      'negotiator'
+    ] as const satisfies PersonalityTraits[];
+
+    const traitsSQL = traits
+      .map((trait) => `${trait} = ${trait} / (SELECT sum_val FROM total)`)
+      .join(', ');
+
+    const sql = `
+            WITH total AS (
+                SELECT (${traits.map((trait) => `${trait}`).join(' + ')}) AS sum_val
+                FROM personality
+                WHERE noun_id = :me_id
+            )
+            UPDATE personality
+            SET ${traitsSQL}, immaturity = immaturity * 0.9
+            WHERE noun_id = :me_id
+        `;
+
+    DB.prepare(sql).run({ me_id: this.me.id });
+  }
+
+  static traitsEverUsed: PersonalityTraits[] = [];
+
+  /**
+   * Reinforces the specified personality traits.
+   * @param {PersonalityTraits[]} traits - The traits to reinforce.
+   */
+  reinforceTraits(traits: PersonalityTraits[]): void {
+    if (traits.length === 0) {
+      return;
+    }
+    for (const trait of traits) {
+      if (!Personality.traitsEverUsed.includes(trait)) {
+        Personality.traitsEverUsed.push(trait);
+      }
+    }
+
+    // Construct the part of the SQL that increments each trait by 0.1
+    const increments = traits
+      .map((trait) => `${trait} = ${trait} + immaturity`)
+      .join(', ');
+
+    // Add the immaturity multiplication to the end of the SET clause
+    const sql = `
+            UPDATE personality
+            SET ${increments}, immaturity = immaturity * 0.9
+            WHERE noun_id = :me_id
+        `;
+
+    DB.prepare(sql).run({ me_id: this.me.id });
+    this.normalizeTraits();
+  }
+
+  /**
+   * Gets the description of the personality.
+   * @returns {string} The description of the personality.
+   */
+  description(): string {
+    return memoryService.getBeliefAbout(this.me.id, 'personality').description;
   }
 }

--- a/packages/converse/src/library/social/personality.ts
+++ b/packages/converse/src/library/social/personality.ts
@@ -70,7 +70,7 @@ export class Personality {
   }
 
   /**
-   * Gets the value of a specific personality trait.
+   * Gets the value of the specified personality trait for the speaker from the database.
    * @param {PersonalityTraits} trait - The trait to get the value of.
    * @returns {number} The value of the trait.
    */
@@ -124,7 +124,8 @@ export class Personality {
   static traitsEverUsed: PersonalityTraits[] = [];
 
   /**
-   * Reinforces the specified personality traits.
+   * Increases the values of the specified personality traits for the speaker.
+   * The 'immaturity' trait is reduced by 10% in each reinforcement.
    * @param {PersonalityTraits[]} traits - The traits to reinforce.
    */
   reinforceTraits(traits: PersonalityTraits[]): void {
@@ -154,7 +155,7 @@ export class Personality {
   }
 
   /**
-   * Gets the description of the personality.
+   * Gets the description of the speaker's personality.
    * @returns {string} The description of the personality.
    */
   description(): string {

--- a/packages/converse/src/library/social/prompts/promptBuilder.ts
+++ b/packages/converse/src/library/social/prompts/promptBuilder.ts
@@ -5,9 +5,10 @@ import { current_date } from '../fantasyDate';
 
 /**
  * Cleans the response by removing unnecessary text and formatting.
- * @param {string} response - The response text to clean.
- * @param {string} name - The name to extract content after.
- * @returns {string} The cleaned response.
+ *
+ * @param response - The response text to clean.
+ * @param name - The name to extract content after.
+ * @returns The cleaned response.
  */
 export function cleanResponse(response: string, name: string): string {
   return stripTextBetweenParentheses(
@@ -22,97 +23,91 @@ export function cleanResponse(response: string, name: string): string {
 
 /**
  * Removes text after the first newline character in the input string.
- * @param {string} input - The input string.
- * @returns {string} The string with text after the first newline removed.
+ *
+ * @param input - The input string.
+ * @returns The trimmed string with text after the first newline removed.
  */
 export function removeTextAfterNewline(input: string): string {
-  // Find the index of the first newline character
   const newlineIndex = input.indexOf('\n');
 
   if (newlineIndex !== -1) {
-    // Extract everything before the newline character
     return input.slice(0, newlineIndex).trim();
   }
 
-  // If no newline is found, return the input trimmed
   return input.trim();
 }
 
 /**
  * Strips text between parentheses, including the parentheses, from the input string.
- * @param {string} input - The input string.
- * @returns {string} The string with text between parentheses removed.
+ *
+ * @param input - The input string.
+ * @returns The string with text between parentheses removed.
  */
 export function stripTextBetweenParentheses(input: string): string {
-  // Regular expression to match any text between parentheses, including the parentheses
   return input.replace(/\s*\([^)]*\)/g, '').trim();
 }
 
 /**
  * Collapses all whitespace characters (spaces, tabs, newlines, etc.) into a single space.
- * @param {string} input - The input string.
- * @returns {string} The string with collapsed whitespace.
+ *
+ * @param input - The input string.
+ * @returns The string with collapsed whitespace.
  */
 export function collapseWhitespace(input: string): string {
-  // Replace all whitespace characters (spaces, tabs, newlines, etc.) with a single space
   return input.replace(/\s+/g, ' ').trim();
 }
 
 /**
  * Trims quotes from the input string.
+ *
  * If the input contains content between double quotes, it returns the content inside the quotes.
  * Otherwise, it removes any lone quotes and trims the input.
- * @param {string} input - The input string.
- * @returns {string} The string with quotes trimmed.
+ *
+ * @param input - The input string.
+ * @returns The string with quotes trimmed.
  */
 export function trimQuotes(input: string): string {
-  // Regular expression to match content between double quotes
   const regex = /"([^"]*)"/;
   const match = input.match(regex);
 
   if (match && match[1]) {
-    // If content inside quotes is found, return it after trimming spaces
     return match[1].trim();
   }
 
-  // If no content inside quotes is found, remove any lone quotes and trim the input
   return input.replace(/"/g, '').trim();
 }
 
 /**
  * Extracts content after the first colon if the text before the colon matches the provided name.
+ *
  * If no colon is found, returns the input trimmed.
- * @param {string} input - The input string.
- * @param {string} name - The name to match before the colon.
- * @returns {string} The extracted content after the colon or the trimmed input.
+ *
+ * @param input - The input string.
+ * @param name - The name to match before the colon.
+ * @returns The extracted content after the colon or the trimmed input.
  */
 export function extractContentAfterColon(input: string, name: string): string {
-  // Find the index of the first colon
   const colonIndex = input.indexOf(':');
 
   if (colonIndex !== -1) {
-    // Extract everything before the colon
     const beforeColon = input.slice(0, colonIndex).trim();
 
-    // If the text before the colon matches the provided name, remove it and return the rest
     if (beforeColon === name) {
-      // Extract everything after the first colon, trim leading/trailing spaces
       return input.slice(colonIndex + 1).trim();
     } else {
-      // Keep the colon as part of the text
       return input.trim();
     }
   }
 
-  // If no colon is found, return the input trimmed
   return input.trim();
 }
 
 /**
  * Summarizes the conversation between two speakers.
- * @param {Speaker} subject - The subject speaker.
- * @param {Speaker} other - The other speaker.
- * @returns {string} The prompt for summarizing the conversation.
+ *
+ * @param subject - The subject speaker.
+ * @param other - The other speaker.
+ * @returns The prompt for summarizing the conversation.
  * @throws Will throw an error if the subject does not have a conversation.
  */
 export function summarizeConversation(
@@ -143,10 +138,11 @@ ${subject.name}'s Summary:`;
 
 /**
  * Builds the game state for the conversation context.
- * @param {Speaker} subject - The subject speaker.
- * @param {Speaker} otherPlayer - The other player in the conversation.
- * @param {Belief[]} context - The context of the conversation, including related memories and relationships.
- * @returns {string} The game state as a string.
+ *
+ * @param subject - The subject speaker.
+ * @param otherPlayer - The other player in the conversation.
+ * @param context - The context of the conversation, including related memories and relationships.
+ * @returns The game state as a string.
  * @throws Will throw an error if the subject does not have a conversation.
  */
 function buildGameState(
@@ -158,9 +154,7 @@ function buildGameState(
     throw new Error('Mob does not have a conversation');
   }
 
-  let gameState =
-    //buildGameState(world, subject) +
-    `Context:
+  let gameState = `Context:
       - This is a game in the style of 90s Super Nintendo RPGs, such as The Legend of Zelda or Final Fantasy.
       - Setting: We are in the land of Elyndra near the Silverclaw tribe. ${current_date().date_description}
       `;
@@ -198,10 +192,11 @@ Related Memories:
 
 /**
  * Builds a prompt for generating speech for an NPC.
- * @param {Speaker} subject - The NPC speaker.
- * @param {Speaker} otherPlayer - The other player involved in the conversation.
- * @param {SpeechAct} speechAct - The speech act to be generated.
- * @returns {string} The generated prompt.
+ *
+ * @param subject - The NPC speaker.
+ * @param otherPlayer - The other player involved in the conversation.
+ * @param speechAct - The speech act to be generated.
+ * @returns The generated prompt.
  */
 export function buildPromptForSpeech(
   subject: Speaker,
@@ -239,10 +234,11 @@ export function buildPromptForSpeech(
 
 /**
  * Builds prompts for multiple responses in a conversation.
- * @param {Speaker} subject - The subject speaker.
- * @param {Speaker} otherPlayer - The other player in the conversation.
- * @param {SpeechAct[]} responses - The array of speech acts to generate prompts for.
- * @returns {string[]} An array of generated prompts.
+ *
+ * @param subject - The subject speaker.
+ * @param otherPlayer - The other player in the conversation.
+ * @param responses - The array of speech acts to generate prompts for.
+ * @returns An array of generated prompts.
  * @throws Will throw an error if the subject does not have a conversation or if no responses are provided.
  */
 export function buildPromptsForResponses(
@@ -268,9 +264,10 @@ export function buildPromptsForResponses(
 
 /**
  * Parses a single response by cleaning it.
- * @param {string} data - The response data to be cleaned.
- * @param {string} name - The name to be used in the cleaning process.
- * @returns {string} The cleaned response.
+ *
+ * @param data - The response data to be cleaned.
+ * @param name - The name to be used in the cleaning process.
+ * @returns The cleaned response.
  */
 export function parseResponse(data: string, name: string): string {
   return cleanResponse(data, name);
@@ -278,9 +275,10 @@ export function parseResponse(data: string, name: string): string {
 
 /**
  * Parses multiple responses by cleaning each one.
- * @param {string[]} response - The array of response data to be cleaned.
- * @param {string} name - The name to be used in the cleaning process.
- * @returns {string[]} An array of cleaned responses.
+ *
+ * @param response - The array of response data to be cleaned.
+ * @param name - The name to be used in the cleaning process.
+ * @returns An array of cleaned responses.
  */
 export function parseMultiResponse(response: string[], name: string): string[] {
   return response.map((res) => cleanResponse(res, name));

--- a/packages/converse/src/library/social/prompts/promptBuilder.ts
+++ b/packages/converse/src/library/social/prompts/promptBuilder.ts
@@ -3,6 +3,12 @@ import { Belief } from '../memories/memoryService';
 import { SpeechAct } from '../speech/speechAct';
 import { current_date } from '../fantasyDate';
 
+/**
+ * Cleans the response by removing unnecessary text and formatting.
+ * @param {string} response - The response text to clean.
+ * @param {string} name - The name to extract content after.
+ * @returns {string} The cleaned response.
+ */
 export function cleanResponse(response: string, name: string): string {
   return stripTextBetweenParentheses(
     trimQuotes(
@@ -14,6 +20,11 @@ export function cleanResponse(response: string, name: string): string {
   );
 }
 
+/**
+ * Removes text after the first newline character in the input string.
+ * @param {string} input - The input string.
+ * @returns {string} The string with text after the first newline removed.
+ */
 export function removeTextAfterNewline(input: string): string {
   // Find the index of the first newline character
   const newlineIndex = input.indexOf('\n');
@@ -27,16 +38,33 @@ export function removeTextAfterNewline(input: string): string {
   return input.trim();
 }
 
+/**
+ * Strips text between parentheses, including the parentheses, from the input string.
+ * @param {string} input - The input string.
+ * @returns {string} The string with text between parentheses removed.
+ */
 export function stripTextBetweenParentheses(input: string): string {
   // Regular expression to match any text between parentheses, including the parentheses
   return input.replace(/\s*\([^)]*\)/g, '').trim();
 }
 
+/**
+ * Collapses all whitespace characters (spaces, tabs, newlines, etc.) into a single space.
+ * @param {string} input - The input string.
+ * @returns {string} The string with collapsed whitespace.
+ */
 export function collapseWhitespace(input: string): string {
   // Replace all whitespace characters (spaces, tabs, newlines, etc.) with a single space
   return input.replace(/\s+/g, ' ').trim();
 }
 
+/**
+ * Trims quotes from the input string.
+ * If the input contains content between double quotes, it returns the content inside the quotes.
+ * Otherwise, it removes any lone quotes and trims the input.
+ * @param {string} input - The input string.
+ * @returns {string} The string with quotes trimmed.
+ */
 export function trimQuotes(input: string): string {
   // Regular expression to match content between double quotes
   const regex = /"([^"]*)"/;
@@ -51,6 +79,13 @@ export function trimQuotes(input: string): string {
   return input.replace(/"/g, '').trim();
 }
 
+/**
+ * Extracts content after the first colon if the text before the colon matches the provided name.
+ * If no colon is found, returns the input trimmed.
+ * @param {string} input - The input string.
+ * @param {string} name - The name to match before the colon.
+ * @returns {string} The extracted content after the colon or the trimmed input.
+ */
 export function extractContentAfterColon(input: string, name: string): string {
   // Find the index of the first colon
   const colonIndex = input.indexOf(':');
@@ -73,6 +108,13 @@ export function extractContentAfterColon(input: string, name: string): string {
   return input.trim();
 }
 
+/**
+ * Summarizes the conversation between two speakers.
+ * @param {Speaker} subject - The subject speaker.
+ * @param {Speaker} other - The other speaker.
+ * @returns {string} The prompt for summarizing the conversation.
+ * @throws Will throw an error if the subject does not have a conversation.
+ */
 export function summarizeConversation(
   subject: Speaker,
   other: Speaker
@@ -99,6 +141,14 @@ ${subject.name}'s Summary:`;
   return prompt;
 }
 
+/**
+ * Builds the game state for the conversation context.
+ * @param {Speaker} subject - The subject speaker.
+ * @param {Speaker} otherPlayer - The other player in the conversation.
+ * @param {Belief[]} context - The context of the conversation, including related memories and relationships.
+ * @returns {string} The game state as a string.
+ * @throws Will throw an error if the subject does not have a conversation.
+ */
 function buildGameState(
   subject: Speaker,
   otherPlayer: Speaker,
@@ -146,6 +196,13 @@ Related Memories:
   return gameState;
 }
 
+/**
+ * Builds a prompt for generating speech for an NPC.
+ * @param {Speaker} subject - The NPC speaker.
+ * @param {Speaker} otherPlayer - The other player involved in the conversation.
+ * @param {SpeechAct} speechAct - The speech act to be generated.
+ * @returns {string} The generated prompt.
+ */
 export function buildPromptForSpeech(
   subject: Speaker,
   otherPlayer: Speaker,
@@ -180,6 +237,14 @@ export function buildPromptForSpeech(
   return prompt;
 }
 
+/**
+ * Builds prompts for multiple responses in a conversation.
+ * @param {Speaker} subject - The subject speaker.
+ * @param {Speaker} otherPlayer - The other player in the conversation.
+ * @param {SpeechAct[]} responses - The array of speech acts to generate prompts for.
+ * @returns {string[]} An array of generated prompts.
+ * @throws Will throw an error if the subject does not have a conversation or if no responses are provided.
+ */
 export function buildPromptsForResponses(
   subject: Speaker,
   otherPlayer: Speaker,
@@ -201,10 +266,22 @@ export function buildPromptsForResponses(
   return prompts;
 }
 
+/**
+ * Parses a single response by cleaning it.
+ * @param {string} data - The response data to be cleaned.
+ * @param {string} name - The name to be used in the cleaning process.
+ * @returns {string} The cleaned response.
+ */
 export function parseResponse(data: string, name: string): string {
   return cleanResponse(data, name);
 }
 
+/**
+ * Parses multiple responses by cleaning each one.
+ * @param {string[]} response - The array of response data to be cleaned.
+ * @param {string} name - The name to be used in the cleaning process.
+ * @returns {string[]} An array of cleaned responses.
+ */
 export function parseMultiResponse(response: string[], name: string): string[] {
   return response.map((res) => cleanResponse(res, name));
 }

--- a/packages/converse/src/library/social/prompts/promptService.ts
+++ b/packages/converse/src/library/social/prompts/promptService.ts
@@ -1,4 +1,14 @@
+/**
+ * Interface representing a dialog service for sending prompts.
+ */
 export interface Dialog {
+  /**
+   * Sends a prompt to the dialog service.
+   * @param {string[]} prompt - The prompt to send.
+   * @param {(data: string[]) => void} onMessage - Callback function to handle the response data.
+   * @param {(error: Error) => void} [onError] - Optional callback function to handle errors.
+   * @returns {Promise<void>} A promise that resolves when the prompt is sent.
+   */
   sendPrompt: (
     prompt: string[],
     onMessage: (data: string[]) => void,
@@ -6,6 +16,10 @@ export interface Dialog {
   ) => Promise<void>;
 }
 
+/**
+ * Initializes the dialog service with the provided dialog implementation.
+ * @param {Dialog} dialog - The dialog implementation to initialize.
+ */
 export function initializeDialog(dialog: Dialog): void {
   dialogService = dialog;
 }

--- a/packages/converse/src/library/social/prompts/promptService.ts
+++ b/packages/converse/src/library/social/prompts/promptService.ts
@@ -4,6 +4,7 @@
 export interface Dialog {
   /**
    * Sends a prompt to the dialog service.
+   *
    * @param {string[]} prompt - The prompt to send.
    * @param {(data: string[]) => void} onMessage - Callback function to handle the response data.
    * @param {(error: Error) => void} [onError] - Optional callback function to handle errors.
@@ -18,7 +19,8 @@ export interface Dialog {
 
 /**
  * Initializes the dialog service with the provided dialog implementation.
- * @param {Dialog} dialog - The dialog implementation to initialize.
+ *
+ * @param dialog - The dialog implementation to initialize.
  */
 export function initializeDialog(dialog: Dialog): void {
   dialogService = dialog;

--- a/packages/converse/src/library/social/speaker/databaseSpeaker.ts
+++ b/packages/converse/src/library/social/speaker/databaseSpeaker.ts
@@ -28,9 +28,10 @@ export class DatabaseSpeaker implements Speaker {
 
   /**
    * Creates an instance of DatabaseSpeaker.
-   * @param {string} id - The unique identifier for the speaker.
-   * @param {string} name - The name of the speaker.
-   * @param {string} type - The type/category of the speaker.
+   *
+   * @param id - The unique identifier for the speaker.
+   * @param name - The name of the speaker.
+   * @param type - The type/category of the speaker.
    */
   constructor(id: string, name: string, type: string) {
     this.id = id;
@@ -48,7 +49,8 @@ export class DatabaseSpeaker implements Speaker {
 
   /**
    * Retrieves the description belief about the speaker.
-   * @returns {Belief} The belief about the speaker's description.
+   *
+   * @returns The belief about the speaker's description.
    */
   description(): Belief {
     return memoryService.getBeliefAbout(this.id, 'description');
@@ -56,9 +58,10 @@ export class DatabaseSpeaker implements Speaker {
 
   /**
    * Calculates the benefit of a given item in a specified quantity for the speaker.
-   * @param {Item} item - The item to evaluate.
-   * @param {number} quantity - The quantity of the item.
-   * @returns {number} The calculated benefit of the item.
+   *
+   * @param item - The item to evaluate.
+   * @param quantity - The quantity of the item.
+   * @returns The calculated benefit of the item.
    */
   benefitOf(item: Item, quantity: number): number {
     const benefit = DB.prepare(
@@ -77,10 +80,11 @@ export class DatabaseSpeaker implements Speaker {
 
   /**
    * Finds a random desire for the speaker that meets the minimum value and is not already obligated.
-   * @param {Speaker} knownBy - The speaker who knows about the desire.
-   * @param {Speaker} givenBy - The speaker who would give the desired item.
-   * @param {number} minimumValue - The minimum benefit value for the desire.
-   * @returns {Desire | undefined} The found desire or undefined if no desire meets the criteria.
+   *
+   * @param knownBy - The speaker who knows about the desire.
+   * @param givenBy - The speaker who would give the desired item.
+   * @param minimumValue - The minimum benefit value for the desire.
+   * @returns The found desire or undefined if no desire meets the criteria.
    */
   findRandomDesire(
     knownBy: Speaker,
@@ -120,8 +124,9 @@ export class DatabaseSpeaker implements Speaker {
 
   /**
    * Loads a DatabaseSpeaker instance by name.
-   * @param {string} name - The name of the speaker to load.
-   * @returns {DatabaseSpeaker} The loaded DatabaseSpeaker instance.
+   *
+   * @param name - The name of the speaker to load.
+   * @returns The loaded DatabaseSpeaker instance.
    * @throws Will throw an error if no speaker with the given name is found.
    */
   static loadByName(name: string): DatabaseSpeaker {
@@ -153,9 +158,10 @@ export class DatabaseSpeaker implements Speaker {
 
   /**
    * Loads or creates a DatabaseSpeaker instance by ID.
-   * @param {string} id - The ID of the speaker to load or create.
-   * @param {string} name - The name of the speaker to create if not found.
-   * @returns {DatabaseSpeaker} The loaded or created DatabaseSpeaker instance.
+   *
+   * @param id - The ID of the speaker to load or create.
+   * @param name - The name of the speaker to create if not found.
+   * @returns The loaded or created DatabaseSpeaker instance.
    */
   static loadOrCreate(id: string, name: string): DatabaseSpeaker {
     // Query the database to retrieve the mob
@@ -189,8 +195,9 @@ export class DatabaseSpeaker implements Speaker {
 
   /**
    * Loads a DatabaseSpeaker instance by ID.
-   * @param {string} id - The ID of the speaker to load.
-   * @returns {DatabaseSpeaker} The loaded DatabaseSpeaker instance.
+   *
+   * @param id - The ID of the speaker to load.
+   * @returns The loaded DatabaseSpeaker instance.
    * @throws Will throw an error if no speaker with the given ID is found.
    */
   static load(id: string): DatabaseSpeaker {

--- a/packages/converse/src/library/social/speaker/databaseSpeaker.ts
+++ b/packages/converse/src/library/social/speaker/databaseSpeaker.ts
@@ -10,6 +10,9 @@ import { Relationships } from './relationships';
 import { Item } from './item';
 import { Speaker } from './speaker';
 
+/**
+ * Represents a speaker that interacts with the database.
+ */
 export class DatabaseSpeaker implements Speaker {
   id: string;
   name: string;
@@ -23,6 +26,12 @@ export class DatabaseSpeaker implements Speaker {
   goal: Goal;
   obligations: Obligations;
 
+  /**
+   * Creates an instance of DatabaseSpeaker.
+   * @param {string} id - The unique identifier for the speaker.
+   * @param {string} name - The name of the speaker.
+   * @param {string} type - The type/category of the speaker.
+   */
   constructor(id: string, name: string, type: string) {
     this.id = id;
     this.name = name;
@@ -37,10 +46,20 @@ export class DatabaseSpeaker implements Speaker {
     this.obligations = new Obligations(this);
   }
 
+  /**
+   * Retrieves the description belief about the speaker.
+   * @returns {Belief} The belief about the speaker's description.
+   */
   description(): Belief {
     return memoryService.getBeliefAbout(this.id, 'description');
   }
 
+  /**
+   * Calculates the benefit of a given item in a specified quantity for the speaker.
+   * @param {Item} item - The item to evaluate.
+   * @param {number} quantity - The quantity of the item.
+   * @returns {number} The calculated benefit of the item.
+   */
   benefitOf(item: Item, quantity: number): number {
     const benefit = DB.prepare(
       `
@@ -55,7 +74,14 @@ export class DatabaseSpeaker implements Speaker {
     }
     return 0;
   }
-  //  obligations (owed_id, owing_id, amount, item_id, by_tick)
+
+  /**
+   * Finds a random desire for the speaker that meets the minimum value and is not already obligated.
+   * @param {Speaker} knownBy - The speaker who knows about the desire.
+   * @param {Speaker} givenBy - The speaker who would give the desired item.
+   * @param {number} minimumValue - The minimum benefit value for the desire.
+   * @returns {Desire | undefined} The found desire or undefined if no desire meets the criteria.
+   */
   findRandomDesire(
     knownBy: Speaker,
     givenBy: Speaker,
@@ -92,6 +118,12 @@ export class DatabaseSpeaker implements Speaker {
     }
   }
 
+  /**
+   * Loads a DatabaseSpeaker instance by name.
+   * @param {string} name - The name of the speaker to load.
+   * @returns {DatabaseSpeaker} The loaded DatabaseSpeaker instance.
+   * @throws Will throw an error if no speaker with the given name is found.
+   */
   static loadByName(name: string): DatabaseSpeaker {
     const retrieveMob = DB.prepare(
       `
@@ -119,6 +151,12 @@ export class DatabaseSpeaker implements Speaker {
     );
   }
 
+  /**
+   * Loads or creates a DatabaseSpeaker instance by ID.
+   * @param {string} id - The ID of the speaker to load or create.
+   * @param {string} name - The name of the speaker to create if not found.
+   * @returns {DatabaseSpeaker} The loaded or created DatabaseSpeaker instance.
+   */
   static loadOrCreate(id: string, name: string): DatabaseSpeaker {
     // Query the database to retrieve the mob
     const retrieveMob = DB.prepare(
@@ -149,6 +187,12 @@ export class DatabaseSpeaker implements Speaker {
     return new DatabaseSpeaker(id, name, 'npc');
   }
 
+  /**
+   * Loads a DatabaseSpeaker instance by ID.
+   * @param {string} id - The ID of the speaker to load.
+   * @returns {DatabaseSpeaker} The loaded DatabaseSpeaker instance.
+   * @throws Will throw an error if no speaker with the given ID is found.
+   */
   static load(id: string): DatabaseSpeaker {
     // Query the database to retrieve the mob
     const retrieveMob = DB.prepare(

--- a/packages/converse/src/library/social/speaker/item.ts
+++ b/packages/converse/src/library/social/speaker/item.ts
@@ -1,3 +1,6 @@
+/**
+ * Represents an item with an ID and a name.
+ */
 export interface Item {
   id: string;
   name: string;

--- a/packages/converse/src/library/social/speaker/obligations.ts
+++ b/packages/converse/src/library/social/speaker/obligations.ts
@@ -5,10 +5,21 @@ import { Speaker } from './speaker';
 export class Obligations {
   private mob: Speaker;
 
+  /**
+   * Creates an instance of Obligations.
+   * @param {Speaker} mob - The speaker who has obligations.
+   */
   constructor(mob: Speaker) {
     this.mob = mob;
   }
 
+  /**
+   * Creates an obligation for the speaker to owe another speaker a certain amount of an item by a specific tick.
+   * @param {Speaker} owed - The speaker who is owed.
+   * @param {number} amount - The amount of the item owed.
+   * @param {Item} item - The item that is owed.
+   * @param {number} byTick - The tick by which the obligation must be fulfilled.
+   */
   obligate(owed: Speaker, amount: number, item: Item, byTick: number) {
     DB.prepare(
       `
@@ -26,6 +37,13 @@ export class Obligations {
     });
   }
 
+  /**
+   * Handles the given item and amount, updating the obligation accordingly.
+   * @param {Speaker} givenBy - The speaker who gave the item.
+   * @param {Item} item - The item that was given.
+   * @param {number} amount - The amount of the item that was given.
+   * @returns {number} The amount deducted from the obligation.
+   */
   given(givenBy: Speaker, item: Item, amount: number): number {
     const obligation = DB.prepare(
       `
@@ -66,6 +84,9 @@ export class Obligations {
     return deductedAmount;
   }
 
+  /**
+   * Processes overdue obligations, updating relationships and removing fulfilled obligations.
+   */
   tick() {
     // Fetch overdue obligations
     const overdueObligations = DB.prepare(

--- a/packages/converse/src/library/social/speaker/obligations.ts
+++ b/packages/converse/src/library/social/speaker/obligations.ts
@@ -7,7 +7,8 @@ export class Obligations {
 
   /**
    * Creates an instance of Obligations.
-   * @param {Speaker} mob - The speaker who has obligations.
+   *
+   * @param mob - The speaker who has obligations.
    */
   constructor(mob: Speaker) {
     this.mob = mob;
@@ -15,10 +16,11 @@ export class Obligations {
 
   /**
    * Creates an obligation for the speaker to owe another speaker a certain amount of an item by a specific tick.
-   * @param {Speaker} owed - The speaker who is owed.
-   * @param {number} amount - The amount of the item owed.
-   * @param {Item} item - The item that is owed.
-   * @param {number} byTick - The tick by which the obligation must be fulfilled.
+   *
+   * @param owed - The speaker who is owed.
+   * @param amount - The amount of the item owed.
+   * @param item - The item that is owed.
+   * @param byTick - The tick by which the obligation must be fulfilled.
    */
   obligate(owed: Speaker, amount: number, item: Item, byTick: number) {
     DB.prepare(
@@ -39,10 +41,11 @@ export class Obligations {
 
   /**
    * Handles the given item and amount, updating the obligation accordingly.
-   * @param {Speaker} givenBy - The speaker who gave the item.
-   * @param {Item} item - The item that was given.
-   * @param {number} amount - The amount of the item that was given.
-   * @returns {number} The amount deducted from the obligation.
+   *
+   * @param givenBy - The speaker who gave the item.
+   * @param item - The item that was given.
+   * @param amount - The amount of the item that was given.
+   * @returns The amount deducted from the obligation.
    */
   given(givenBy: Speaker, item: Item, amount: number): number {
     const obligation = DB.prepare(

--- a/packages/converse/src/library/social/speaker/relationships.ts
+++ b/packages/converse/src/library/social/speaker/relationships.ts
@@ -10,7 +10,8 @@ export class Relationships {
 
   /**
    * Creates an instance of Relationships.
-   * @param {Speaker} mob - The speaker instance representing the mob.
+   *
+   * @param mob - The speaker instance representing the mob.
    */
   constructor(mob: Speaker) {
     this.mob = mob;
@@ -18,7 +19,8 @@ export class Relationships {
 
   /**
    * Introduces the current mob to another mob, creating a relationship entry in the database.
-   * @param {Speaker} other - The other speaker instance to introduce to.
+   *
+   * @param other - The other speaker instance to introduce to.
    */
   introduce(other: Speaker) {
     const createRelationship = DB.prepare(`
@@ -35,8 +37,9 @@ export class Relationships {
 
   /**
    * Finds a special relationship (belief) between the current mob and another mob.
-   * @param {Speaker} other - The other speaker instance to find the relationship with.
-   * @returns {Belief} - The belief representing the special relationship.
+   *
+   * @param other - The other speaker instance to find the relationship with.
+   * @returns The belief representing the special relationship.
    */
   specialRelationshipWith(other: Speaker): Belief {
     const belief = memoryService.findConnectionBetweenNouns(
@@ -49,8 +52,9 @@ export class Relationships {
 
   /**
    * Updates the conversation summary between the current mob and another mob in the database.
-   * @param {Speaker} other - The other speaker instance to update the conversation summary with.
-   * @param {string} summary - The summary of the conversation.
+   *
+   * @param other - The other speaker instance to update the conversation summary with.
+   * @param summary - The summary of the conversation.
    */
   updateConversationSummary(other: Speaker, summary: string) {
     const updateRelationship = DB.prepare(`
@@ -67,8 +71,9 @@ export class Relationships {
 
   /**
    * Retrieves the conversation summary between the current mob and another mob from the database.
-   * @param {Speaker} other - The other speaker instance to get the conversation summary with.
-   * @returns {string} - The conversation summary.
+   *
+   * @param other - The other speaker instance to get the conversation summary with.
+   * @returns The conversation summary.
    */
   conversationSummaryWith(other: Speaker): string {
     const selectRelationship = DB.prepare(`
@@ -86,8 +91,9 @@ export class Relationships {
 
   /**
    * Selects the appropriate tones for the current mob when listening to another speaker.
-   * @param {Speaker} listening - The speaker instance that the current mob is listening to.
-   * @returns {Tone[]} - An array of tones selected based on various factors.
+   *
+   * @param listening - The speaker instance that the current mob is listening to.
+   * @returns An array of tones selected based on various factors.
    */
   selectTone(listening: Speaker): Tone[] {
     // Tone is a combination of:
@@ -120,8 +126,9 @@ export class Relationships {
 
   /**
    * Retrieves the affinity value between the current mob and another mob from the database.
-   * @param {Speaker} other - The other speaker instance to get the affinity with.
-   * @returns {number} - The affinity value.
+   *
+   * @param other - The other speaker instance to get the affinity with.
+   * @returns - The affinity value.
    */
   getAffinity(other: Speaker): number {
     const selectRelationship = DB.prepare(`
@@ -139,8 +146,9 @@ export class Relationships {
 
   /**
    * Modifies the relationship affinity between the current mob and another mob in the database.
-   * @param {Speaker} other - The other speaker instance to modify the relationship with.
-   * @param {number} affinity_change - The change in affinity value.
+   *
+   * @param other - The other speaker instance to modify the relationship with.
+   * @param affinity_change - The change in affinity value.
    */
   modifyRelationship(other: Speaker, affinity_change: number) {
     if (affinity_change === 0) {
@@ -161,8 +169,9 @@ export class Relationships {
 
   /**
    * Processes the current mob listening to another speaker's speech act, modifying the relationship accordingly.
-   * @param {Speaker} speaker - The speaker instance that the current mob is listening to.
-   * @param {SpeechAct} speechAct - The speech act being listened to.
+   *
+   * @param speaker - The speaker instance that the current mob is listening to.
+   * @param speechAct - The speech act being listened to.
    */
   listenTo(speaker: Speaker, speechAct: SpeechAct) {
     let affinityChange = 0;

--- a/packages/converse/src/library/social/speaker/relationships.ts
+++ b/packages/converse/src/library/social/speaker/relationships.ts
@@ -8,10 +8,18 @@ import { potentialTones } from '../speech/tones/toneFactory';
 export class Relationships {
   private mob: Speaker;
 
+  /**
+   * Creates an instance of Relationships.
+   * @param {Speaker} mob - The speaker instance representing the mob.
+   */
   constructor(mob: Speaker) {
     this.mob = mob;
   }
 
+  /**
+   * Introduces the current mob to another mob, creating a relationship entry in the database.
+   * @param {Speaker} other - The other speaker instance to introduce to.
+   */
   introduce(other: Speaker) {
     const createRelationship = DB.prepare(`
             INSERT OR IGNORE INTO
@@ -25,6 +33,11 @@ export class Relationships {
     });
   }
 
+  /**
+   * Finds a special relationship (belief) between the current mob and another mob.
+   * @param {Speaker} other - The other speaker instance to find the relationship with.
+   * @returns {Belief} - The belief representing the special relationship.
+   */
   specialRelationshipWith(other: Speaker): Belief {
     const belief = memoryService.findConnectionBetweenNouns(
       this.mob.id,
@@ -34,6 +47,11 @@ export class Relationships {
     return belief;
   }
 
+  /**
+   * Updates the conversation summary between the current mob and another mob in the database.
+   * @param {Speaker} other - The other speaker instance to update the conversation summary with.
+   * @param {string} summary - The summary of the conversation.
+   */
   updateConversationSummary(other: Speaker, summary: string) {
     const updateRelationship = DB.prepare(`
             UPDATE relationships 
@@ -47,6 +65,11 @@ export class Relationships {
     });
   }
 
+  /**
+   * Retrieves the conversation summary between the current mob and another mob from the database.
+   * @param {Speaker} other - The other speaker instance to get the conversation summary with.
+   * @returns {string} - The conversation summary.
+   */
   conversationSummaryWith(other: Speaker): string {
     const selectRelationship = DB.prepare(`
             SELECT conversation_summary
@@ -61,6 +84,11 @@ export class Relationships {
     return row?.conversation_summary ?? '';
   }
 
+  /**
+   * Selects the appropriate tones for the current mob when listening to another speaker.
+   * @param {Speaker} listening - The speaker instance that the current mob is listening to.
+   * @returns {Tone[]} - An array of tones selected based on various factors.
+   */
   selectTone(listening: Speaker): Tone[] {
     // Tone is a combination of:
     // - What the subject is (are they positive or negative towards the subject)
@@ -90,6 +118,11 @@ export class Relationships {
     return sortedTones.map(([tone]) => tone);
   }
 
+  /**
+   * Retrieves the affinity value between the current mob and another mob from the database.
+   * @param {Speaker} other - The other speaker instance to get the affinity with.
+   * @returns {number} - The affinity value.
+   */
   getAffinity(other: Speaker): number {
     const selectRelationship = DB.prepare(`
             SELECT (2.0 / (1.0 + exp(-0.05 * raw_affinity)) - 1.0) AS affinity
@@ -104,6 +137,11 @@ export class Relationships {
     return relationship ? relationship.affinity : 0;
   }
 
+  /**
+   * Modifies the relationship affinity between the current mob and another mob in the database.
+   * @param {Speaker} other - The other speaker instance to modify the relationship with.
+   * @param {number} affinity_change - The change in affinity value.
+   */
   modifyRelationship(other: Speaker, affinity_change: number) {
     if (affinity_change === 0) {
       return;
@@ -121,6 +159,11 @@ export class Relationships {
     });
   }
 
+  /**
+   * Processes the current mob listening to another speaker's speech act, modifying the relationship accordingly.
+   * @param {Speaker} speaker - The speaker instance that the current mob is listening to.
+   * @param {SpeechAct} speechAct - The speech act being listened to.
+   */
   listenTo(speaker: Speaker, speechAct: SpeechAct) {
     let affinityChange = 0;
 

--- a/packages/converse/src/library/social/speaker/speaker.ts
+++ b/packages/converse/src/library/social/speaker/speaker.ts
@@ -26,27 +26,9 @@ export interface Speaker {
 
   personality: Personality;
 
-  /**
-   * Provides a description of the speaker.
-   * @returns {Belief} The belief representing the description.
-   */
   description(): Belief;
 
-  /**
-   * Calculates the benefit of an item to the speaker.
-   * @param {Item} item - The item to evaluate.
-   * @param {number} quantity - The quantity of the item.
-   * @returns {number} The calculated benefit.
-   */
   benefitOf(item: Item, quantity: number): number;
-
-  /**
-   * Finds a random desire of the speaker.
-   * @param {Speaker} knownBy - The speaker who knows the desire.
-   * @param {Speaker} givenBy - The speaker who gives the desire.
-   * @param {number} minimumValue - The minimum value of the desire.
-   * @returns {Desire | undefined} The found desire or undefined.
-   */
   findRandomDesire(
     knownBy: Speaker,
     givenBy: Speaker,

--- a/packages/converse/src/library/social/speaker/speaker.ts
+++ b/packages/converse/src/library/social/speaker/speaker.ts
@@ -8,6 +8,9 @@ import { Personality } from '../personality';
 import { Relationships } from './relationships';
 import { Item } from './item';
 
+/**
+ * Interface representing a speaker in the system.
+ */
 export interface Speaker {
   id: string;
   name: string;
@@ -23,9 +26,27 @@ export interface Speaker {
 
   personality: Personality;
 
+  /**
+   * Provides a description of the speaker.
+   * @returns {Belief} The belief representing the description.
+   */
   description(): Belief;
 
+  /**
+   * Calculates the benefit of an item to the speaker.
+   * @param {Item} item - The item to evaluate.
+   * @param {number} quantity - The quantity of the item.
+   * @returns {number} The calculated benefit.
+   */
   benefitOf(item: Item, quantity: number): number;
+
+  /**
+   * Finds a random desire of the speaker.
+   * @param {Speaker} knownBy - The speaker who knows the desire.
+   * @param {Speaker} givenBy - The speaker who gives the desire.
+   * @param {number} minimumValue - The minimum value of the desire.
+   * @returns {Desire | undefined} The found desire or undefined.
+   */
   findRandomDesire(
     knownBy: Speaker,
     givenBy: Speaker,

--- a/packages/converse/src/library/social/speaker/speakerService.ts
+++ b/packages/converse/src/library/social/speaker/speakerService.ts
@@ -4,24 +4,8 @@ import { Speaker } from './speaker';
  * Interface representing the speaker service.
  */
 export interface SpeakerService {
-  /**
-   * Closes the chat between the specified mob and target.
-   * @param {string} mobKey - The key of the mob.
-   * @param {string} target - The target to close the chat with.
-   */
   closeChat(mobKey: string, target: string): void;
 
-  /**
-   * Provides possible responses for the speaker.
-   * @param {Speaker} speaker - The speaker instance.
-   * @param {string[]} responses - The possible responses.
-   */
   possibleResponses(speaker: Speaker, responses: string[]): void;
-
-  /**
-   * Makes the speaker say the given response.
-   * @param {Speaker} speaker - The speaker instance.
-   * @param {string} response - The response to say.
-   */
   speak(speaker: Speaker, response: string): void;
 }

--- a/packages/converse/src/library/social/speaker/speakerService.ts
+++ b/packages/converse/src/library/social/speaker/speakerService.ts
@@ -1,8 +1,27 @@
 import { Speaker } from './speaker';
 
+/**
+ * Interface representing the speaker service.
+ */
 export interface SpeakerService {
+  /**
+   * Closes the chat between the specified mob and target.
+   * @param {string} mobKey - The key of the mob.
+   * @param {string} target - The target to close the chat with.
+   */
   closeChat(mobKey: string, target: string): void;
 
+  /**
+   * Provides possible responses for the speaker.
+   * @param {Speaker} speaker - The speaker instance.
+   * @param {string[]} responses - The possible responses.
+   */
   possibleResponses(speaker: Speaker, responses: string[]): void;
+
+  /**
+   * Makes the speaker say the given response.
+   * @param {Speaker} speaker - The speaker instance.
+   * @param {string} response - The response to say.
+   */
   speak(speaker: Speaker, response: string): void;
 }

--- a/packages/converse/src/library/social/speech/responses/acceptOffer.ts
+++ b/packages/converse/src/library/social/speech/responses/acceptOffer.ts
@@ -2,7 +2,19 @@ import { Speaker } from '../../speaker/speaker';
 import { SpeechPart } from '../speechPart';
 import { SpeechResponse } from './speechResponse';
 
+/**
+ * Represents a response to accept an offer in a conversation.
+ */
 export class AcceptOffer implements SpeechResponse {
+  /**
+   * Creates potential speech responses for accepting an offer.
+   *
+   * @param inResponseTo - The speech part being responded to.
+   * @param speaking - The speaker accepting the offer.
+   * @param listening - The listener of the acceptance.
+   * @param _alreadyTraversed - The list of already traversed topics.
+   * @returns The potential speech parts for the acceptance response.
+   */
   createPotentialSpeechResponse(
     inResponseTo: SpeechPart,
     speaking: Speaker,

--- a/packages/converse/src/library/social/speech/responses/answer.ts
+++ b/packages/converse/src/library/social/speech/responses/answer.ts
@@ -3,7 +3,19 @@ import { Speaker } from '../../speaker/speaker';
 import { SpeechPart } from '../speechPart';
 import { SpeechResponse } from './speechResponse';
 
+/**
+ * Represents a response to answer a question in a conversation.
+ */
 export class Answer implements SpeechResponse {
+  /**
+   * Creates potential speech responses for answering a question.
+   *
+   * @param inResponseTo - The speech part being responded to.
+   * @param speaking - The speaker answering the question.
+   * @param listening - The listener of the answer.
+   * @param _alreadyTraversed - The list of already traversed topics.
+   * @returns The potential speech parts for the answer response.
+   */
   createPotentialSpeechResponse(
     inResponseTo: SpeechPart,
     speaking: Speaker,

--- a/packages/converse/src/library/social/speech/responses/counterOffer.ts
+++ b/packages/converse/src/library/social/speech/responses/counterOffer.ts
@@ -4,7 +4,19 @@ import { SpeechResponse } from './speechResponse';
 
 const PROPOSALS_TO_EVALUATE = 5;
 
+/**
+ * Represents a response to make a counter offer in a conversation.
+ */
 export class CounterOffer implements SpeechResponse {
+  /**
+   * Creates potential speech responses for making a counter offer.
+   *
+   * @param inResponseTo - The speech part being responded to.
+   * @param speaking - The speaker making the counter offer.
+   * @param listening - The listener of the counter offer.
+   * @param alreadyTraversed - The list of already traversed topics.
+   * @returns The potential speech parts for the counter offer response.
+   */
   createPotentialSpeechResponse(
     inResponseTo: SpeechPart,
     speaking: Speaker,

--- a/packages/converse/src/library/social/speech/responses/offerMore.ts
+++ b/packages/converse/src/library/social/speech/responses/offerMore.ts
@@ -4,7 +4,19 @@ import { SpeechResponse } from './speechResponse';
 
 const PROPOSALS_TO_EVALUATE = 5;
 
+/**
+ * Represents a response to offer more in a conversation.
+ */
 export class OfferMore implements SpeechResponse {
+  /**
+   * Creates potential speech responses for offering more.
+   *
+   * @param inResponseTo - The speech part being responded to.
+   * @param speaking - The speaker offering more.
+   * @param listening - The listener of the offer.
+   * @param alreadyTraversed - The list of already traversed topics.
+   * @returns The potential speech parts for the offer response.
+   */
   createPotentialSpeechResponse(
     inResponseTo: SpeechPart,
     speaking: Speaker,

--- a/packages/converse/src/library/social/speech/responses/react.ts
+++ b/packages/converse/src/library/social/speech/responses/react.ts
@@ -2,7 +2,19 @@ import { Speaker } from '../../speaker/speaker';
 import { SpeechPart } from '../speechPart';
 import { SpeechResponse } from './speechResponse';
 
+/**
+ * Represents a response to react to a statement in a conversation.
+ */
 export class React implements SpeechResponse {
+  /**
+   * Creates potential speech responses for reacting to a statement.
+   *
+   * @param inResponseTo - The speech part being responded to.
+   * @param speaking - The speaker reacting to the statement.
+   * @param listening - The listener of the reaction.
+   * @param _alreadyTraversed - The list of already traversed topics.
+   * @returns The potential speech parts for the reaction response.
+   */
   createPotentialSpeechResponse(
     inResponseTo: SpeechPart,
     speaking: Speaker,

--- a/packages/converse/src/library/social/speech/responses/rejectOffer.ts
+++ b/packages/converse/src/library/social/speech/responses/rejectOffer.ts
@@ -2,7 +2,19 @@ import { Speaker } from '../../speaker/speaker';
 import { SpeechPart } from '../speechPart';
 import { SpeechResponse } from './speechResponse';
 
+/**
+ * Represents a response to reject an offer in a conversation.
+ */
 export class RejectOffer implements SpeechResponse {
+  /**
+   * Creates potential speech responses for rejecting an offer.
+   *
+   * @param inResponseTo - The speech part being responded to.
+   * @param speaking - The speaker rejecting the offer.
+   * @param listening - The listener of the rejection.
+   * @param _alreadyTraversed - The list of already traversed topics.
+   * @returns The potential speech parts for the rejection response.
+   */
   createPotentialSpeechResponse(
     inResponseTo: SpeechPart,
     speaking: Speaker,

--- a/packages/converse/src/library/social/speech/responses/speechResponse.ts
+++ b/packages/converse/src/library/social/speech/responses/speechResponse.ts
@@ -1,6 +1,9 @@
 import { Speaker } from '../../speaker/speaker';
 import { SpeechPart } from '../speechPart';
 
+/**
+ * Interface representing a speech response.
+ */
 export interface SpeechResponse {
   createPotentialSpeechResponse(
     inResponseTo: SpeechPart,

--- a/packages/converse/src/library/social/speech/speechAct.ts
+++ b/packages/converse/src/library/social/speech/speechAct.ts
@@ -5,6 +5,9 @@ import { Speaker } from '../speaker/speaker';
 import { SpeechPart } from './speechPart';
 import { Tone } from './tones/tone';
 
+/**
+ * Represents a speech act in a conversation.
+ */
 export class SpeechAct {
   private readonly spokenBy: Speaker;
   private readonly spokenTo: Speaker;
@@ -80,18 +83,38 @@ export class SpeechAct {
     }
   }
 
+  /**
+   * Gets the initiative speech part.
+   *
+   * @returns The initiative speech part.
+   */
   getInitiative(): SpeechPart {
     return this.initiative;
   }
 
+  /**
+   * Gets the proposal associated with the speech act.
+   *
+   * @returns The proposal, or undefined if none exists.
+   */
   getProposal(): Proposal | undefined {
     return this.proposal;
   }
 
+  /**
+   * Checks if the speech act is a goodbye.
+   *
+   * @returns True if it is a goodbye, false otherwise.
+   */
   isGoodbye(): boolean {
     return this.initiative.isGoodbye();
   }
 
+  /**
+   * Calculates the benefit to the listener.
+   *
+   * @returns The benefit to the listener.
+   */
   benefitToListener(): number {
     return (
       this.initiative.getBenefitToListener() +
@@ -99,22 +122,47 @@ export class SpeechAct {
     );
   }
 
+  /**
+   * Gets the value of the speech act.
+   *
+   * @returns The value of the speech act.
+   */
   getValue(): number {
     return this.value;
   }
 
+  /**
+   * Gets the context of the speech act.
+   *
+   * @returns The context of the speech act.
+   */
   getContext(): Belief[] {
     return this.context;
   }
 
+  /**
+   * Sets the text of the speech act.
+   *
+   * @param text - The text to set.
+   */
   setText(text: string) {
     this.text = text;
   }
 
+  /**
+   * Gets the text of the speech act.
+   *
+   * @returns The text of the speech act.
+   */
   getText(): string {
     return this.text ? this.text : this.getPrompt();
   }
 
+  /**
+   * Gets the tones of the speech act.
+   *
+   * @returns The tones of the speech act.
+   */
   getTones(): Tone[] {
     const tones: Tone[] = [];
     tones.push(this.initiative.getTone());
@@ -124,6 +172,9 @@ export class SpeechAct {
     return tones;
   }
 
+  /**
+   * Applies the effects of the speech act.
+   */
   doEffects() {
     this.spokenTo.relationships.listenTo(this.spokenBy, this);
 
@@ -140,14 +191,29 @@ export class SpeechAct {
     }
   }
 
+  /**
+   * Gets the personality traits used in the speech act.
+   *
+   * @returns The personality traits used.
+   */
   getTraits(): PersonalityTraits[] {
     return this.personalityTraitsUse;
   }
 
+  /**
+   * Gets the topics of the speech act.
+   *
+   * @returns The topics of the speech act.
+   */
   getTopics(): string[] {
     return this.topics;
   }
 
+  /**
+   * Gets the prompt of the speech act.
+   *
+   * @returns The prompt of the speech act.
+   */
   getPrompt() {
     if (this.response) {
       return (
@@ -158,6 +224,11 @@ export class SpeechAct {
     }
   }
 
+  /**
+   * Gets the memories conveyed in the speech act.
+   *
+   * @returns The memories conveyed.
+   */
   getMemoriesConveyed(): Belief[] {
     return this.memoriesConveyed;
   }

--- a/packages/converse/src/library/social/speech/speechFactory.ts
+++ b/packages/converse/src/library/social/speech/speechFactory.ts
@@ -17,6 +17,9 @@ import { SpeechResponse } from './responses/speechResponse';
 import { ExpressFeelings } from './starts/expressFeelings';
 import { SpeechAct } from './speechAct';
 
+/**
+ * Factory for creating speech acts, starts, and responses.
+ */
 export class SpeechFactory {
   potentialSpeechStarts: SpeechStart[] = [];
   potentialSpeechResponses: SpeechResponse[] = [];
@@ -39,6 +42,14 @@ export class SpeechFactory {
     this.potentialSpeechResponses.push(new RejectOffer());
   }
 
+  /**
+   * Creates potential speech starts.
+   *
+   * @param speaking - The speaker initiating the speech act.
+   * @param listening - The listener of the speech act.
+   * @param alreadyTraversed - The list of already traversed topics.
+   * @returns The potential speech parts for the speech act.
+   */
   static createPotentialSpeechStarts(
     speaking: Speaker,
     listening: Speaker,
@@ -54,6 +65,15 @@ export class SpeechFactory {
     return speechActs;
   }
 
+  /**
+   * Creates potential speech responses.
+   *
+   * @param inResponseTo - The speech part being responded to.
+   * @param speaking - The speaker making the response.
+   * @param listening - The listener of the response.
+   * @param alreadyTraversed - The list of already traversed topics.
+   * @returns The potential speech parts for the response.
+   */
   static createPotentialSpeechResponses(
     inResponseTo: SpeechPart,
     speaking: Speaker,
@@ -75,6 +95,15 @@ export class SpeechFactory {
     return speechActs;
   }
 
+  /**
+   * Creates potential speech acts.
+   *
+   * @param inResponseTo - The speech part being responded to, or null if initiating.
+   * @param speaking - The speaker initiating or responding.
+   * @param listening - The listener of the speech act.
+   * @param alreadyTraversed - The list of already traversed topics.
+   * @returns The potential speech acts.
+   */
   static createPotentialSpeechActs(
     inResponseTo: SpeechPart | null,
     speaking: Speaker,

--- a/packages/converse/src/library/social/speech/speechPart.ts
+++ b/packages/converse/src/library/social/speech/speechPart.ts
@@ -5,6 +5,9 @@ import { neutralTone } from './tones/toneFactory';
 import { PersonalityTraits } from '../personality';
 import { Belief, Question } from '../memories/memoryService';
 
+/**
+ * Represents a part of a speech in a conversation.
+ */
 export class SpeechPart {
   private prompt: string;
 
@@ -24,6 +27,15 @@ export class SpeechPart {
   private finished: boolean = false;
   canBeChained: boolean = false;
 
+  /**
+   * Constructs a SpeechPart instance.
+   *
+   * @param trait - The personality trait used in the speech part.
+   * @param speaker - The speaker of the speech part.
+   * @param listener - The listener of the speech part.
+   * @param prompt - The prompt text of the speech part.
+   * @param offer - The proposal associated with the speech part, if any.
+   */
   constructor(
     trait: PersonalityTraits,
     speaker: Speaker,
@@ -38,6 +50,16 @@ export class SpeechPart {
     this.listener = listener;
   }
 
+  /**
+   * Builds a question speech part.
+   *
+   * @param trait - The personality trait used in the speech part.
+   * @param speaker - The speaker of the speech part.
+   * @param listener - The listener of the speech part.
+   * @param prompt - The prompt text of the speech part.
+   * @param question - The question associated with the speech part.
+   * @returns The constructed question speech part.
+   */
   static buildQuestion(
     trait: PersonalityTraits,
     speaker: Speaker,
@@ -50,6 +72,16 @@ export class SpeechPart {
     return speech;
   }
 
+  /**
+   * Builds a statement speech part.
+   *
+   * @param trait - The personality trait used in the speech part.
+   * @param speaker - The speaker of the speech part.
+   * @param listener - The listener of the speech part.
+   * @param prompt - The prompt text of the speech part.
+   * @param belief - The belief associated with the speech part.
+   * @returns The constructed statement speech part.
+   */
   static buildStatement(
     trait: PersonalityTraits,
     speaker: Speaker,
@@ -62,6 +94,16 @@ export class SpeechPart {
     return speech;
   }
 
+  /**
+   * Builds an offer speech part.
+   *
+   * @param trait - The personality trait used in the speech part.
+   * @param speaker - The speaker of the speech part.
+   * @param listener - The listener of the speech part.
+   * @param prompt - The prompt text of the speech part.
+   * @param offer - The proposal associated with the speech part.
+   * @returns The constructed offer speech part.
+   */
   static buildOffer(
     trait: PersonalityTraits,
     speaker: Speaker,
@@ -72,26 +114,56 @@ export class SpeechPart {
     return new SpeechPart(trait, speaker, listener, prompt, offer);
   }
 
+  /**
+   * Gets the memory conveyed in the speech part.
+   *
+   * @returns The memory conveyed, or undefined if none exists.
+   */
   getMemoryConveyed(): Belief | undefined {
     return this.memoriesConveyed;
   }
 
+  /**
+   * Gets the question associated with the speech part.
+   *
+   * @returns The question, or undefined if none exists.
+   */
   getQuestionOn(): Question | undefined {
     return this.questionOn;
   }
 
+  /**
+   * Sets the tone of the speech part.
+   *
+   * @param tone - The tone to set.
+   */
   setTone(tone: Tone) {
     this.tone = tone;
   }
 
+  /**
+   * Gets the tone of the speech part.
+   *
+   * @returns The tone of the speech part.
+   */
   getTone(): Tone {
     return this.tone;
   }
 
+  /**
+   * Gets the benefit to the listener of the speech part.
+   *
+   * @returns The benefit to the listener.
+   */
   getBenefitToListener(): number {
     return this.memoriesConveyed ? 1 : 0 + this.tone.valence();
   }
 
+  /**
+   * Calculates the value of the speech part.
+   *
+   * @returns The value of the speech part.
+   */
   value(): number {
     let value = 0;
     const affinityWith = this.speaker.relationships.getAffinity(this.listener);
@@ -119,14 +191,29 @@ export class SpeechPart {
     return value;
   }
 
+  /**
+   * Checks if the speech part is making a statement.
+   *
+   * @returns True if making a statement, false otherwise.
+   */
   isMakingStatement(): boolean {
     return this.memoriesConveyed !== undefined;
   }
 
+  /**
+   * Checks if the speech part is a question.
+   *
+   * @returns True if it is a question, false otherwise.
+   */
   isQuestion(): boolean {
     return this.questionOn !== undefined;
   }
 
+  /**
+   * Checks if the speech part is a goodbye.
+   *
+   * @returns True if it is a goodbye, false otherwise.
+   */
   isGoodbye(): boolean {
     return (
       !this.isMakingStatement() &&
@@ -135,15 +222,29 @@ export class SpeechPart {
     );
   }
 
-  // Retrieve the speech text for use in conversation
+  /**
+   * Gets the prompt text of the speech part.
+   *
+   * @returns The prompt text.
+   */
   getPrompt(): string {
     return this.prompt;
   }
 
+  /**
+   * Checks if the speech part is negotiating an offer.
+   *
+   * @returns True if negotiating an offer, false otherwise.
+   */
   isNegotiatingOffer(): boolean {
     return this.offer !== undefined;
   }
 
+  /**
+   * Gets the proposal associated with the speech part.
+   *
+   * @returns The proposal, or undefined if none exists.
+   */
   getProposal(): Proposal | undefined {
     return this.offer;
   }

--- a/packages/converse/src/library/social/speech/starts/askAbout.ts
+++ b/packages/converse/src/library/social/speech/starts/askAbout.ts
@@ -3,12 +3,27 @@ import { Speaker } from '../../speaker/speaker';
 import { SpeechPart } from '../speechPart';
 import { SpeechStart } from './speechStart';
 
+/**
+ * Replaces all occurrences of "<subject>" in the input string with the replacement string.
+ * @param {string} input - The input string containing "<subject>" placeholders.
+ * @param {string} replacement - The string to replace "<subject>" with.
+ * @returns {string} The modified string.
+ */
 function replaceSubject(input: string, replacement: string): string {
-  // Replace all occurrences of "<subject>" with the replacement string
   return input.replace(/<subject>/g, replacement);
 }
 
+/**
+ * Represents aspeech start that asks about something.
+ */
 export class AskAbout implements SpeechStart {
+  /**
+   * Creates potential speech acts for asking about a topic.
+   * @param {Speaker} speaking - The speaker initiating the speech act.
+   * @param {Speaker} listening - The listener of the speech act.
+   * @param {string[]} alreadyTraversed - The list of already traversed topics.
+   * @returns {SpeechPart[]} The potential speech parts for the speech act.
+   */
   createPotentialSpeechAct(
     speaking: Speaker,
     listening: Speaker,

--- a/packages/converse/src/library/social/speech/starts/askAbout.ts
+++ b/packages/converse/src/library/social/speech/starts/askAbout.ts
@@ -5,9 +5,10 @@ import { SpeechStart } from './speechStart';
 
 /**
  * Replaces all occurrences of "<subject>" in the input string with the replacement string.
- * @param {string} input - The input string containing "<subject>" placeholders.
- * @param {string} replacement - The string to replace "<subject>" with.
- * @returns {string} The modified string.
+ *
+ * @param input - The input string containing "<subject>" placeholders.
+ * @param replacement - The string to replace "<subject>" with.
+ * @returns The modified string.
  */
 function replaceSubject(input: string, replacement: string): string {
   return input.replace(/<subject>/g, replacement);
@@ -19,10 +20,11 @@ function replaceSubject(input: string, replacement: string): string {
 export class AskAbout implements SpeechStart {
   /**
    * Creates potential speech acts for asking about a topic.
-   * @param {Speaker} speaking - The speaker initiating the speech act.
-   * @param {Speaker} listening - The listener of the speech act.
-   * @param {string[]} alreadyTraversed - The list of already traversed topics.
-   * @returns {SpeechPart[]} The potential speech parts for the speech act.
+   *
+   * @param speaking - The speaker initiating the speech act.
+   * @param listening - The listener of the speech act.
+   * @param alreadyTraversed - The list of already traversed topics.
+   * @returns The potential speech parts for the speech act.
    */
   createPotentialSpeechAct(
     speaking: Speaker,

--- a/packages/converse/src/library/social/speech/starts/expressFeelings.ts
+++ b/packages/converse/src/library/social/speech/starts/expressFeelings.ts
@@ -9,6 +9,7 @@ import { SpeechStart } from './speechStart';
 export class ExpressFeelings implements SpeechStart {
   /**
    * Creates potential speech acts for expressing feelings.
+   *
    * @param speaking - The speaker initiating the speech act.
    * @param listening - The listener of the speech act.
    * @param alreadyTraversed - The list of already traversed topics.

--- a/packages/converse/src/library/social/speech/starts/expressFeelings.ts
+++ b/packages/converse/src/library/social/speech/starts/expressFeelings.ts
@@ -9,10 +9,10 @@ import { SpeechStart } from './speechStart';
 export class ExpressFeelings implements SpeechStart {
   /**
    * Creates potential speech acts for expressing feelings.
-   * @param {Speaker} speaking - The speaker initiating the speech act.
-   * @param {Speaker} listening - The listener of the speech act.
-   * @param {string[]} alreadyTraversed - The list of already traversed topics.
-   * @returns {SpeechPart[]} The potential speech parts for the speech act.
+   * @param speaking - The speaker initiating the speech act.
+   * @param listening - The listener of the speech act.
+   * @param alreadyTraversed - The list of already traversed topics.
+   * @returns The potential speech parts for the speech act.
    */
   createPotentialSpeechAct(
     speaking: Speaker,

--- a/packages/converse/src/library/social/speech/starts/expressFeelings.ts
+++ b/packages/converse/src/library/social/speech/starts/expressFeelings.ts
@@ -3,7 +3,17 @@ import { Speaker } from '../../speaker/speaker';
 import { SpeechPart } from '../speechPart';
 import { SpeechStart } from './speechStart';
 
+/**
+ * Represents a speech start that expresses feelings.
+ */
 export class ExpressFeelings implements SpeechStart {
+  /**
+   * Creates potential speech acts for expressing feelings.
+   * @param {Speaker} speaking - The speaker initiating the speech act.
+   * @param {Speaker} listening - The listener of the speech act.
+   * @param {string[]} alreadyTraversed - The list of already traversed topics.
+   * @returns {SpeechPart[]} The potential speech parts for the speech act.
+   */
   createPotentialSpeechAct(
     speaking: Speaker,
     listening: Speaker,

--- a/packages/converse/src/library/social/speech/starts/gift.ts
+++ b/packages/converse/src/library/social/speech/starts/gift.ts
@@ -9,10 +9,10 @@ import { SpeechStart } from './speechStart';
 export class Gift implements SpeechStart {
   /**
    * Creates potential speech acts for offering a gift.
-   * @param {Speaker} speaking - The speaker initiating the speech act.
-   * @param {Speaker} listening - The listener of the speech act.
-   * @param {string[]} alreadyTraversed - The list of already traversed topics.
-   * @returns {SpeechPart[]} The potential speech parts for the speech act.
+   * @param speaking - The speaker initiating the speech act.
+   * @param listening - The listener of the speech act.
+   * @param alreadyTraversed - The list of already traversed topics.
+   * @returns The potential speech parts for the speech act.
    */
   createPotentialSpeechAct(
     speaking: Speaker,

--- a/packages/converse/src/library/social/speech/starts/gift.ts
+++ b/packages/converse/src/library/social/speech/starts/gift.ts
@@ -3,7 +3,17 @@ import { Speaker } from '../../speaker/speaker';
 import { SpeechPart } from '../speechPart';
 import { SpeechStart } from './speechStart';
 
+/**
+ * Represents a speech start when offering a gift.
+ */
 export class Gift implements SpeechStart {
+  /**
+   * Creates potential speech acts for offering a gift.
+   * @param {Speaker} speaking - The speaker initiating the speech act.
+   * @param {Speaker} listening - The listener of the speech act.
+   * @param {string[]} alreadyTraversed - The list of already traversed topics.
+   * @returns {SpeechPart[]} The potential speech parts for the speech act.
+   */
   createPotentialSpeechAct(
     speaking: Speaker,
     listening: Speaker,
@@ -15,7 +25,6 @@ export class Gift implements SpeechStart {
       if (alreadyTraversed.includes(initialGift.hash())) {
         return [];
       }
-      //const askForSomething = new SpeechAct(this.initiator, `Hello ${this.respondent.name}, ${initialProposal.prompt()}`, 'offer', initialProposal);
       const offerGift = SpeechPart.buildOffer(
         'generous',
         speaking,
@@ -24,7 +33,6 @@ export class Gift implements SpeechStart {
         initialGift
       );
       return [offerGift];
-      // const justChat = new SpeechAct(this.initiator, `Hello ${this.respondent.name}, tell me about yourself.`, 'chat');
     }
 
     return [];

--- a/packages/converse/src/library/social/speech/starts/gift.ts
+++ b/packages/converse/src/library/social/speech/starts/gift.ts
@@ -9,6 +9,7 @@ import { SpeechStart } from './speechStart';
 export class Gift implements SpeechStart {
   /**
    * Creates potential speech acts for offering a gift.
+   *
    * @param speaking - The speaker initiating the speech act.
    * @param listening - The listener of the speech act.
    * @param alreadyTraversed - The list of already traversed topics.

--- a/packages/converse/src/library/social/speech/starts/goodbye.ts
+++ b/packages/converse/src/library/social/speech/starts/goodbye.ts
@@ -2,7 +2,17 @@ import { Speaker } from '../../speaker/speaker';
 import { SpeechPart } from '../speechPart';
 import { SpeechStart } from './speechStart';
 
+/**
+ * Represents a speech start when saying goodbye.
+ */
 export class Goodbye implements SpeechStart {
+  /**
+   * Creates potential speech acts for saying goodbye.
+   * @param {Speaker} speaking - The speaker initiating the speech act.
+   * @param {Speaker} listening - The listener of the speech act.
+   * @param {string[]} _alreadyTraversed - The list of already traversed topics.
+   * @returns {SpeechPart[]} The potential speech parts for the speech act.
+   */
   createPotentialSpeechAct(
     speaking: Speaker,
     listening: Speaker,

--- a/packages/converse/src/library/social/speech/starts/goodbye.ts
+++ b/packages/converse/src/library/social/speech/starts/goodbye.ts
@@ -8,10 +8,11 @@ import { SpeechStart } from './speechStart';
 export class Goodbye implements SpeechStart {
   /**
    * Creates potential speech acts for saying goodbye.
-   * @param {Speaker} speaking - The speaker initiating the speech act.
-   * @param {Speaker} listening - The listener of the speech act.
-   * @param {string[]} _alreadyTraversed - The list of already traversed topics.
-   * @returns {SpeechPart[]} The potential speech parts for the speech act.
+   *
+   * @param speaking - The speaker initiating the speech act.
+   * @param listening - The listener of the speech act.
+   * @param _alreadyTraversed - The list of already traversed topics.
+   * @returns The potential speech parts for the speech act.
    */
   createPotentialSpeechAct(
     speaking: Speaker,

--- a/packages/converse/src/library/social/speech/starts/gossip.ts
+++ b/packages/converse/src/library/social/speech/starts/gossip.ts
@@ -3,7 +3,17 @@ import { Speaker } from '../../speaker/speaker';
 import { SpeechPart } from '../speechPart';
 import { SpeechStart } from './speechStart';
 
+/**
+ * Represents a speech start when gossiping.
+ */
 export class Gossip implements SpeechStart {
+  /**
+   * Creates potential speech acts for gossiping.
+   * @param {Speaker} speaking - The speaker initiating the speech act.
+   * @param {Speaker} listening - The listener of the speech act.
+   * @param {string[]} _alreadyTraversed - The list of already traversed topics.
+   * @returns {SpeechPart[]} The potential speech parts for the speech act.
+   */
   createPotentialSpeechAct(
     speaking: Speaker,
     listening: Speaker,

--- a/packages/converse/src/library/social/speech/starts/gossip.ts
+++ b/packages/converse/src/library/social/speech/starts/gossip.ts
@@ -9,10 +9,11 @@ import { SpeechStart } from './speechStart';
 export class Gossip implements SpeechStart {
   /**
    * Creates potential speech acts for gossiping.
-   * @param {Speaker} speaking - The speaker initiating the speech act.
-   * @param {Speaker} listening - The listener of the speech act.
-   * @param {string[]} _alreadyTraversed - The list of already traversed topics.
-   * @returns {SpeechPart[]} The potential speech parts for the speech act.
+   *
+   * @param speaking - The speaker initiating the speech act.
+   * @param listening - The listener of the speech act.
+   * @param _alreadyTraversed - The list of already traversed topics.
+   * @returns The potential speech parts for the speech act.
    */
   createPotentialSpeechAct(
     speaking: Speaker,

--- a/packages/converse/src/library/social/speech/starts/requestTribute.ts
+++ b/packages/converse/src/library/social/speech/starts/requestTribute.ts
@@ -9,10 +9,10 @@ import { SpeechStart } from './speechStart';
 export class RequestTribute implements SpeechStart {
   /**
    * Creates potential speech acts for requesting a tribute.
-   * @param {Speaker} speaking - The speaker initiating the speech act.
-   * @param {Speaker} listening - The listener of the speech act.
-   * @param {string[]} alreadyTraversed - The list of already traversed topics.
-   * @returns {SpeechPart[]} The potential speech parts for the speech act.
+   * @param speaking - The speaker initiating the speech act.
+   * @param listening - The listener of the speech act.
+   * @param alreadyTraversed - The list of already traversed topics.
+   * @returns The potential speech parts for the speech act.
    */
   createPotentialSpeechAct(
     speaking: Speaker,

--- a/packages/converse/src/library/social/speech/starts/requestTribute.ts
+++ b/packages/converse/src/library/social/speech/starts/requestTribute.ts
@@ -3,7 +3,17 @@ import { Speaker } from '../../speaker/speaker';
 import { SpeechPart } from '../speechPart';
 import { SpeechStart } from './speechStart';
 
+/**
+ * Represents a speech start when requesting a tribute.
+ */
 export class RequestTribute implements SpeechStart {
+  /**
+   * Creates potential speech acts for requesting a tribute.
+   * @param {Speaker} speaking - The speaker initiating the speech act.
+   * @param {Speaker} listening - The listener of the speech act.
+   * @param {string[]} alreadyTraversed - The list of already traversed topics.
+   * @returns {SpeechPart[]} The potential speech parts for the speech act.
+   */
   createPotentialSpeechAct(
     speaking: Speaker,
     listening: Speaker,
@@ -15,7 +25,6 @@ export class RequestTribute implements SpeechStart {
       if (alreadyTraversed.includes(initialRequest.hash())) {
         return [];
       }
-      //const askForSomething = new SpeechAct(this.initiator, `Hello ${this.respondent.name}, ${initialProposal.prompt()}`, 'offer', initialProposal);
       const offer = SpeechPart.buildOffer(
         'demanding',
         speaking,
@@ -24,7 +33,6 @@ export class RequestTribute implements SpeechStart {
         initialRequest
       );
       return [offer];
-      // const justChat = new SpeechAct(this.initiator, `Hello ${this.respondent.name}, tell me about yourself.`, 'chat');
     }
 
     return [];

--- a/packages/converse/src/library/social/speech/starts/requestTribute.ts
+++ b/packages/converse/src/library/social/speech/starts/requestTribute.ts
@@ -9,6 +9,7 @@ import { SpeechStart } from './speechStart';
 export class RequestTribute implements SpeechStart {
   /**
    * Creates potential speech acts for requesting a tribute.
+   *
    * @param speaking - The speaker initiating the speech act.
    * @param listening - The listener of the speech act.
    * @param alreadyTraversed - The list of already traversed topics.

--- a/packages/converse/src/library/social/speech/starts/speechStart.ts
+++ b/packages/converse/src/library/social/speech/starts/speechStart.ts
@@ -1,6 +1,9 @@
 import { Speaker } from '../../speaker/speaker';
 import { SpeechPart } from '../speechPart';
 
+/**
+ * Interface representing a speech start.
+ */
 export interface SpeechStart {
   createPotentialSpeechAct(
     speaking: Speaker,

--- a/packages/converse/src/library/social/speech/starts/talkAbout.ts
+++ b/packages/converse/src/library/social/speech/starts/talkAbout.ts
@@ -3,7 +3,17 @@ import { Speaker } from '../../speaker/speaker';
 import { SpeechPart } from '../speechPart';
 import { SpeechStart } from './speechStart';
 
+/**
+ * Represents a speech start when talking about a topic.
+ */
 export class TalkAbout implements SpeechStart {
+  /**
+   * Creates potential speech acts for talking about a topic.
+   * @param {Speaker} speaking - The speaker initiating the speech act.
+   * @param {Speaker} listening - The listener of the speech act.
+   * @param {string[]} alreadyTraversed - The list of already traversed topics.
+   * @returns {SpeechPart[]} The potential speech parts for the speech act.
+   */
   createPotentialSpeechAct(
     speaking: Speaker,
     listening: Speaker,

--- a/packages/converse/src/library/social/speech/starts/talkAbout.ts
+++ b/packages/converse/src/library/social/speech/starts/talkAbout.ts
@@ -9,6 +9,7 @@ import { SpeechStart } from './speechStart';
 export class TalkAbout implements SpeechStart {
   /**
    * Creates potential speech acts for talking about a topic.
+   *
    * @param speaking - The speaker initiating the speech act.
    * @param listening - The listener of the speech act.
    * @param alreadyTraversed - The list of already traversed topics.

--- a/packages/converse/src/library/social/speech/starts/talkAbout.ts
+++ b/packages/converse/src/library/social/speech/starts/talkAbout.ts
@@ -9,10 +9,10 @@ import { SpeechStart } from './speechStart';
 export class TalkAbout implements SpeechStart {
   /**
    * Creates potential speech acts for talking about a topic.
-   * @param {Speaker} speaking - The speaker initiating the speech act.
-   * @param {Speaker} listening - The listener of the speech act.
-   * @param {string[]} alreadyTraversed - The list of already traversed topics.
-   * @returns {SpeechPart[]} The potential speech parts for the speech act.
+   * @param speaking - The speaker initiating the speech act.
+   * @param listening - The listener of the speech act.
+   * @param alreadyTraversed - The list of already traversed topics.
+   * @returns The potential speech parts for the speech act.
    */
   createPotentialSpeechAct(
     speaking: Speaker,

--- a/packages/converse/src/library/social/speech/tones/compliment.ts
+++ b/packages/converse/src/library/social/speech/tones/compliment.ts
@@ -7,7 +7,8 @@ import { Tone } from './tone';
 export class Compliment implements Tone {
   /**
    * Returns the statement associated with the compliment tone.
-   * @returns {string} The statement.
+   *
+   * @returns The statement.
    */
   statement(): string {
     return 'compliments';
@@ -15,7 +16,8 @@ export class Compliment implements Tone {
 
   /**
    * Returns the question associated with the compliment tone.
-   * @returns {string} The question.
+   *
+   * @returns The question.
    */
   question(): string {
     return 'asks in a complimentary way';
@@ -24,7 +26,8 @@ export class Compliment implements Tone {
   /**
    * Returns the valence of the compliment tone.
    * A positive valence indicates a positive tone.
-   * @returns {number} The valence.
+   *
+   * @returns The valence.
    */
   valence(): number {
     return 1;
@@ -32,7 +35,8 @@ export class Compliment implements Tone {
 
   /**
    * Returns the associated personality trait of the compliment tone.
-   * @returns {PersonalityTraits} The associated personality trait.
+   *
+   * @returns The associated personality trait.
    */
   associatedTrait(): PersonalityTraits {
     return 'complimentary';
@@ -41,7 +45,8 @@ export class Compliment implements Tone {
   /**
    * Returns the effect value of the compliment tone.
    * The effect value indicates the strength of the tone's impact.
-   * @returns {number} The effect value.
+   *
+   * @returns The effect value.
    */
   effect(): number {
     return 10;

--- a/packages/converse/src/library/social/speech/tones/compliment.ts
+++ b/packages/converse/src/library/social/speech/tones/compliment.ts
@@ -1,23 +1,48 @@
 import { PersonalityTraits } from '../../personality';
 import { Tone } from './tone';
 
+/**
+ * Represents a compliment tone.
+ */
 export class Compliment implements Tone {
-  statement() {
+  /**
+   * Returns the statement associated with the compliment tone.
+   * @returns {string} The statement.
+   */
+  statement(): string {
     return 'compliments';
   }
 
-  question() {
-    return 'asks in a complimentry way';
+  /**
+   * Returns the question associated with the compliment tone.
+   * @returns {string} The question.
+   */
+  question(): string {
+    return 'asks in a complimentary way';
   }
 
+  /**
+   * Returns the valence of the compliment tone.
+   * A positive valence indicates a positive tone.
+   * @returns {number} The valence.
+   */
   valence(): number {
     return 1;
   }
 
+  /**
+   * Returns the associated personality trait of the compliment tone.
+   * @returns {PersonalityTraits} The associated personality trait.
+   */
   associatedTrait(): PersonalityTraits {
     return 'complimentary';
   }
 
+  /**
+   * Returns the effect value of the compliment tone.
+   * The effect value indicates the strength of the tone's impact.
+   * @returns {number} The effect value.
+   */
   effect(): number {
     return 10;
   }

--- a/packages/converse/src/library/social/speech/tones/insult.ts
+++ b/packages/converse/src/library/social/speech/tones/insult.ts
@@ -1,19 +1,39 @@
 import { PersonalityTraits } from '../../personality';
 import { Tone } from './tone';
 
+/**
+ * Represents an insult tone.
+ */
 export class Insult implements Tone {
-  statement() {
+  /**
+   * Returns the statement associated with the insult tone.
+   * @returns {string} The statement.
+   */
+  statement(): string {
     return 'insults';
   }
 
-  question() {
+  /**
+   * Returns the question associated with the insult tone.
+   * @returns {string} The question.
+   */
+  question(): string {
     return 'insultingly asks';
   }
 
+  /**
+   * Returns the valence of the insult tone.
+   * A negative valence indicates a negative tone.
+   * @returns {number} The valence.
+   */
   valence(): number {
     return -1;
   }
 
+  /**
+   * Returns the associated personality trait of the insult tone.
+   * @returns {PersonalityTraits} The associated personality trait.
+   */
   associatedTrait(): PersonalityTraits {
     return 'insulting';
   }

--- a/packages/converse/src/library/social/speech/tones/insult.ts
+++ b/packages/converse/src/library/social/speech/tones/insult.ts
@@ -7,7 +7,8 @@ import { Tone } from './tone';
 export class Insult implements Tone {
   /**
    * Returns the statement associated with the insult tone.
-   * @returns {string} The statement.
+   *
+   * @returns The statement.
    */
   statement(): string {
     return 'insults';
@@ -15,7 +16,8 @@ export class Insult implements Tone {
 
   /**
    * Returns the question associated with the insult tone.
-   * @returns {string} The question.
+   *
+   * @returns The question.
    */
   question(): string {
     return 'insultingly asks';
@@ -24,7 +26,8 @@ export class Insult implements Tone {
   /**
    * Returns the valence of the insult tone.
    * A negative valence indicates a negative tone.
-   * @returns {number} The valence.
+   *
+   * @returns The valence.
    */
   valence(): number {
     return -1;
@@ -32,7 +35,8 @@ export class Insult implements Tone {
 
   /**
    * Returns the associated personality trait of the insult tone.
-   * @returns {PersonalityTraits} The associated personality trait.
+   *
+   * @returns The associated personality trait.
    */
   associatedTrait(): PersonalityTraits {
     return 'insulting';

--- a/packages/converse/src/library/social/speech/tones/joking.ts
+++ b/packages/converse/src/library/social/speech/tones/joking.ts
@@ -7,7 +7,8 @@ import { Tone } from './tone';
 export class Joking implements Tone {
   /**
    * Returns the statement associated with the joking tone.
-   * @returns {string} The statement.
+   *
+   * @returns The statement.
    */
   statement() {
     return 'jokes about';
@@ -15,7 +16,8 @@ export class Joking implements Tone {
 
   /**
    * Returns the question associated with the joking tone.
-   * @returns {string} The question.
+   *
+   * @returns The question.
    */
   question() {
     return 'jokingly asks';
@@ -24,7 +26,8 @@ export class Joking implements Tone {
   /**
    * Returns the valence of the joking tone.
    * The valence is randomly determined to be positive or negative.
-   * @returns {number} The valence.
+   *
+   * @returns The valence.
    */
   valence(): number {
     return Math.random() - 0.5;
@@ -32,7 +35,8 @@ export class Joking implements Tone {
 
   /**
    * Returns the associated personality trait of the joking tone.
-   * @returns {PersonalityTraits} The associated personality trait.
+   *
+   * @returns The associated personality trait.
    */
   associatedTrait(): PersonalityTraits {
     return 'funny';

--- a/packages/converse/src/library/social/speech/tones/joking.ts
+++ b/packages/converse/src/library/social/speech/tones/joking.ts
@@ -1,19 +1,39 @@
 import { PersonalityTraits } from '../../personality';
 import { Tone } from './tone';
 
+/**
+ * Represents a joking tone.
+ */
 export class Joking implements Tone {
+  /**
+   * Returns the statement associated with the joking tone.
+   * @returns {string} The statement.
+   */
   statement() {
     return 'jokes about';
   }
 
+  /**
+   * Returns the question associated with the joking tone.
+   * @returns {string} The question.
+   */
   question() {
     return 'jokingly asks';
   }
 
+  /**
+   * Returns the valence of the joking tone.
+   * The valence is randomly determined to be positive or negative.
+   * @returns {number} The valence.
+   */
   valence(): number {
     return Math.random() - 0.5;
   }
 
+  /**
+   * Returns the associated personality trait of the joking tone.
+   * @returns {PersonalityTraits} The associated personality trait.
+   */
   associatedTrait(): PersonalityTraits {
     return 'funny';
   }

--- a/packages/converse/src/library/social/speech/tones/neutral.ts
+++ b/packages/converse/src/library/social/speech/tones/neutral.ts
@@ -1,19 +1,39 @@
 import { PersonalityTraits } from '../../personality';
 import { Tone } from './tone';
 
+/**
+ * Represents a neutral tone.
+ */
 export class Neutral implements Tone {
+  /**
+   * Returns the statement associated with the neutral tone.
+   * @returns {string} The statement.
+   */
   statement() {
     return 'tells';
   }
 
+  /**
+   * Returns the question associated with the neutral tone.
+   * @returns {string} The question.
+   */
   question() {
     return 'asks';
   }
 
+  /**
+   * Returns the valence of the neutral tone.
+   * A valence of 0 indicates a neutral tone.
+   * @returns {number} The valence.
+   */
   valence(): number {
     return 0;
   }
 
+  /**
+   * Returns the associated personality trait of the neutral tone.
+   * @returns {PersonalityTraits} The associated personality trait.
+   */
   associatedTrait(): PersonalityTraits {
     return 'neutral';
   }

--- a/packages/converse/src/library/social/speech/tones/neutral.ts
+++ b/packages/converse/src/library/social/speech/tones/neutral.ts
@@ -7,7 +7,8 @@ import { Tone } from './tone';
 export class Neutral implements Tone {
   /**
    * Returns the statement associated with the neutral tone.
-   * @returns {string} The statement.
+   *
+   * @returns The statement.
    */
   statement() {
     return 'tells';
@@ -15,7 +16,8 @@ export class Neutral implements Tone {
 
   /**
    * Returns the question associated with the neutral tone.
-   * @returns {string} The question.
+   *
+   * @returns The question.
    */
   question() {
     return 'asks';
@@ -24,7 +26,8 @@ export class Neutral implements Tone {
   /**
    * Returns the valence of the neutral tone.
    * A valence of 0 indicates a neutral tone.
-   * @returns {number} The valence.
+   *
+   * @returns The valence.
    */
   valence(): number {
     return 0;
@@ -32,7 +35,8 @@ export class Neutral implements Tone {
 
   /**
    * Returns the associated personality trait of the neutral tone.
-   * @returns {PersonalityTraits} The associated personality trait.
+   *
+   * @returns The associated personality trait.
    */
   associatedTrait(): PersonalityTraits {
     return 'neutral';

--- a/packages/converse/src/library/social/speech/tones/tone.ts
+++ b/packages/converse/src/library/social/speech/tones/tone.ts
@@ -1,5 +1,8 @@
 import { PersonalityTraits } from '../../personality';
 
+/**
+ * Interface representing a tone.
+ */
 export interface Tone {
   question(): string;
   statement(): string;

--- a/packages/converse/src/library/social/turn.ts
+++ b/packages/converse/src/library/social/turn.ts
@@ -1,19 +1,35 @@
 import { Speaker } from './speaker/speaker';
 import { SpeechAct } from './speech/speechAct';
 
+/**
+ * Represents a turn in a conversation.
+ */
 export class Turn {
   mob: Speaker;
   speechAct: SpeechAct;
 
+  /**
+   * Creates a new Turn instance.
+   * @param {Speaker} mob - The speaker taking the turn.
+   * @param {SpeechAct} speechAct - The speech act performed during the turn.
+   */
   constructor(mob: Speaker, speechAct: SpeechAct) {
     this.mob = mob;
     this.speechAct = speechAct;
   }
 
+  /**
+   * Gets the message of the turn.
+   * @returns {string} The message of the turn.
+   */
   getMessage(): string {
     return `${this.mob.name}: ${this.speechAct.getText()}`;
   }
 
+  /**
+   * Gets the speaker of the turn.
+   * @returns {Speaker} The speaker of the turn.
+   */
   getMob(): Speaker {
     return this.mob;
   }

--- a/packages/converse/src/library/social/turn.ts
+++ b/packages/converse/src/library/social/turn.ts
@@ -10,8 +10,9 @@ export class Turn {
 
   /**
    * Creates a new Turn instance.
-   * @param {Speaker} mob - The speaker taking the turn.
-   * @param {SpeechAct} speechAct - The speech act performed during the turn.
+   *
+   * @param mob - The speaker taking the turn.
+   * @param speechAct - The speech act performed during the turn.
    */
   constructor(mob: Speaker, speechAct: SpeechAct) {
     this.mob = mob;
@@ -20,7 +21,8 @@ export class Turn {
 
   /**
    * Gets the message of the turn.
-   * @returns {string} The message of the turn.
+   *
+   * @returns The message of the turn.
    */
   getMessage(): string {
     return `${this.mob.name}: ${this.speechAct.getText()}`;
@@ -28,7 +30,8 @@ export class Turn {
 
   /**
    * Gets the speaker of the turn.
-   * @returns {Speaker} The speaker of the turn.
+   *
+   * @returns The speaker of the turn.
    */
   getMob(): Speaker {
     return this.mob;

--- a/packages/converse/src/repl/index.ts
+++ b/packages/converse/src/repl/index.ts
@@ -21,7 +21,7 @@ const rl = readline.createInterface({
  * from the database. This function executes an SQL query to select two random
  * villagers whose beliefs indicate a relationship to the 'Silverclaw' community.
  *
- * @returns {string[]} An array containing the IDs of the selected villagers.
+ * @returns An array containing the IDs of the selected villagers.
  */
 function twoRandomSilverClaws(): string[] {
   // Define the type for the rows returned by the query
@@ -53,22 +53,22 @@ set_current_date({
 });
 
 const speakerService: SpeakerService = {
-/**
- * Closes the chat between two entities identified by their keys.
- *
- * @param mobKey - The identifier for the first entity involved in the chat.
- * @param target - The identifier for the second entity involved in the chat.
- */
+  /**
+   * Closes the chat between two entities identified by their keys.
+   *
+   * @param mobKey - The identifier for the first entity involved in the chat.
+   * @param target - The identifier for the second entity involved in the chat.
+   */
   closeChat: function (mobKey: string, target: string): void {
     console.log(`Chat closed between ${mobKey} and ${target}.`);
   },
-/**
- * Displays a list of possible responses for a speaker and prompts the user
- * to select one by entering its corresponding number.
- *
- * @param speaker - The speaker for whom the responses are being shown.
- * @param responses - An array of possible responses to display.
- */
+  /**
+   * Displays a list of possible responses for a speaker and prompts the user
+   * to select one by entering its corresponding number.
+   *
+   * @param speaker - The speaker for whom the responses are being shown.
+   * @param responses - An array of possible responses to display.
+   */
   possibleResponses: function (speaker: Speaker, responses: string[]): void {
     responses.forEach((response, index) => {
       console.log(`${index}: ${response}`);
@@ -93,7 +93,7 @@ const speakerService: SpeakerService = {
  * all members of the tribe. This is useful for testing the conversation code.
  *
  * @remarks
- * This function is intended to be used in the REPL (Read-Eval-Print Loop). It is 
+ * This function is intended to be used in the REPL (Read-Eval-Print Loop). It is
  * not intended to be called from other code.
  */
 async function main() {
@@ -158,8 +158,6 @@ const conversation = new Conversation(
   speakerService
 );
 
-//console.log('random concept', memoryService.getRandomConcept());
-
 /**
  * Prompts the user to enter a number, and will recursively call itself until
  * the user enters a valid number in the range of 0 to numOptions - 1.
@@ -184,7 +182,6 @@ function promptForNumber(numOptions: number) {
 }
 
 rl.on('line', () => {
-  //console.log(`blah blah`);
   conversation.prepareNextResponse();
 
   if (conversation.isFinished()) {

--- a/packages/converse/src/repl/index.ts
+++ b/packages/converse/src/repl/index.ts
@@ -16,6 +16,13 @@ const rl = readline.createInterface({
   prompt: 'next turn> '
 });
 
+/**
+ * Retrieves the IDs of two random villagers associated with the 'Silverclaw' region
+ * from the database. This function executes an SQL query to select two random
+ * villagers whose beliefs indicate a relationship to the 'Silverclaw' community.
+ *
+ * @returns {string[]} An array containing the IDs of the selected villagers.
+ */
 function twoRandomSilverClaws(): string[] {
   // Define the type for the rows returned by the query
   interface Mob {
@@ -46,9 +53,22 @@ set_current_date({
 });
 
 const speakerService: SpeakerService = {
+/**
+ * Closes the chat between two entities identified by their keys.
+ *
+ * @param mobKey - The identifier for the first entity involved in the chat.
+ * @param target - The identifier for the second entity involved in the chat.
+ */
   closeChat: function (mobKey: string, target: string): void {
     console.log(`Chat closed between ${mobKey} and ${target}.`);
   },
+/**
+ * Displays a list of possible responses for a speaker and prompts the user
+ * to select one by entering its corresponding number.
+ *
+ * @param speaker - The speaker for whom the responses are being shown.
+ * @param responses - An array of possible responses to display.
+ */
   possibleResponses: function (speaker: Speaker, responses: string[]): void {
     responses.forEach((response, index) => {
       console.log(`${index}: ${response}`);
@@ -56,11 +76,26 @@ const speakerService: SpeakerService = {
 
     promptForNumber(responses.length);
   },
+  /**
+   * Simulates a speaker saying a given response in the chat conversation.
+   *
+   * @param speaker - The speaker who is saying the response.
+   * @param response - The text of the response.
+   */
   speak: function (speaker: Speaker, response: string): void {
     console.log(`${speaker.name} says: ${response}`);
   }
 };
 
+/**
+ * Simulates a series of conversations between randomly selected members of the
+ * Silver Claw tribe. After every 10 conversations, it refreshes the memories of
+ * all members of the tribe. This is useful for testing the conversation code.
+ *
+ * @remarks
+ * This function is intended to be used in the REPL (Read-Eval-Print Loop). It is 
+ * not intended to be called from other code.
+ */
 async function main() {
   for (let i = 0; i < 100; i++) {
     if (i % 10 === 9) {
@@ -125,6 +160,11 @@ const conversation = new Conversation(
 
 //console.log('random concept', memoryService.getRandomConcept());
 
+/**
+ * Prompts the user to enter a number, and will recursively call itself until
+ * the user enters a valid number in the range of 0 to numOptions - 1.
+ * @param {number} numOptions The number of possible options to choose from.
+ */
 function promptForNumber(numOptions: number) {
   rl.question('What do you say? ', (response) => {
     const responseNumber = parseInt(response, 10);

--- a/packages/converse/src/repl/test_data/buildMobKnowledge.ts
+++ b/packages/converse/src/repl/test_data/buildMobKnowledge.ts
@@ -13,7 +13,7 @@ import { Region } from '../../library/knowledge_graph/people/region';
 
 /**
  * Constructs and returns a `KnowledgeGraph` representing the Silverclaw Tribe and its environment.
- * 
+ *
  * This function defines several regions, communities, items, and people within the fictional world
  * of Elyndra, specifically focused on the Silverclaw Tribe. It includes:
  *   - Regions such as Elyndra, the Shattered Expanse, and Claw Island.
@@ -21,12 +21,12 @@ import { Region } from '../../library/knowledge_graph/people/region';
  *   - Items such as Blueberry, Heartbeet, and Eidelweiss.
  *   - Various people with specific roles and personalities, forming a family tree.
  *   - Events that have occurred or are anticipated within the tribe.
- * 
+ *
  * The resulting `KnowledgeGraph` aggregates these entities, along with their relationships and
  * associated beliefs, to provide a comprehensive representation of the Silverclaw Tribe's
  * knowledge and lore.
- * 
- * @returns {KnowledgeGraph} The constructed knowledge graph of the Silverclaw Tribe.
+ *
+ * @returns The constructed knowledge graph of the Silverclaw Tribe.
  */
 export function buildSilverclawTribe(): KnowledgeGraph {
   const elyndra = new Region(

--- a/packages/converse/src/repl/test_data/buildMobKnowledge.ts
+++ b/packages/converse/src/repl/test_data/buildMobKnowledge.ts
@@ -11,6 +11,23 @@ import { Item } from '../../library/knowledge_graph/people/item';
 import { Person } from '../../library/knowledge_graph/people/person';
 import { Region } from '../../library/knowledge_graph/people/region';
 
+/**
+ * Constructs and returns a `KnowledgeGraph` representing the Silverclaw Tribe and its environment.
+ * 
+ * This function defines several regions, communities, items, and people within the fictional world
+ * of Elyndra, specifically focused on the Silverclaw Tribe. It includes:
+ *   - Regions such as Elyndra, the Shattered Expanse, and Claw Island.
+ *   - Communities like Silverclaw and the Alchemist's Guild.
+ *   - Items such as Blueberry, Heartbeet, and Eidelweiss.
+ *   - Various people with specific roles and personalities, forming a family tree.
+ *   - Events that have occurred or are anticipated within the tribe.
+ * 
+ * The resulting `KnowledgeGraph` aggregates these entities, along with their relationships and
+ * associated beliefs, to provide a comprehensive representation of the Silverclaw Tribe's
+ * knowledge and lore.
+ * 
+ * @returns {KnowledgeGraph} The constructed knowledge graph of the Silverclaw Tribe.
+ */
 export function buildSilverclawTribe(): KnowledgeGraph {
   const elyndra = new Region(
     'elyndra',


### PR DESCRIPTION
## **Problem:**

Right now, there is minimal documentation to help developers navigate the various functions in each of the packages. By adding JSDocs headers to each relevant function, the code will be easier to follow along and understand.

## **Solution:**

Added JSDocs headers to the functions in the converse package.

## **Tests:**

Not relevant.

**Fixes** [#248 ](https://github.com/sloalchemist/potions/issues/248)
