### PR TITLE
Simplify Upload/Download Data Process & Allow For Multiple Worlds to be Saved

### DIFF
--- a/packages/server/src/services/developerCheats.ts
+++ b/packages/server/src/services/developerCheats.ts
@@ -1,6 +1,6 @@
 import { Mob } from '../mobs/mob';
 import { uploadLocalData } from './supabaseStorage';
-import { setLastUploadTime, supabase } from './setup';
+import { setLastUploadTime, supabase, worldID } from './setup';
 
 export function applyCheat(player: Mob, cheat_code: string) {
   if (cheat_code === 'speed') {
@@ -8,7 +8,7 @@ export function applyCheat(player: Mob, cheat_code: string) {
   } else if (cheat_code === 'health') {
     player.changeHealth(100);
   } else if (cheat_code === 'save') {
-    uploadLocalData(supabase);
+    uploadLocalData(supabase, worldID);
     setLastUploadTime(Date.now());
   }
 }

--- a/packages/server/src/services/setup.ts
+++ b/packages/server/src/services/setup.ts
@@ -42,18 +42,13 @@ async function initializeAsync() {
 
   console.log(`loading world ${worldID}`);
 
-  let downloaded = true;
-
   try {
     await downloadData(supabase);
     console.log('Data successfully downloaded from Supabase');
   } catch {
     try {
       console.log('Download failed, uploading local files instead');
-      initializeKnowledgeDB('data/knowledge-graph.db', false);
-      initializeServerDatabase('data/server-data.db');
       await uploadLocalData(supabase);
-      downloaded = false;
     } catch (error) {
       console.log(
         'Could not download data or upload data, cannot play the game'
@@ -63,10 +58,8 @@ async function initializeAsync() {
   }
 
   try {
-    if (downloaded) {
-      initializeKnowledgeDB('data/knowledge-graph.db', false);
-      initializeServerDatabase('data/server-data.db');
-    }
+    initializeKnowledgeDB('data/knowledge-graph.db', false);
+    initializeServerDatabase('data/server-data.db');
 
     const globalDescription = globalData as ServerWorldDescription;
     const specificDescription =

--- a/packages/server/src/services/setup.ts
+++ b/packages/server/src/services/setup.ts
@@ -18,6 +18,7 @@ import { shouldUploadDB } from '../util/dataUploadUtil';
 let lastUpdateTime = Date.now();
 let lastUploadTime = Date.now();
 let world: ServerWorld;
+export let worldID: string = '';
 
 export const supabase = initializeSupabase();
 
@@ -34,7 +35,7 @@ function initializeAbly(worldId: string): AblyService {
 
 async function initializeAsync() {
   const args = process.argv.slice(2);
-  const worldID = args[0];
+  worldID = args[0];
 
   if (!worldID) {
     throw new Error('No world ID provided, provide a world ID as an argument');
@@ -43,12 +44,12 @@ async function initializeAsync() {
   console.log(`loading world ${worldID}`);
 
   try {
-    await downloadData(supabase);
+    await downloadData(supabase, worldID);
     console.log('Data successfully downloaded from Supabase');
   } catch {
     try {
       console.log('Download failed, uploading local files instead');
-      await uploadLocalData(supabase);
+      await uploadLocalData(supabase, worldID);
     } catch (error) {
       console.log(
         'Could not download data or upload data, cannot play the game'
@@ -99,7 +100,7 @@ export function worldTimer() {
   }
 
   if (shouldUploadDB(now, lastUploadTime)) {
-    uploadLocalData(supabase);
+    uploadLocalData(supabase, worldID);
     lastUploadTime = now;
   }
 

--- a/packages/server/src/services/supabaseStorage.ts
+++ b/packages/server/src/services/supabaseStorage.ts
@@ -58,10 +58,18 @@ async function downloadFile(
   });
 }
 
-async function downloadData(supabase: SupabaseClient) {
+async function downloadData(supabase: SupabaseClient, worldID: string) {
   await Promise.all([
-    downloadFile('knowledge-graph-snapshot.db', 'knowledge-graph.db', supabase),
-    downloadFile('server-data-snapshot.db', 'server-data.db', supabase)
+    downloadFile(
+      `${worldID}-knowledge-graph-snapshot.db`,
+      'knowledge-graph.db',
+      supabase
+    ),
+    downloadFile(
+      `${worldID}-server-data-snapshot.db`,
+      'server-data.db',
+      supabase
+    )
   ]);
 }
 
@@ -130,14 +138,14 @@ async function uploadLocalFile(path: string, supabase: SupabaseClient) {
 }
 
 // Merges WAL into a snapshot, then uploads database files in supabase
-async function uploadLocalData(supabase: SupabaseClient) {
+async function uploadLocalData(supabase: SupabaseClient, worldID: string) {
   try {
     // Take snapshot of current state, so upload can not interrupt the next tick
     const serverDb = 'data/server-data.db';
-    const serverSnapshot = 'data/server-data-snapshot.db';
+    const serverSnapshot = `data/${worldID}-server-data-snapshot.db`;
 
     const knowledgeDb = 'data/knowledge-graph.db';
-    const knowledgeSnapshot = 'data/knowledge-graph-snapshot.db';
+    const knowledgeSnapshot = `data/${worldID}-knowledge-graph-snapshot.db`;
 
     createDbSnapshot(serverDb, serverSnapshot);
     createDbSnapshot(knowledgeDb, knowledgeSnapshot);
@@ -146,8 +154,8 @@ async function uploadLocalData(supabase: SupabaseClient) {
     mergeWalIntoDb(knowledgeSnapshot);
 
     await Promise.all([
-      uploadLocalFile('server-data-snapshot.db', supabase),
-      uploadLocalFile('knowledge-graph-snapshot.db', supabase)
+      uploadLocalFile(`${worldID}-server-data-snapshot.db`, supabase),
+      uploadLocalFile(`${worldID}-knowledge-graph-snapshot.db`, supabase)
     ]);
     console.log('Successfully uploaded local data to Supabase');
   } catch (error) {

--- a/packages/server/src/services/supabaseStorage.ts
+++ b/packages/server/src/services/supabaseStorage.ts
@@ -1,6 +1,7 @@
 import fs from 'fs';
 import { createClient, SupabaseClient } from '@supabase/supabase-js';
 import * as dotenv from 'dotenv';
+import { execSync } from 'child_process';
 import path from 'path';
 
 // Load environment variables from .env file
@@ -17,7 +18,11 @@ export function initializeSupabase() {
   );
 }
 
-async function downloadFile(file: string, supabase: SupabaseClient) {
+async function downloadFile(
+  supabase_file_name: string,
+  local_file_name: string,
+  supabase: SupabaseClient
+) {
   if (!process.env.SUPABASE_BUCKET) {
     throw Error(
       'Your server env needs the SUPABASE_BUCKET var. Check README for info'
@@ -26,7 +31,7 @@ async function downloadFile(file: string, supabase: SupabaseClient) {
 
   const { data, error } = await supabase.storage
     .from(process.env.SUPABASE_BUCKET)
-    .download(file);
+    .download(supabase_file_name);
 
   console.log(data);
 
@@ -35,7 +40,7 @@ async function downloadFile(file: string, supabase: SupabaseClient) {
   }
 
   // Convert Blob to file
-  const myfile = new File([data], file, {
+  const myfile = new File([data], local_file_name, {
     type: data.type,
     lastModified: new Date().getTime()
   });
@@ -44,7 +49,7 @@ async function downloadFile(file: string, supabase: SupabaseClient) {
   const buffer = Buffer.from(arrayBuffer);
 
   var newPath = path.join('..', 'server', 'data');
-  const destPath = path.join(newPath, file); // Target file path
+  const destPath = path.join(newPath, local_file_name); // Target file path
 
   fs.writeFile(destPath, buffer, (err) => {
     if (err) {
@@ -55,13 +60,43 @@ async function downloadFile(file: string, supabase: SupabaseClient) {
 
 async function downloadData(supabase: SupabaseClient) {
   await Promise.all([
-    downloadFile('knowledge-graph.db', supabase),
-    downloadFile('knowledge-graph.db-wal', supabase),
-    downloadFile('knowledge-graph.db-shm', supabase),
-    downloadFile('server-data.db', supabase),
-    downloadFile('server-data.db-wal', supabase),
-    downloadFile('server-data.db-shm', supabase)
+    downloadFile('knowledge-graph-snapshot.db', 'knowledge-graph.db', supabase),
+    downloadFile('server-data-snapshot.db', 'server-data.db', supabase)
   ]);
+}
+
+function createDbSnapshot(originalDbPath: string, snapshotDbPath: string) {
+  try {
+    console.log(
+      `Creating a snapshot of ${originalDbPath} at ${snapshotDbPath}...`
+    );
+
+    // Copy the database and its WAL file (if it exists)
+    fs.copyFileSync(originalDbPath, snapshotDbPath);
+    if (fs.existsSync(`${originalDbPath}-wal`)) {
+      fs.copyFileSync(`${originalDbPath}-wal`, `${snapshotDbPath}-wal`);
+    }
+
+    console.log(`Snapshot created at ${snapshotDbPath}`);
+  } catch (error) {
+    console.error(`Error creating snapshot:`, error);
+    throw error;
+  }
+}
+
+function mergeWalIntoDb(dbPath: string) {
+  try {
+    console.log(`Merging WAL into ${dbPath} snapshot...`);
+
+    // Run SQLite commands to merge WAL and compact the snapshot
+    execSync(`sqlite3 ${dbPath} "PRAGMA journal_mode=DELETE;"`);
+    execSync(`sqlite3 ${dbPath} "VACUUM;"`);
+
+    console.log(`Successfully merged WAL into ${dbPath}`);
+  } catch (error) {
+    console.error(`Error merging WAL into ${dbPath}:`, error);
+    throw error;
+  }
 }
 
 async function uploadLocalFile(path: string, supabase: SupabaseClient) {
@@ -94,15 +129,25 @@ async function uploadLocalFile(path: string, supabase: SupabaseClient) {
   }
 }
 
+// Merges WAL into a snapshot, then uploads database files in supabase
 async function uploadLocalData(supabase: SupabaseClient) {
   try {
+    // Take snapshot of current state, so upload can not interrupt the next tick
+    const serverDb = 'data/server-data.db';
+    const serverSnapshot = 'data/server-data-snapshot.db';
+
+    const knowledgeDb = 'data/knowledge-graph.db';
+    const knowledgeSnapshot = 'data/knowledge-graph-snapshot.db';
+
+    createDbSnapshot(serverDb, serverSnapshot);
+    createDbSnapshot(knowledgeDb, knowledgeSnapshot);
+
+    mergeWalIntoDb(serverSnapshot);
+    mergeWalIntoDb(knowledgeSnapshot);
+
     await Promise.all([
-      uploadLocalFile('server-data.db', supabase),
-      uploadLocalFile('server-data.db-wal', supabase),
-      uploadLocalFile('server-data.db-shm', supabase),
-      uploadLocalFile('knowledge-graph.db', supabase),
-      uploadLocalFile('knowledge-graph.db-wal', supabase),
-      uploadLocalFile('knowledge-graph.db-shm', supabase)
+      uploadLocalFile('server-data-snapshot.db', supabase),
+      uploadLocalFile('knowledge-graph-snapshot.db', supabase)
     ]);
     console.log('Successfully uploaded local data to Supabase');
   } catch (error) {


### PR DESCRIPTION
We simplified the upload/download data process by merging the WAL file into the db file, then only uploading the db file. This is not only simpler, but also fixes a rogue bug with the previous implementation.

In addition, the file being uploaded now includes the world ID, allowing for multiple worlds to be saved. 