### PR TITLE
Changed NPC Movement Behavior so They No Longer Walk Over Water

### DIFF
--- a/packages/server/src/mobs/mob.ts
+++ b/packages/server/src/mobs/mob.ts
@@ -294,16 +294,16 @@ export class Mob {
   }
 
   setMoveTarget(target: Coord, fuzzy: boolean = false): boolean {
-    const start = floor(this.position);
+    const start = this.position;
     const end = floor(target);
     if (
       //equals(this.target?, end) ||
-      equals(start, end) &&
+      equals(floor(start), end) &&
       this.target == null
     ) {
       return true;
     }
-    if (equals(start, end)) {
+    if (equals(floor(start), end)) {
       this.updateMoveTarget(end, [end]);
       return true;
     }


### PR DESCRIPTION
## Problem:

NPCs were cutting corners and walking over areas where they technically are not supposed to.

## Solution:

The reason was very similar to why the user was able to cut corners and walk over unwalkable areas, which was due to the fact that the start coordinate was getting floored and therefore a key point in the path gets missed. So, we removed the code for flooring the start position in the setting move target function for the mobs as it is already handled in the path finding algorithms in the common package.

## Tests:

Didn't write any tests for this as tests already exist for the path finding in the common package tests and this was a minor change to ensure the npc movement is like the user movement.

**Fixes** [#112](https://github.com/sloalchemist/potions/issues/112)