### PR TITLE
fix: display speech bubble on speak

### DIFF
--- a/packages/client/src/services/playerToServer.ts
+++ b/packages/client/src/services/playerToServer.ts
@@ -21,6 +21,9 @@ function showSpeech(message: string, response?: number) {
   if (response !== undefined) {
     publishPlayerMessage('speak', { response: response });
   }
+
+  const player = world.mobs[publicCharacterId] as SpriteMob;
+  player.showSpeechBubble(message, true);
 }
 
 export function requestFight(mob: Mob) {


### PR DESCRIPTION
During merging of https://github.com/sloalchemist/potions/pull/271, two lines were accidently deleted that display the speech bubble.

**Changes**
https://github.com/sloalchemist/potions/commit/781980d1abd284b1a01e5de086a7c961e89b1833

- Correctly display the speech bubble