### PR TITLE
fix: prevent give item interaction if mob is carrying

### DIFF
--- a/packages/client/src/world/controller.ts
+++ b/packages/client/src/world/controller.ts
@@ -186,7 +186,7 @@ export function getCarriedItemInteractions(
 
   // give to nearby mobs
   nearbyMobs.forEach((mob) => {
-    if (mob.key !== playerId) {
+    if (mob.key !== playerId && !mob.carrying) {
       interactions.push({
         action: 'give',
         item: item as Item,

--- a/packages/client/test/items/uses/playerCarriedItems.test.ts
+++ b/packages/client/test/items/uses/playerCarriedItems.test.ts
@@ -1,0 +1,76 @@
+import { getCarriedItemInteractions } from '../../../src/world/controller';
+import { Item } from '../../../src/world/item';
+import { Mob } from '../../../src/world/mob';
+import { World } from '../../../src/world/world';
+import { ItemType } from '../../../src/worldDescription';
+
+describe('"Give" action item interaction tests', () => {
+  let world: World | null = null;
+  let log_item: Item | null = null;
+  let nearby_mob: Mob | null = null;
+
+  beforeAll(() => {
+    world = new World();
+    world.load({
+      tiles: [
+        [-1, -1],
+        [-1, -1]
+      ],
+      terrain_types: [{ id: 0, name: 'Grass', walkable: true }],
+      item_types: [],
+      mob_types: []
+    });
+
+    const log_type: ItemType = {
+      name: 'Log',
+      type: 'log',
+      carryable: true,
+      smashable: true,
+      walkable: false,
+      interactions: [],
+      attributes: []
+    };
+    log_item = new Item(world!, 'log', { x: 1, y: 1 }, log_type);
+
+    nearby_mob = new Mob(
+      world!,
+      'mob2',
+      'Player2',
+      'player',
+      100,
+      { x: 1, y: 1 },
+      {},
+      {}
+    );
+  });
+
+  test('Give action is present when receiver is not carrying an item', () => {
+    const interactions = getCarriedItemInteractions(
+      log_item!,
+      [],
+      [nearby_mob!],
+      'player'
+    );
+
+    expect(interactions.some((interaction) => interaction.action === 'give'));
+  });
+
+  test('Give action is absent when receiver is carrying item', () => {
+    nearby_mob!.carrying = 'log';
+
+    const interactions = getCarriedItemInteractions(
+      log_item!,
+      [],
+      [nearby_mob!],
+      'player'
+    );
+
+    expect(
+      interactions.some((interaction) => interaction.action === 'give')
+    ).toBe(false);
+  });
+
+  afterAll(() => {
+    world = null;
+  });
+});


### PR DESCRIPTION
Group: Daniel Ching, Josh Queja, Keith Lee

### Bug
When a player possesses an item and encounters a mob that already holds an item, the option to give the item to the mob should not appear. Functionally, nothing happens if the button is pressed.

<img src="https://github.com/user-attachments/assets/f3a693d6-c2cf-4729-bc41-ac4dc87390c0" width="300" height="300" />

### Changes
https://github.com/sloalchemist/potions/commit/4d9c9ffddc882e8206f310730cab5b9c793abf58

- Check if mobs are carrying items before adding the 'give' interaction

### Testing

- Created `playerCarriedItems.test.ts` to verify presence/absence of 'give' interaction