### PR TITLE
fix: use GITHUB_TOKEN for client deploy

### DIFF
--- a/.github/workflows/client-deploy.yml
+++ b/.github/workflows/client-deploy.yml
@@ -57,6 +57,6 @@ jobs:
       - name: Deploy to GitHub Pages
         uses: peaceiris/actions-gh-pages@v3
         with:
-            github_token: ${{ secrets.ACCESS_GITHUB_TOKEN }}
+            github_token: ${{ secrets.GITHUB_TOKEN }}
             publish_dir: ./packages/client/dist
             


### PR DESCRIPTION
ACCESS_GITHUB_TOKEN is not the correct one for actions
