### PR TITLE
fix max health being attack value after death

### DIFF
--- a/packages/server/src/services/clientCommunication/ablyService.ts
+++ b/packages/server/src/services/clientCommunication/ablyService.ts
@@ -471,7 +471,7 @@ export class AblyService implements PubSub {
       //get default health to reset
       health_for_update = mobFactory.getTemplate('player').health;
       gold_for_update = 0; //reset gold to 0
-      health_for_update = mobFactory.getTemplate('player').attack;
+      attack_for_update = mobFactory.getTemplate('player').attack;
     }
     console.log('\t Persist player health:', health_for_update);
     console.log('\t Persist player gold:', gold_for_update);


### PR DESCRIPTION
After dying for the first time, player max health becomes the value of their attack.

Fix: Set player health to the correct value in `packages/server/src/services/clientCommunication/ablyService.ts` when sending player data after dying instead of setting it to the player's attack value.

Unit Tests: None