### PR TITLE
prevent player movement with WASD when chat is open

### DIFF
--- a/packages/client/src/scenes/worldScene.ts
+++ b/packages/client/src/scenes/worldScene.ts
@@ -535,6 +535,10 @@ export class WorldScene extends Phaser.Scene {
       return;
     }
 
+    if (this.scene.isActive('ChatOverlayScene')) {
+      return;
+    }
+
     let moveX = player.position.x;
     let moveY = player.position.y;
 


### PR DESCRIPTION
When opening the chat for players to type in, if they type the WASD keys, the player will move in the game world while at the same time typing those keys in the chat.

Fix: If `ChatOverlayScene` is active then return from `handlePlayerMovement` function.

Unit Tests: None