### PR TITLE
Added Custom Domain Name

### DIFF
--- a/.github/workflows/client-deploy.yml
+++ b/.github/workflows/client-deploy.yml
@@ -59,4 +59,5 @@ jobs:
         with:
             github_token: ${{ secrets.GITHUB_TOKEN }}
             publish_dir: ./packages/client/dist
+            cname: potions.gg
             


### PR DESCRIPTION
We want the custom domain `potions.gg` to be used for the server world. Currently, it seems to be getting overwritten on client builds, so we have updated the build script to include the CNAME.

[Docs we followed](https://github.com/peaceiris/actions-gh-pages?tab=readme-ov-file#%EF%B8%8F-add-cname-file-cname)