### PR TITLE
196 feature respawn after death

### DIFF
--- a/packages/client/src/scenes/loadWorldScene.ts
+++ b/packages/client/src/scenes/loadWorldScene.ts
@@ -10,7 +10,7 @@ import { setGameState } from '../world/controller';
 import { SCREEN_HEIGHT, SCREEN_WIDTH } from '../config';
 import { parseName } from '../utils/validators';
 
-const buttonStyle = {
+export const buttonStyle = {
   fontSize: '24px',
   color: '#ffffff',
   backgroundColor: '#28a745', // Green background
@@ -21,7 +21,7 @@ const buttonStyle = {
   align: 'center'
 };
 
-const nameButtonHoverStyle = {
+export const nameButtonHoverStyle = {
   backgroundColor: '#138496' // Darker teal
 };
 

--- a/packages/client/src/scenes/worldScene.ts
+++ b/packages/client/src/scenes/worldScene.ts
@@ -13,7 +13,7 @@ import { PaletteSwapper } from '../sprite/palette_swapper';
 import { SpriteHouse } from '../sprite/sprite_house';
 import { World } from '../world/world';
 import { GRAY } from './pauseScene';
-import { publishPlayerPosition } from '../services/playerToServer';
+import { leaveWorld, publishPlayerPosition } from '../services/playerToServer';
 import { getNightSkyOpacity } from '../utils/nightOverlayHandler';
 import {
   ItemType,
@@ -23,6 +23,7 @@ import {
 import { UxScene } from './uxScene';
 import { setGameState } from '../world/controller';
 import { restoreHealth, speedUpCharacter } from '../utils/developerCheats';
+import { buttonStyle, nameButtonHoverStyle } from './loadWorldScene';
 
 export let world: World;
 let needsAnimationsLoaded: boolean = true;
@@ -473,6 +474,45 @@ export class WorldScene extends Phaser.Scene {
     text.setOrigin(0, 0);
     text.setScrollFactor(0); // Make it stay static
     text.setDepth(100);
+
+    this.time.delayedCall(RESPAWN_DELAY, () => {
+      const respawn = this.add.text(90, 200, 'RESPAWN', buttonStyle);
+      respawn.setOrigin(0, 0);
+      respawn.setScrollFactor(0);
+      respawn.setDepth(100);
+      respawn.setInteractive({ useHandCursor: true });
+
+      // Hover effects
+      respawn.on('pointerover', () => {
+        respawn.setStyle(nameButtonHoverStyle);
+      });
+      respawn.on('pointerout', () => {
+        respawn.setStyle(buttonStyle);
+      });
+
+      respawn.on('pointerdown', () => {
+        this.resetToRespawn();
+      });
+
+      const menu = this.add.text(290, 200, 'MENU', buttonStyle);
+      menu.setOrigin(0, 0);
+      menu.setScrollFactor(0);
+      menu.setDepth(100);
+      menu.setInteractive({ useHandCursor: true });
+
+      // Hover effects
+      menu.on('pointerover', () => {
+        menu.setStyle(nameButtonHoverStyle);
+      });
+      menu.on('pointerout', () => {
+        menu.setStyle(buttonStyle);
+      });
+
+      menu.on('pointerdown', () => {
+        leaveWorld();
+        this.resetToLoadWorldScene();
+      });
+    });
   }
 
   /* Stop all scenes related to game play and go back to the LoadWordScene 
@@ -486,5 +526,9 @@ export class WorldScene extends Phaser.Scene {
       this.scene.stop('FrameScene');
       this.scene.start('LoadWorldScene');
     });
+  }
+
+  resetToRespawn() {
+    console.log('respawning');
   }
 }

--- a/packages/client/src/scenes/worldScene.ts
+++ b/packages/client/src/scenes/worldScene.ts
@@ -478,6 +478,7 @@ export class WorldScene extends Phaser.Scene {
     text.setDepth(100);
 
     this.time.delayedCall(RESPAWN_DELAY, () => {
+      // Add respawn button
       const respawn = this.add.text(90, 200, 'RESPAWN', buttonStyle);
       respawn.setOrigin(0, 0);
       respawn.setScrollFactor(0);
@@ -492,10 +493,12 @@ export class WorldScene extends Phaser.Scene {
         respawn.setStyle(buttonStyle);
       });
 
+      // Respawn button action
       respawn.on('pointerdown', () => {
         this.resetToRespawn();
       });
 
+      // Add menu button
       const menu = this.add.text(290, 200, 'MENU', buttonStyle);
       menu.setOrigin(0, 0);
       menu.setScrollFactor(0);
@@ -510,6 +513,7 @@ export class WorldScene extends Phaser.Scene {
         menu.setStyle(buttonStyle);
       });
 
+      // Main menu button
       menu.on('pointerdown', () => {
         this.resetToLoadWorldScene();
       });
@@ -527,6 +531,10 @@ export class WorldScene extends Phaser.Scene {
     this.scene.start('LoadWorldScene');
   }
 
+  /**
+   * Stop the world scene, re-connect to Ably after being disconnected by
+   * the server, then restart the world scene
+   */
   resetToRespawn() {
     this.scene.stop('WorldScene');
 

--- a/packages/client/src/scenes/worldScene.ts
+++ b/packages/client/src/scenes/worldScene.ts
@@ -5,7 +5,7 @@ import {
   initializePlayer,
   tick
 } from '../world/controller';
-import { bindAblyToWorldScene } from '../services/ablySetup';
+import { bindAblyToWorldScene, setupAbly } from '../services/ablySetup';
 import { TerrainType } from '@rt-potion/common';
 import { Coord } from '@rt-potion/common';
 import { publicCharacterId } from '../worldMetadata';
@@ -463,6 +463,8 @@ export class WorldScene extends Phaser.Scene {
   }
 
   showGameOver() {
+    leaveWorld();
+
     let uxscene = this.scene.get('UxScene') as UxScene;
     uxscene.chatButtons?.clearButtonOptions();
 
@@ -509,7 +511,6 @@ export class WorldScene extends Phaser.Scene {
       });
 
       menu.on('pointerdown', () => {
-        leaveWorld();
         this.resetToLoadWorldScene();
       });
     });
@@ -518,17 +519,23 @@ export class WorldScene extends Phaser.Scene {
   /* Stop all scenes related to game play and go back to the LoadWordScene 
      for character custmization and game restart.*/
   resetToLoadWorldScene() {
-    this.time.delayedCall(RESPAWN_DELAY, () => {
-      setGameState('uninitialized');
-      this.scene.stop('PauseScene');
-      this.scene.stop('WorldScene');
-      this.scene.stop('UxScene');
-      this.scene.stop('FrameScene');
-      this.scene.start('LoadWorldScene');
-    });
+    setGameState('uninitialized');
+    this.scene.stop('PauseScene');
+    this.scene.stop('WorldScene');
+    this.scene.stop('UxScene');
+    this.scene.stop('FrameScene');
+    this.scene.start('LoadWorldScene');
   }
 
   resetToRespawn() {
-    console.log('respawning');
+    this.scene.stop('WorldScene');
+
+    setupAbly()
+      .then(() => {
+        this.scene.start('WorldScene');
+      })
+      .catch((_error) => {
+        console.error('Error setting up Ably');
+      });
   }
 }

--- a/packages/client/src/services/serverToBroadcast.ts
+++ b/packages/client/src/services/serverToBroadcast.ts
@@ -15,14 +15,13 @@ import {
   SetDatetimeData,
   SpeakData
 } from '@rt-potion/common';
-import { world, WorldScene } from '../scenes/worldScene';
-import { addNewItem, addNewMob, gameState, setDate } from '../world/controller';
-import { SpriteMob } from '../sprite/sprite_mob';
-import { publicCharacterId } from '../worldMetadata';
-import { SpriteItem } from '../sprite/sprite_item';
 import { Types } from 'ably';
-import { leaveWorld } from './playerToServer';
 import { focused } from '../main';
+import { world, WorldScene } from '../scenes/worldScene';
+import { SpriteItem } from '../sprite/sprite_item';
+import { SpriteMob } from '../sprite/sprite_mob';
+import { addNewItem, addNewMob, gameState, setDate } from '../world/controller';
+import { publicCharacterId } from '../worldMetadata';
 
 export let playerDead = false;
 
@@ -113,8 +112,6 @@ export function setupBroadcast(
         // one game focused, leave the world and display game over
         waitUntilFocused.then(() => {
           scene.showGameOver();
-          leaveWorld();
-          scene.resetToLoadWorldScene();
         });
       }
     }

--- a/packages/server/src/mobs/mob.ts
+++ b/packages/server/src/mobs/mob.ts
@@ -530,11 +530,24 @@ export class Mob {
   destroy() {
     if (this.gold > 0 && this.position) {
       const position = Item.findEmptyPosition(this.position);
-      itemGenerator.createItem({
-        type: 'gold',
-        position,
-        attributes: { amount: Math.floor(this.gold / 2) }
-      });
+      //if player drop gold by half
+      if (this.type === 'player') {
+        const halfGold = Math.floor(this.gold / 2);
+        itemGenerator.createItem({
+          type: 'gold',
+          position,
+          attributes: { amount: halfGold }
+        });
+        this.changeGold(-halfGold);
+      }
+      // if player.type === 'npc' then keep all gold
+      else {
+        itemGenerator.createItem({
+          type: 'gold',
+          position,
+          attributes: { amount: this.gold }
+        });
+      }
     }
 
     const carriedItem = this.carrying;

--- a/packages/server/src/mobs/mob.ts
+++ b/packages/server/src/mobs/mob.ts
@@ -533,7 +533,7 @@ export class Mob {
       itemGenerator.createItem({
         type: 'gold',
         position,
-        attributes: { amount: this.gold }
+        attributes: { amount: Math.floor(this.gold / 2) }
       });
     }
 

--- a/packages/server/src/mobs/mob.ts
+++ b/packages/server/src/mobs/mob.ts
@@ -530,18 +530,21 @@ export class Mob {
   destroy() {
     if (this.gold > 0 && this.position) {
       const position = Item.findEmptyPosition(this.position);
-      //if player drop gold by half
+
       if (this.type === 'player') {
+        // If the player dies, drop half their gold
         const halfGold = Math.floor(this.gold / 2);
         itemGenerator.createItem({
           type: 'gold',
           position,
           attributes: { amount: halfGold }
         });
+        // NOTE: The team working on the persistence feature (which
+        // is currently incomplete on mainline) will update the changeGold
+        // method to persist to supabase in addition to the local DB
         this.changeGold(-halfGold);
-      }
-      // if player.type === 'npc' then keep all gold
-      else {
+      } else {
+        // Otherwise drop all of the mob's gold
         itemGenerator.createItem({
           type: 'gold',
           position,


### PR DESCRIPTION
**Group:  Ananya Thapar, Caroline Koddenberg, Adam Mikacich**

**Refactor description:**
Previously, when a player's health dropped to zero, the game would simply display "Game Over," requiring a refresh to restart. This PR introduces a respawn feature that allows players to continue without refreshing. Now, when a player dies, two buttons appear: Respawn and Menu. Clicking Respawn revives the player inside the portal. If the "destroyed mob" is of type player, their gold is reduced by half. If the mob is an NPC, their gold remains unchanged.

**What changed:**

`loadWorldScene.ts`
- Exported buttonStyle and nameButtonHoverStyle for use in the Respawn and Menu buttons.

`worldScene.ts`
- Added UI components for the new buttons.
- Stopped all gameplay-related scenes upon death.
- Restarted the world scene when "Respawn" is clicked.

`mob.ts`
- Implemented logic to reduce player gold by half upon respawn if player's type is player
- Ensured NPC gold remains unchanged if player's type is NPC

**Why**
This improvement enhances the game flow by preventing unnecessary refreshes.

**Before:**
<img width="493" alt="PNG image" src="https://github.com/user-attachments/assets/fe4edd8b-2817-4196-976b-d3caa48233e8" />

**After**
<img width="484" alt="PNG image" src="https://github.com/user-attachments/assets/ede99eb4-e8b6-4ec6-99a5-fa02f9b7f22c" />

https://github.com/user-attachments/assets/1de97f81-20c0-4fec-90c4-95672aabf4b2
