### PR TITLE
Player profile

### DIFF
--- a/packages/client/src/scenes/uxScene.ts
+++ b/packages/client/src/scenes/uxScene.ts
@@ -30,6 +30,7 @@ export class UxScene extends Phaser.Scene {
   attackText: Phaser.GameObjects.Text | null = null;
   speedText: Phaser.GameObjects.Text | null = null;
   affiliationText: Phaser.GameObjects.Text | null = null;
+  stubbornnessText: Phaser.GameObjects.Text | null = null;
   dateText: Phaser.GameObjects.Text | null = null;
   chatRequested: boolean = false;
 
@@ -179,6 +180,14 @@ export class UxScene extends Phaser.Scene {
       );
       this.statsContainer.add(this.dateText);
 
+      this.stubbornnessText = this.add.text(
+        15,
+        215,
+        'Stubborness: ' + currentCharacter.stubbornness
+      );
+      this.statsContainer.add(this.stubbornnessText);
+      
+
       this.time.addEvent({
         delay: 1000,
         callback: () => {
@@ -229,6 +238,7 @@ export class UxScene extends Phaser.Scene {
       this.attackText?.setText('Attack: ' + currentCharacter.attack);
       this.speedText?.setText('Speed: ' + currentCharacter.speed);
       this.affiliationText?.setText('Affiliation: ' + currentCharacter.community_id);
+      this.stubbornnessText?.setText('Stubbornness: ' + currentCharacter.stubbornness);
     }
   }
 

--- a/packages/client/src/scenes/uxScene.ts
+++ b/packages/client/src/scenes/uxScene.ts
@@ -31,6 +31,13 @@ export class UxScene extends Phaser.Scene {
   speedText: Phaser.GameObjects.Text | null = null;
   affiliationText: Phaser.GameObjects.Text | null = null;
   stubbornnessText: Phaser.GameObjects.Text | null = null;
+  braveryText: Phaser.GameObjects.Text | null = null;
+  aggressionText: Phaser.GameObjects.Text | null = null;
+  industriousnessText: Phaser.GameObjects.Text | null = null;
+  adventurousnessText: Phaser.GameObjects.Text | null = null;
+  gluttonyText: Phaser.GameObjects.Text | null = null;
+  sleepyText: Phaser.GameObjects.Text | null = null;
+  extroversionText: Phaser.GameObjects.Text | null = null;
   dateText: Phaser.GameObjects.Text | null = null;
   chatRequested: boolean = false;
 
@@ -181,11 +188,60 @@ export class UxScene extends Phaser.Scene {
       this.statsContainer.add(this.dateText);
 
       this.stubbornnessText = this.add.text(
-        15,
-        215,
+        240,
+        40,
         'Stubborness: ' + currentCharacter.stubbornness
       );
       this.statsContainer.add(this.stubbornnessText);
+
+      this.braveryText = this.add.text(
+        240,
+        65,
+        'Bravery: ' + currentCharacter.bravery
+      );
+      this.statsContainer.add(this.braveryText);
+
+      this.aggressionText = this.add.text(
+        240,
+        90,
+        'Aggression: ' + currentCharacter.aggression
+      );
+      this.statsContainer.add(this.aggressionText);
+
+      this.industriousnessText = this.add.text(
+        240,
+        115,
+        'Industriousness: ' + currentCharacter.industriousness
+      );
+      this.statsContainer.add(this.industriousnessText);
+
+      this.adventurousnessText = this.add.text(
+        240,
+        140,
+        'Adventurousness: ' + currentCharacter.adventurousness
+      );
+      this.statsContainer.add(this.adventurousnessText);
+
+      this.gluttonyText = this.add.text(
+        240,
+        165,
+        'Gluttony: ' + currentCharacter.gluttony
+      );
+      this.statsContainer.add(this.gluttonyText);
+
+      this.sleepyText = this.add.text(
+        240,
+        190,
+        'Sleepy: ' + currentCharacter.sleepy
+      );
+      this.statsContainer.add(this.sleepyText);
+
+      this.extroversionText = this.add.text(
+        240,
+        215,
+        'Extroversion: ' + currentCharacter.extroversion
+      );
+      this.statsContainer.add(this.extroversionText);
       
 
       this.time.addEvent({
@@ -239,6 +295,13 @@ export class UxScene extends Phaser.Scene {
       this.speedText?.setText('Speed: ' + currentCharacter.speed);
       this.affiliationText?.setText('Affiliation: ' + currentCharacter.community_id);
       this.stubbornnessText?.setText('Stubbornness: ' + currentCharacter.stubbornness);
+      this.braveryText?.setText('Bravery: ' + currentCharacter.bravery);
+      this.aggressionText?.setText('Aggression: ' + currentCharacter.aggression);
+      this.industriousnessText?.setText('Industriousness: ' + currentCharacter.industriousness);
+      this.adventurousnessText?.setText('Adventurousness: ' + currentCharacter.adventurousness);
+      this.gluttonyText?.setText('Gluttony: ' + currentCharacter.gluttony);
+      this.sleepyText?.setText('Sleepy: ' + currentCharacter.sleepy);
+      this.extroversionText?.setText('Extroversion: ' + currentCharacter.extroversion);
     }
   }
 

--- a/packages/client/src/scenes/uxScene.ts
+++ b/packages/client/src/scenes/uxScene.ts
@@ -27,7 +27,9 @@ export class UxScene extends Phaser.Scene {
   chatButtons: ButtonManager = new ButtonManager([]);
   goldText: Phaser.GameObjects.Text | null = null;
   healthText: Phaser.GameObjects.Text | null = null;
+  attackText: Phaser.GameObjects.Text | null = null;
   speedText: Phaser.GameObjects.Text | null = null;
+  affiliationText: Phaser.GameObjects.Text | null = null;
   dateText: Phaser.GameObjects.Text | null = null;
   chatRequested: boolean = false;
 
@@ -149,16 +151,30 @@ export class UxScene extends Phaser.Scene {
       );
       this.statsContainer.add(this.healthText);
 
-      this.speedText = this.add.text(
+      this.attackText = this.add.text(
         15,
         115,
+        'Attack: ' + currentCharacter.attack
+      );
+      this.statsContainer.add(this.attackText);
+
+      this.speedText = this.add.text(
+        15,
+        140,
         'Speed: ' + currentCharacter.speed
       );
       this.statsContainer.add(this.speedText);
 
+      this.affiliationText = this.add.text(
+        15,
+        165,
+        'Affiliation: ' + currentCharacter.community_id
+      );
+      this.statsContainer.add(this.affiliationText);
+
       this.dateText = this.add.text(
         15,
-        140,
+        190,
         'Date: reading position of sun and stars'
       );
       this.statsContainer.add(this.dateText);
@@ -210,7 +226,9 @@ export class UxScene extends Phaser.Scene {
     if (currentCharacter) {
       this.goldText?.setText('Gold: ' + currentCharacter.gold);
       this.healthText?.setText('Health: ' + currentCharacter.health);
+      this.attackText?.setText('Attack: ' + currentCharacter.attack);
       this.speedText?.setText('Speed: ' + currentCharacter.speed);
+      this.affiliationText?.setText('Affiliation: ' + currentCharacter.community_id);
     }
   }
 

--- a/packages/client/src/scenes/uxScene.ts
+++ b/packages/client/src/scenes/uxScene.ts
@@ -242,7 +242,6 @@ export class UxScene extends Phaser.Scene {
         'Extroversion: ' + currentCharacter.extroversion
       );
       this.statsContainer.add(this.extroversionText);
-      
 
       this.time.addEvent({
         delay: 1000,
@@ -293,15 +292,27 @@ export class UxScene extends Phaser.Scene {
       this.healthText?.setText('Health: ' + currentCharacter.health);
       this.attackText?.setText('Attack: ' + currentCharacter.attack);
       this.speedText?.setText('Speed: ' + currentCharacter.speed);
-      this.affiliationText?.setText('Affiliation: ' + currentCharacter.community_id);
-      this.stubbornnessText?.setText('Stubbornness: ' + currentCharacter.stubbornness);
+      this.affiliationText?.setText(
+        'Affiliation: ' + currentCharacter.community_id
+      );
+      this.stubbornnessText?.setText(
+        'Stubbornness: ' + currentCharacter.stubbornness
+      );
       this.braveryText?.setText('Bravery: ' + currentCharacter.bravery);
-      this.aggressionText?.setText('Aggression: ' + currentCharacter.aggression);
-      this.industriousnessText?.setText('Industriousness: ' + currentCharacter.industriousness);
-      this.adventurousnessText?.setText('Adventurousness: ' + currentCharacter.adventurousness);
+      this.aggressionText?.setText(
+        'Aggression: ' + currentCharacter.aggression
+      );
+      this.industriousnessText?.setText(
+        'Industriousness: ' + currentCharacter.industriousness
+      );
+      this.adventurousnessText?.setText(
+        'Adventurousness: ' + currentCharacter.adventurousness
+      );
       this.gluttonyText?.setText('Gluttony: ' + currentCharacter.gluttony);
       this.sleepyText?.setText('Sleepy: ' + currentCharacter.sleepy);
-      this.extroversionText?.setText('Extroversion: ' + currentCharacter.extroversion);
+      this.extroversionText?.setText(
+        'Extroversion: ' + currentCharacter.extroversion
+      );
     }
   }
 

--- a/packages/client/src/sprite/sprite_mob.ts
+++ b/packages/client/src/sprite/sprite_mob.ts
@@ -46,7 +46,8 @@ export class SpriteMob extends Mob {
       mob.type,
       mob.maxHealth,
       mob.position,
-      mob.attributes
+      mob.attributes,
+      mob.personalities
     );
     this.scene = scene;
     this.path = mob.path;

--- a/packages/client/src/world/mob.ts
+++ b/packages/client/src/world/mob.ts
@@ -10,6 +10,7 @@ export class Mob extends Physical {
   dead: boolean = false;
   carrying?: string;
   attributes: Record<string, number> = {};
+  personalities: Record<string, number> = {};
   unlocks: string[] = [];
   doing: string = '';
 
@@ -20,7 +21,8 @@ export class Mob extends Physical {
     type: string,
     maxHealth: number,
     position: Coord | null,
-    attributes: Record<string, number>
+    attributes: Record<string, number>,
+    personalities: Record<string, number>
   ) {
     super(world, key, type, position);
     this.name = name;
@@ -31,6 +33,9 @@ export class Mob extends Physical {
 
     for (const [key, value] of Object.entries(attributes)) {
       this.attributes[key] = value;
+    }
+    for (const [key, value] of Object.entries(personalities)) {
+      this.personalities[key] = value;
     }
   }
 

--- a/packages/client/src/world/mob.ts
+++ b/packages/client/src/world/mob.ts
@@ -25,7 +25,6 @@ export class Mob extends Physical {
     super(world, key, type, position);
     this.name = name;
     this.maxHealth = maxHealth;
-
     if (position) {
       world.addMobToGrid(this);
     }

--- a/packages/client/src/worldMetadata.ts
+++ b/packages/client/src/worldMetadata.ts
@@ -122,7 +122,6 @@ export class Character {
     return world.mobs[publicCharacterId].personalities['extroversion'];
   }
 
-
   subtype(): string {
     return `${this.eyeColor}-${this.bellyColor}-${this.furColor}`;
   }
@@ -160,7 +159,7 @@ export async function retrieveCharacter() {
     hexStringToNumber(localStorage.getItem('eyeColor') || getRandomColor()),
     hexStringToNumber(localStorage.getItem('furColor') || getRandomColor()),
     hexStringToNumber(localStorage.getItem('bellyColor') || getRandomColor()),
-    "alchemists"
+    'alchemists'
   );
 
   saveColors();

--- a/packages/client/src/worldMetadata.ts
+++ b/packages/client/src/worldMetadata.ts
@@ -15,14 +15,14 @@ export class Character {
   eyeColor: number;
   furColor: number;
   bellyColor: number;
-  community_id: string | undefined;
+  community_id: string;
 
   constructor(
     name: string,
     eyeColor: number,
     furColor: number,
     bellyColor: number,
-    community_id: string | undefined
+    community_id: string
   ) {
     this.name = name;
     this.eyeColor = eyeColor;
@@ -43,6 +43,13 @@ export class Character {
       return 0;
     }
     return world.mobs[publicCharacterId].attributes['health'];
+  }
+
+  get attack(): number {
+    if (!world || !world.mobs[publicCharacterId]) {
+      return 0;
+    }
+    return world.mobs[publicCharacterId].attributes['attack'];
   }
 
   get speed(): number {
@@ -96,7 +103,7 @@ export async function retrieveCharacter() {
     hexStringToNumber(localStorage.getItem('eyeColor') || getRandomColor()),
     hexStringToNumber(localStorage.getItem('furColor') || getRandomColor()),
     hexStringToNumber(localStorage.getItem('bellyColor') || getRandomColor()),
-    localStorage.getItem('community_id') || undefined
+    "alchemists"
   );
 
   saveColors();

--- a/packages/client/src/worldMetadata.ts
+++ b/packages/client/src/worldMetadata.ts
@@ -73,6 +73,56 @@ export class Character {
     return world.mobs[publicCharacterId].personalities['stubbornness'];
   }
 
+  get bravery(): number {
+    if (!world || !world.mobs[publicCharacterId]) {
+      return 0;
+    }
+    return world.mobs[publicCharacterId].personalities['bravery'];
+  }
+
+  get aggression(): number {
+    if (!world || !world.mobs[publicCharacterId]) {
+      return 0;
+    }
+    return world.mobs[publicCharacterId].personalities['aggression'];
+  }
+
+  get industriousness(): number {
+    if (!world || !world.mobs[publicCharacterId]) {
+      return 0;
+    }
+    return world.mobs[publicCharacterId].personalities['industriousness'];
+  }
+
+  get adventurousness(): number {
+    if (!world || !world.mobs[publicCharacterId]) {
+      return 0;
+    }
+    return world.mobs[publicCharacterId].personalities['adventurousness'];
+  }
+
+  get gluttony(): number {
+    if (!world || !world.mobs[publicCharacterId]) {
+      return 0;
+    }
+    return world.mobs[publicCharacterId].personalities['gluttony'];
+  }
+
+  get sleepy(): number {
+    if (!world || !world.mobs[publicCharacterId]) {
+      return 0;
+    }
+    return world.mobs[publicCharacterId].personalities['sleepy'];
+  }
+
+  get extroversion(): number {
+    if (!world || !world.mobs[publicCharacterId]) {
+      return 0;
+    }
+    return world.mobs[publicCharacterId].personalities['extroversion'];
+  }
+
+
   subtype(): string {
     return `${this.eyeColor}-${this.bellyColor}-${this.furColor}`;
   }

--- a/packages/client/src/worldMetadata.ts
+++ b/packages/client/src/worldMetadata.ts
@@ -66,6 +66,13 @@ export class Character {
     return world.mobs[publicCharacterId].attributes['target_speed_tick'];
   }
 
+  get stubbornness(): number {
+    if (!world || !world.mobs[publicCharacterId]) {
+      return 0;
+    }
+    return world.mobs[publicCharacterId].personalities['stubbornness'];
+  }
+
   subtype(): string {
     return `${this.eyeColor}-${this.bellyColor}-${this.furColor}`;
   }

--- a/packages/client/test/chatui/chatui.test.ts
+++ b/packages/client/test/chatui/chatui.test.ts
@@ -111,7 +111,16 @@ describe('Chat UI updates based on chatting state', () => {
       {},
       {}
     );
-    const npc = new Mob(world!, 'mob2', 'NPC1', 'npc', 100, { x: 2, y: 2 }, {}, {});
+    const npc = new Mob(
+      world!,
+      'mob2',
+      'NPC1',
+      'npc',
+      100,
+      { x: 2, y: 2 },
+      {},
+      {}
+    );
     const mobs = [player1, npc];
 
     setChatting(false);

--- a/packages/client/test/chatui/chatui.test.ts
+++ b/packages/client/test/chatui/chatui.test.ts
@@ -66,6 +66,7 @@ describe('Chat UI updates based on chatting state', () => {
       'player',
       100,
       { x: 1, y: 1 },
+      {},
       {}
     );
     const npc1 = new Mob(
@@ -75,6 +76,7 @@ describe('Chat UI updates based on chatting state', () => {
       'npc',
       100,
       { x: 2, y: 2 },
+      {},
       {}
     );
     const mobs = [player1, npc1];
@@ -106,9 +108,10 @@ describe('Chat UI updates based on chatting state', () => {
       'player',
       100,
       { x: 1, y: 1 },
+      {},
       {}
     );
-    const npc = new Mob(world!, 'mob2', 'NPC1', 'npc', 100, { x: 2, y: 2 }, {});
+    const npc = new Mob(world!, 'mob2', 'NPC1', 'npc', 100, { x: 2, y: 2 }, {}, {});
     const mobs = [player1, npc];
 
     setChatting(false);
@@ -132,6 +135,7 @@ describe('Chat UI updates based on chatting state', () => {
       'player',
       100,
       { x: 1, y: 1 },
+      {},
       {}
     );
     const npc1 = new Mob(
@@ -141,6 +145,7 @@ describe('Chat UI updates based on chatting state', () => {
       'npc',
       100,
       { x: 2, y: 2 },
+      {},
       {}
     );
     let mobs = [player1, npc1];
@@ -161,6 +166,7 @@ describe('Chat UI updates based on chatting state', () => {
       'npc',
       100,
       { x: 3, y: 3 },
+      {},
       {}
     );
     mobs = [player1, npc1, npc2];

--- a/packages/client/test/world/mob.test.ts
+++ b/packages/client/test/world/mob.test.ts
@@ -28,6 +28,7 @@ const createTestMob = (): Mob => {
     'test',
     1,
     { x: 0, y: 0 },
+    {},
     {}
   );
   mob.path = TEST_OLD_PATH;

--- a/packages/common/src/mob.ts
+++ b/packages/common/src/mob.ts
@@ -1,6 +1,7 @@
 import { Coord } from './coord';
 
 export type MobI = {
+  personalities: Record<string, number>;
   id: string;
   position: Coord;
   type: string;
@@ -9,6 +10,7 @@ export type MobI = {
   path: Coord[];
   name: string;
   maxHealth: number;
+  community_id: string;
   carrying?: string;
   attributes: Record<string, number>;
   unlocks: string[];

--- a/packages/server/src/mobs/mob.ts
+++ b/packages/server/src/mobs/mob.ts
@@ -18,6 +18,7 @@ import { gameWorld } from '../services/gameWorld/gameWorld';
 import { selectAction } from './plans/actionRunner';
 
 export type MobData = {
+  personalities: Personality;
   id: string;
   action_type: string;
   subtype: string;

--- a/packages/server/src/mobs/mob.ts
+++ b/packages/server/src/mobs/mob.ts
@@ -5,7 +5,7 @@ import {
   floor,
   followPath
 } from '@rt-potion/common';
-import { Personality } from './traits/personality';
+import { Personality, PersonalityTraits } from './traits/personality';
 import { DB } from '../services/database';
 import { Item } from '../items/item';
 import { House, HouseData } from '../community/house';
@@ -79,7 +79,7 @@ export class Mob {
 
   private _gold: number;
   private _health: number;
-  public readonly attack: number;
+  public attack: number;
 
   private constructor({
     key,
@@ -375,6 +375,38 @@ export class Mob {
       ).run({ id: this.id });
       this.destroy();
     }
+  }
+
+  changeAttack(amount: number) {
+    if (amount === 0) return;
+    let newAttack = this.attack + amount;
+    if (newAttack <= 0 ) {
+      newAttack = 0;
+    }
+    DB.prepare(
+      `
+            UPDATE mobs
+            SET attack = :attack
+            WHERE id = :id
+        `
+    ).run({ attack: newAttack, id: this.id });
+    this.attack = newAttack;
+    pubSub.changeAttack(this.id, amount, this.attack);
+  }
+
+  changePersonality(trait: string, amount: number) {
+    if (amount === 0) return;
+    const traitKey = trait as PersonalityTraits;
+    let newValue = this.personality.traits[traitKey] + amount;
+    DB.prepare(
+      `
+            UPDATE personalities
+            SET ${trait} = :value
+            WHERE mob_id = :id
+        `
+    ).run({ value: newValue, id: this.id });
+    this.personality.traits[traitKey] = newValue;
+    pubSub.changePersonality(this.id, trait, amount);
   }
 
   changeEffect(delta: number, duration: number, attribute: string): void {

--- a/packages/server/src/mobs/mob.ts
+++ b/packages/server/src/mobs/mob.ts
@@ -380,7 +380,7 @@ export class Mob {
   changeAttack(amount: number) {
     if (amount === 0) return;
     let newAttack = this.attack + amount;
-    if (newAttack <= 0 ) {
+    if (newAttack <= 0) {
       newAttack = 0;
     }
     DB.prepare(

--- a/packages/server/src/mobs/mobFactory.ts
+++ b/packages/server/src/mobs/mobFactory.ts
@@ -43,7 +43,8 @@ class MobFactory {
     subtype?: string,
     //Adding fields that can now be from the auth-server  (health gold appearance)
     health_from_auth?: number,
-    gold_from_auth?: number
+    gold_from_auth?: number,
+    attack_from_auth?: number
   ): void {
     if (id == undefined) {
       id = uuidv4();
@@ -63,7 +64,7 @@ class MobFactory {
       name = nameGeneratorFactory.generateName(mobType.name_style);
     }
     const speed = mobType.speed;
-    const attack = mobType.attack;
+    const attack = attack_from_auth ?? mobType.attack;
     const community_id = mobType.community;
     const health = health_from_auth ?? mobType.health; // mobType.health;
 

--- a/packages/server/src/mobs/traits/personality.ts
+++ b/packages/server/src/mobs/traits/personality.ts
@@ -24,6 +24,18 @@ export interface PersonalityData {
   extroversion: number;
 }
 
+export type Personalities = {
+  mob_id: string;
+  stubbornness: number;
+  bravery: number;
+  aggression: number;
+  industriousness: number;
+  adventurousness: number;
+  gluttony: number;
+  sleepy: number;
+  extroversion: number;
+};
+
 export class Personality {
   traits: Record<PersonalityTraits, number>;
 

--- a/packages/server/src/services/authMarshalling.ts
+++ b/packages/server/src/services/authMarshalling.ts
@@ -13,6 +13,7 @@ export interface PlayerData {
   health: number;
   name: string;
   gold: number;
+  attack: number;
   appearance: string;
 }
 

--- a/packages/server/src/services/clientCommunication/ablyService.ts
+++ b/packages/server/src/services/clientCommunication/ablyService.ts
@@ -272,6 +272,53 @@ export class AblyService implements PubSub {
     });
   }
 
+  private changeTrait(key: string, traitName: string, newValue: number): void {
+    if (key === undefined || newValue === undefined) {
+      throw new Error(`Sending invalid changeTrait message: ${key}, ${traitName}, ${newValue}`);
+    }
+    this.addToBroadcast({
+      type: 'mob_change',
+      data: {
+        id: key,
+        property: traitName,
+        delta: newValue,
+        new_value: newValue
+      }
+    });
+  }
+
+  public changeStubbornness(key: string, oldValue: number, newValue: number): void {
+    this.changeTrait(key, 'stubbornness', newValue);
+  }
+
+  public changeBravery(key: string, oldValue: number, newValue: number): void {
+    this.changeTrait(key, 'bravery', newValue);
+  }
+
+  public changeAggression(key: string, oldValue: number, newValue: number): void {
+    this.changeTrait(key, 'aggression', newValue);
+  }
+
+  public changeIndustriousness(key: string, oldValue: number, newValue: number): void {
+    this.changeTrait(key, 'industriousness', newValue);
+  }
+
+  public changeAdventurousness(key: string, oldValue: number, newValue: number): void {
+    this.changeTrait(key, 'adventurousness', newValue);
+  }
+
+  public changeGluttony(key: string, oldValue: number, newValue: number): void {
+    this.changeTrait(key, 'gluttony', newValue);
+  }
+
+  public changeSleepy(key: string, oldValue: number, newValue: number): void {
+    this.changeTrait(key, 'sleepy', newValue);
+  }
+
+  public changeExtroversion(key: string, oldValue: number, newValue: number): void {
+    this.changeTrait(key, 'extroversion', newValue);
+  }
+
   public changeEffect(
     key: string,
     attribute: string,

--- a/packages/server/src/services/clientCommunication/ablyService.ts
+++ b/packages/server/src/services/clientCommunication/ablyService.ts
@@ -272,51 +272,19 @@ export class AblyService implements PubSub {
     });
   }
 
-  private changeTrait(key: string, traitName: string, newValue: number): void {
-    if (key === undefined || newValue === undefined) {
-      throw new Error(`Sending invalid changeTrait message: ${key}, ${traitName}, ${newValue}`);
+  public changePersonality(key: string, trait: string, newValue: number): void {
+    if (key === undefined || newValue === undefined || trait === undefined) {
+      throw new Error(`Sending invalid changePersonality message: ${key}, ${trait}, ${newValue}`);
     }
     this.addToBroadcast({
       type: 'mob_change',
       data: {
         id: key,
-        property: traitName,
+        property: trait,
         delta: newValue,
         new_value: newValue
       }
     });
-  }
-
-  public changeStubbornness(key: string, oldValue: number, newValue: number): void {
-    this.changeTrait(key, 'stubbornness', newValue);
-  }
-
-  public changeBravery(key: string, oldValue: number, newValue: number): void {
-    this.changeTrait(key, 'bravery', newValue);
-  }
-
-  public changeAggression(key: string, oldValue: number, newValue: number): void {
-    this.changeTrait(key, 'aggression', newValue);
-  }
-
-  public changeIndustriousness(key: string, oldValue: number, newValue: number): void {
-    this.changeTrait(key, 'industriousness', newValue);
-  }
-
-  public changeAdventurousness(key: string, oldValue: number, newValue: number): void {
-    this.changeTrait(key, 'adventurousness', newValue);
-  }
-
-  public changeGluttony(key: string, oldValue: number, newValue: number): void {
-    this.changeTrait(key, 'gluttony', newValue);
-  }
-
-  public changeSleepy(key: string, oldValue: number, newValue: number): void {
-    this.changeTrait(key, 'sleepy', newValue);
-  }
-
-  public changeExtroversion(key: string, oldValue: number, newValue: number): void {
-    this.changeTrait(key, 'extroversion', newValue);
   }
 
   public changeEffect(

--- a/packages/server/src/services/clientCommunication/ablyService.ts
+++ b/packages/server/src/services/clientCommunication/ablyService.ts
@@ -150,6 +150,7 @@ export class AblyService implements PubSub {
       console.log('data.name:', message.data.name);
       console.log('data.health:', message.data.health);
       console.log('data.gold:', message.data.gold);
+      console.log('data.attack:', message.data.attack);
       this.userMembershipChannel.publish('serving', {
         name: message.data.name,
         world: this.worldID,
@@ -161,7 +162,8 @@ export class AblyService implements PubSub {
           message.data.name,
           message.data.char_id,
           message.data.health,
-          message.data.gold
+          message.data.gold,
+          message.data.attack
         );
       }
     }
@@ -253,6 +255,23 @@ export class AblyService implements PubSub {
     });
   }
 
+  public changeAttack(key: string, attack: number, newValue: number): void {
+    if (newValue == undefined || key == undefined || attack == undefined) {
+      throw new Error(
+        `Sending invalid changeAttack message ${key}, ${attack}, ${newValue}`
+      );
+    }
+    this.addToBroadcast({
+      type: 'mob_change',
+      data: {
+        id: key,
+        property: 'attack',
+        delta: attack,
+        new_value: newValue
+      }
+    });
+  }
+
   public changeEffect(
     key: string,
     attribute: string,
@@ -298,6 +317,7 @@ export class AblyService implements PubSub {
       }
     });
   }
+
 
   public changeGold(key: string, gold: number, newValue: number): void {
     if (newValue == undefined || key == undefined || gold == undefined) {
@@ -408,18 +428,22 @@ export class AblyService implements PubSub {
     }
     let health_for_update = player.health;
     let gold_for_update = player.gold;
+    let attack_for_update = player.attack;
     if (player.health <= 0) {
       //get default health to reset
       health_for_update = mobFactory.getTemplate('player').health;
       gold_for_update = 0; //reset gold to 0
+      health_for_update = mobFactory.getTemplate('player').attack;
     }
     console.log('\t Persist player health:', health_for_update);
     console.log('\t Persist player gold:', gold_for_update);
+    console.log('\t Persist player attack:', attack_for_update);
     // Update existing character data
     const playerData: PlayerData = {
       health: health_for_update,
       name: player.name,
       gold: gold_for_update,
+      attack: attack_for_update,
       appearance: ''
     };
     this.sendPlayerData(char_id, playerData);
@@ -429,7 +453,8 @@ export class AblyService implements PubSub {
     username: string,
     char_id: number,
     health: number,
-    gold: number
+    gold: number,
+    attack: number
   ) {
     const playerChannelName = `${username}-${this.worldID}`;
     const playerChannel = this.ably.channels.get(playerChannelName);
@@ -455,6 +480,7 @@ export class AblyService implements PubSub {
       if (!player) {
         console.log(`Making mob for the character that joined: ${username}
           \t health recieved: ${health}
+          \t attack recieved: ${attack}
           \t gold recieved: ${gold} `);
         mobFactory.makeMob(
           'player',
@@ -463,7 +489,8 @@ export class AblyService implements PubSub {
           data.name,
           data.subtype,
           health,
-          gold
+          gold,
+          attack
         );
       } else if (player.subtype !== data.subtype || player.name !== data.name) {
         player.updatePlayer(data.name, data.subtype);

--- a/packages/server/src/services/clientCommunication/ablyService.ts
+++ b/packages/server/src/services/clientCommunication/ablyService.ts
@@ -274,7 +274,9 @@ export class AblyService implements PubSub {
 
   public changePersonality(key: string, trait: string, newValue: number): void {
     if (key === undefined || newValue === undefined || trait === undefined) {
-      throw new Error(`Sending invalid changePersonality message: ${key}, ${trait}, ${newValue}`);
+      throw new Error(
+        `Sending invalid changePersonality message: ${key}, ${trait}, ${newValue}`
+      );
     }
     this.addToBroadcast({
       type: 'mob_change',
@@ -332,7 +334,6 @@ export class AblyService implements PubSub {
       }
     });
   }
-
 
   public changeGold(key: string, gold: number, newValue: number): void {
     if (newValue == undefined || key == undefined || gold == undefined) {

--- a/packages/server/src/services/clientCommunication/clientMarshalling.ts
+++ b/packages/server/src/services/clientCommunication/clientMarshalling.ts
@@ -55,7 +55,8 @@ function mobDataToMob(mobData: MobData): MobI {
     attributes: {
       health: mobData.health,
       gold: mobData.gold,
-      speed: mobData.speed
+      speed: mobData.speed,
+      attack: mobData.attack
     },
     unlocks: mobData.community_id ? [mobData.community_id] : [],
     doing: mobData.current_action

--- a/packages/server/src/services/clientCommunication/clientMarshalling.ts
+++ b/packages/server/src/services/clientCommunication/clientMarshalling.ts
@@ -41,14 +41,15 @@ export function dateToFantasyDate(date: FantasyDate): FantasyDateI {
 
 function mobDataToMob(mobData: MobData): MobI {
   const mob: MobI = {
-    personalities: mobData.personalities && mobData.personalities.traits
-    ? Object.fromEntries(
-        Object.entries(mobData.personalities.traits).map(([key, value]) => {
-          const numericValue = Number(value);
-          return [key, isNaN(numericValue) ? 0 : numericValue];
-        })
-      )
-    : {},
+    personalities:
+      mobData.personalities && mobData.personalities.traits
+        ? Object.fromEntries(
+            Object.entries(mobData.personalities.traits).map(([key, value]) => {
+              const numericValue = Number(value);
+              return [key, isNaN(numericValue) ? 0 : numericValue];
+            })
+          )
+        : {},
     id: mobData.id,
     position: { x: mobData.position_x, y: mobData.position_y },
     type: mobData.action_type,
@@ -140,7 +141,6 @@ export function getMobsAbly(): MobI[] {
 
   return mobs;
 }
-
 
 function itemDataToItem(
   itemData: ItemData,

--- a/packages/server/src/services/clientCommunication/pubsub.ts
+++ b/packages/server/src/services/clientCommunication/pubsub.ts
@@ -35,14 +35,7 @@ export interface PubSub {
   ): void;
   changeGold(key: string, gold: number, newValue: number): void;
   changeAttack(key: string, attack: number, newValue: number): void;
-  changeStubbornness(key: string, stubbornness: number, newValue: number): void;
-  changeBravery(key: string, bravery: number, newValue: number): void;
-  changeAggression(key: string, aggression: number, newValue: number): void;
-  changeIndustriousness(key: string, industriousness: number, newValue: number): void;
-  changeAdventurousness(key: string, adventurousness: number, newValue: number): void;
-  changeGluttony(key: string, gluttony: number, newValue: number): void;
-  changeSleepy(key: string, sleepy: number, newValue: number): void;
-  changeExtroversion(key: string, extroversion: number, newValue: number): void;
+  changePersonality(key: string, trait: string, newValue: number): void;
   changeItemAttribute(itemKey: string, property: string, value: number): void;
   speak(key: string, message: string): void;
   setDateTime(fantasyDate: FantasyDate): void;

--- a/packages/server/src/services/clientCommunication/pubsub.ts
+++ b/packages/server/src/services/clientCommunication/pubsub.ts
@@ -35,6 +35,14 @@ export interface PubSub {
   ): void;
   changeGold(key: string, gold: number, newValue: number): void;
   changeAttack(key: string, attack: number, newValue: number): void;
+  changeStubbornness(key: string, stubbornness: number, newValue: number): void;
+  changeBravery(key: string, bravery: number, newValue: number): void;
+  changeAggression(key: string, aggression: number, newValue: number): void;
+  changeIndustriousness(key: string, industriousness: number, newValue: number): void;
+  changeAdventurousness(key: string, adventurousness: number, newValue: number): void;
+  changeGluttony(key: string, gluttony: number, newValue: number): void;
+  changeSleepy(key: string, sleepy: number, newValue: number): void;
+  changeExtroversion(key: string, extroversion: number, newValue: number): void;
   changeItemAttribute(itemKey: string, property: string, value: number): void;
   speak(key: string, message: string): void;
   setDateTime(fantasyDate: FantasyDate): void;

--- a/packages/server/src/services/clientCommunication/pubsub.ts
+++ b/packages/server/src/services/clientCommunication/pubsub.ts
@@ -34,6 +34,7 @@ export interface PubSub {
     newValue: number
   ): void;
   changeGold(key: string, gold: number, newValue: number): void;
+  changeAttack(key: string, attack: number, newValue: number): void;
   changeItemAttribute(itemKey: string, property: string, value: number): void;
   speak(key: string, message: string): void;
   setDateTime(fantasyDate: FantasyDate): void;

--- a/packages/server/src/services/clientCommunication/stubbedPubSub.ts
+++ b/packages/server/src/services/clientCommunication/stubbedPubSub.ts
@@ -40,6 +40,8 @@ export class StubbedPubSub implements PubSub {
     _newValue: number
   ): void {}
 
+  changeAttack(_key: string, _attack: number, _newValue: number): void {}
+
   changeGold(_key: string, _gold: number, _newValue: number): void {}
 
   changeItemAttribute(

--- a/packages/server/src/services/clientCommunication/stubbedPubSub.ts
+++ b/packages/server/src/services/clientCommunication/stubbedPubSub.ts
@@ -40,6 +40,22 @@ export class StubbedPubSub implements PubSub {
     _newValue: number
   ): void {}
 
+  changeStubbornness(_key: string, _stubbornness: number, _newValue: number): void {}
+
+  changeBravery(_key: string, _bravery: number, _newValue: number): void {}
+
+  changeAggression(_key: string, _aggression: number, _newValue: number): void {}
+
+  changeIndustriousness(_key: string, _industriousness: number, _newValue: number): void {}
+
+  changeAdventurousness(_key: string, _adventurousness: number, _newValue: number): void {}
+
+  changeGluttony(_key: string, _gluttony: number, _newValue: number): void {}
+
+  changeSleepy(_key: string, _sleepy: number, _newValue: number): void {}
+
+  changeExtroversion(_key: string, _extroversion: number, _newValue: number): void {}
+
   changeAttack(_key: string, _attack: number, _newValue: number): void {}
 
   changeGold(_key: string, _gold: number, _newValue: number): void {}

--- a/packages/server/src/services/clientCommunication/stubbedPubSub.ts
+++ b/packages/server/src/services/clientCommunication/stubbedPubSub.ts
@@ -40,21 +40,7 @@ export class StubbedPubSub implements PubSub {
     _newValue: number
   ): void {}
 
-  changeStubbornness(_key: string, _stubbornness: number, _newValue: number): void {}
-
-  changeBravery(_key: string, _bravery: number, _newValue: number): void {}
-
-  changeAggression(_key: string, _aggression: number, _newValue: number): void {}
-
-  changeIndustriousness(_key: string, _industriousness: number, _newValue: number): void {}
-
-  changeAdventurousness(_key: string, _adventurousness: number, _newValue: number): void {}
-
-  changeGluttony(_key: string, _gluttony: number, _newValue: number): void {}
-
-  changeSleepy(_key: string, _sleepy: number, _newValue: number): void {}
-
-  changeExtroversion(_key: string, _extroversion: number, _newValue: number): void {}
+  changePersonality(_key: string, _trait: string, _newValue: number): void {}
 
   changeAttack(_key: string, _attack: number, _newValue: number): void {}
 

--- a/packages/server/test/mobs/mob.test.ts
+++ b/packages/server/test/mobs/mob.test.ts
@@ -149,7 +149,7 @@ describe('Mob Tests', () => {
       expect(testMob?.attack).toBe(5);
       testMob?.changeAttack(-2);
       expect(testMob?.attack).toBe(3);
-    })
+    });
 
     test('Mob personality values can be changed', () => {
       const mobId = 'testmob-personality';
@@ -159,10 +159,10 @@ describe('Mob Tests', () => {
       const testMob = Mob.getMob(mobId);
 
       // personality bravery init is 5. 5 should be 10 bravery.
-      expect(testMob?.personality.traits["bravery"]).toBe(5);
-      testMob?.changePersonality("bravery", 5);
-      expect(testMob?.personality.traits["bravery"]).toBe(10);
-    })
+      expect(testMob?.personality.traits['bravery']).toBe(5);
+      testMob?.changePersonality('bravery', 5);
+      expect(testMob?.personality.traits['bravery']).toBe(10);
+    });
   });
 
   describe('Mob Removal', () => {

--- a/packages/server/test/mobs/mob.test.ts
+++ b/packages/server/test/mobs/mob.test.ts
@@ -137,6 +137,34 @@ describe('Mob Tests', () => {
     });
   });
 
+  describe('Mob attribute changes', () => {
+    test('Mob attack can be changed', () => {
+      const mobId = 'testmob-attack';
+      const playerPosition: Coord = { x: 0, y: 0 };
+
+      mobFactory.makeMob('player', playerPosition, mobId, 'testPlayer');
+      const testMob = Mob.getMob(mobId);
+
+      // attack init is 5. -2 should be 3 attack.
+      expect(testMob?.attack).toBe(5);
+      testMob?.changeAttack(-2);
+      expect(testMob?.attack).toBe(3);
+    })
+
+    test('Mob personality values can be changed', () => {
+      const mobId = 'testmob-personality';
+      const playerPosition: Coord = { x: 0, y: 0 };
+
+      mobFactory.makeMob('player', playerPosition, mobId, 'testPlayer');
+      const testMob = Mob.getMob(mobId);
+
+      // personality bravery init is 5. 5 should be 10 bravery.
+      expect(testMob?.personality.traits["bravery"]).toBe(5);
+      testMob?.changePersonality("bravery", 5);
+      expect(testMob?.personality.traits["bravery"]).toBe(10);
+    })
+  });
+
   describe('Mob Removal', () => {
     test('Mob is removed correctly and no longer accessible', () => {
       const mobId = 'testmob-remove';


### PR DESCRIPTION
Group: Darren Hong, Andrew Mei

**Bug Description** (Issue https://github.com/sloalchemist/potions/issues/209): Making sure the Player Profile can present the attack stats and personality stats, as well as making them mutable for any future features. 

**What Changed**: We changed `mob.ts` in the common folder to allow all MobIs to contain personalities. We added functions in `mob.ts` in the server folder to where the stats can be mutable. In `clientMarshalling`, we formatted the personality data so that the client is able to read it. In `uxScene`, we updated User Interface to contain new attacks and personality stats. The default values of the stats were already provided by the `global.json` in the server folder. We used `community_id` for the players affiliation and is unmutable.

Result:
<img width="454" alt="image" src="https://github.com/user-attachments/assets/3e980b52-a7c3-40e2-b01f-11c6c02265a2" />

