### PR TITLE
Upgrade Node Version for Supabase Change

### DIFF
--- a/.github/workflows/client-deploy.yml
+++ b/.github/workflows/client-deploy.yml
@@ -23,7 +23,7 @@ jobs:
       - name: Set up Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: '18' # Use the version your project requires
+          node-version: '20' # Use the version your project requires
 
       # Step 3: Install PNPM
       - name: Install PNPM


### PR DESCRIPTION
The Supabase change just released did not change Node Version in the client build workflow causing the deploy to fail in Render. The required node version is 20 or higher, so I have updated to node 20 for them.