### PR TITLE
Fix #369: Client / Server Mob Community Communication for Controller Interactions

### DIFF
--- a/packages/client/src/sprite/sprite_mob.ts
+++ b/packages/client/src/sprite/sprite_mob.ts
@@ -47,7 +47,8 @@ export class SpriteMob extends Mob {
       mob.maxHealth,
       mob.position,
       mob.attributes,
-      mob.personalities
+      mob.personalities,
+      mob.community_id
     );
     this.scene = scene;
     this.path = mob.path;
@@ -56,6 +57,7 @@ export class SpriteMob extends Mob {
     this.carrying = mob.carrying;
     this.doing = mob.doing;
     this.unlocks = mob.unlocks;
+    this.community_id = mob.community_id;
 
     if (this.subtype) {
       const parts = this.subtype.split('-');

--- a/packages/client/src/world/controller.ts
+++ b/packages/client/src/world/controller.ts
@@ -230,24 +230,10 @@ export function getPhysicalInteractions(
   physical: Physical,
   carried?: Item
 ): Interactions[] {
-  console.log('Debugging getPhysicalInteractions');
-  console.log('world:', world);
-  console.log('publicCharacterId:', publicCharacterId);
-  console.log('world.mobs:', world ? world.mobs : ' world is undefined');
-  console.log(
-    'world.mobs[publicCharacterId]:',
-    world?.mobs?.[publicCharacterId] ??
-      ' world.mobs[publicCharacterId] is undefined'
-  );
-
   const interactions: Interactions[] = [];
   const item = physical as Item;
   const player = world.mobs[publicCharacterId] as SpriteMob;
   const isOwner = item.isOwnedBy(player.community_id);
-
-  console.log(
-    `commmunity: ${player.community_id}; item owned by ${item.ownedBy}; isOwner? ${isOwner}`
-  );
 
   // if the item can be picked up
   if (item.itemType.carryable) {

--- a/packages/client/src/world/controller.ts
+++ b/packages/client/src/world/controller.ts
@@ -234,6 +234,11 @@ export function getPhysicalInteractions(
   const item = physical as Item;
   const isOwner = item.isOwnedBy(currentCharacter?.community_id);
 
+
+  // const player = world.mobs[publicCharacterId] as SpriteMob;
+
+  // console.log(`commmunity: ${currentCharacter?.community_id}; item owned by ${item.ownedBy}; isOwner? ${isOwner}`)
+
   // if the item can be picked up
   if (item.itemType.carryable) {
     interactions.push({

--- a/packages/client/src/world/controller.ts
+++ b/packages/client/src/world/controller.ts
@@ -230,14 +230,24 @@ export function getPhysicalInteractions(
   physical: Physical,
   carried?: Item
 ): Interactions[] {
+  console.log('Debugging getPhysicalInteractions');
+  console.log('world:', world);
+  console.log('publicCharacterId:', publicCharacterId);
+  console.log('world.mobs:', world ? world.mobs : ' world is undefined');
+  console.log(
+    'world.mobs[publicCharacterId]:',
+    world?.mobs?.[publicCharacterId] ??
+      ' world.mobs[publicCharacterId] is undefined'
+  );
+
   const interactions: Interactions[] = [];
   const item = physical as Item;
-  const isOwner = item.isOwnedBy(currentCharacter?.community_id);
+  const player = world.mobs[publicCharacterId] as SpriteMob;
+  const isOwner = item.isOwnedBy(player.community_id);
 
-
-  // const player = world.mobs[publicCharacterId] as SpriteMob;
-
-  // console.log(`commmunity: ${currentCharacter?.community_id}; item owned by ${item.ownedBy}; isOwner? ${isOwner}`)
+  console.log(
+    `commmunity: ${player.community_id}; item owned by ${item.ownedBy}; isOwner? ${isOwner}`
+  );
 
   // if the item can be picked up
   if (item.itemType.carryable) {

--- a/packages/client/src/world/mob.ts
+++ b/packages/client/src/world/mob.ts
@@ -13,6 +13,7 @@ export class Mob extends Physical {
   personalities: Record<string, number> = {};
   unlocks: string[] = [];
   doing: string = '';
+  community_id?: string;
 
   constructor(
     world: World,
@@ -22,7 +23,8 @@ export class Mob extends Physical {
     maxHealth: number,
     position: Coord | null,
     attributes: Record<string, number>,
-    personalities: Record<string, number>
+    personalities: Record<string, number>,
+    community_id?: string
   ) {
     super(world, key, type, position);
     this.name = name;
@@ -36,6 +38,10 @@ export class Mob extends Physical {
     }
     for (const [key, value] of Object.entries(personalities)) {
       this.personalities[key] = value;
+    }
+
+    if (community_id) {
+      this.community_id = community_id;
     }
   }
 

--- a/packages/client/test/items/uses/playerPermissibleInteractions.test.ts
+++ b/packages/client/test/items/uses/playerPermissibleInteractions.test.ts
@@ -1,19 +1,33 @@
+jest.mock('../../../src/worldMetadata', () => ({
+  publicCharacterId: '11111'
+}));
+
+jest.mock('../../../src/scenes/worldScene', () => {
+  const { World } = jest.requireActual('../../../src/world/world');
+  return { world: new World() };
+});
+
+import { world } from '../../../src/scenes/worldScene';
 import {
   getInteractablePhysicals,
   getPhysicalInteractions
 } from '../../../src/world/controller';
 import { Item } from '../../../src/world/item';
-import { World } from '../../../src/world/world';
+// import { World } from '../../../src/world/world';
+// import { publicCharacterId } from '../../../src/worldMetadata';
+import { Mob } from '../../../src/world/mob';
 import { ItemType } from '../../../src/worldDescription';
 import { Coord } from '@rt-potion/common';
 
 describe('Community ownership based interactions', () => {
-  let world: World | null = null;
+  // let world: World | null = null;
   let potionStand: Item;
 
   beforeAll(() => {
     // Initialize world
-    world = new World();
+    // globalThis.world = new World();
+    // world = new World();
+
     world.load({
       tiles: [
         [0, 0, 0],
@@ -24,6 +38,24 @@ describe('Community ownership based interactions', () => {
       item_types: [],
       mob_types: []
     });
+
+    const publicCharacterId = '11111';
+    // (global as any).publicCharacterId = '11111';
+
+    const player = new Mob(
+      world,
+      publicCharacterId,
+      'player1',
+      'player',
+      100,
+      { x: 1, y: 1 },
+      {},
+      {},
+      'alchemists'
+    );
+
+    world.mobs[publicCharacterId] = player;
+    world.addMobToGrid(player);
 
     // Define potion stand type with available interactions and their permissions
     const potionStandItemType: ItemType = {
@@ -60,7 +92,15 @@ describe('Community ownership based interactions', () => {
       world!,
       'potionstand',
       { x: 1, y: 1 },
-      potionStandItemType
+      potionStandItemType,
+      'alchemists'
+    );
+
+    console.log('publicCharacterId:', publicCharacterId);
+    console.log('world.mobs:', world.mobs);
+    console.log(
+      'world.mobs[publicCharacterId]:',
+      world.mobs[publicCharacterId]
     );
   });
 
@@ -103,6 +143,6 @@ describe('Community ownership based interactions', () => {
   });
 
   afterAll(() => {
-    world = null;
+    // world = null;
   });
 });

--- a/packages/client/test/items/uses/playerPermissibleInteractions.test.ts
+++ b/packages/client/test/items/uses/playerPermissibleInteractions.test.ts
@@ -14,7 +14,6 @@ import {
 } from '../../../src/world/controller';
 import { Item } from '../../../src/world/item';
 // import { World } from '../../../src/world/world';
-// import { publicCharacterId } from '../../../src/worldMetadata';
 import { Mob } from '../../../src/world/mob';
 import { ItemType } from '../../../src/worldDescription';
 import { Coord } from '@rt-potion/common';
@@ -25,9 +24,7 @@ describe('Community ownership based interactions', () => {
 
   beforeAll(() => {
     // Initialize world
-    // globalThis.world = new World();
     // world = new World();
-
     world.load({
       tiles: [
         [0, 0, 0],
@@ -40,7 +37,6 @@ describe('Community ownership based interactions', () => {
     });
 
     const publicCharacterId = '11111';
-    // (global as any).publicCharacterId = '11111';
 
     const player = new Mob(
       world,

--- a/packages/client/test/items/uses/smashGate.test.ts
+++ b/packages/client/test/items/uses/smashGate.test.ts
@@ -1,18 +1,29 @@
+jest.mock('../../../src/worldMetadata', () => ({
+  publicCharacterId: '11111'
+}));
+
+jest.mock('../../../src/scenes/worldScene', () => {
+  const { World } = jest.requireActual('../../../src/world/world');
+  return { world: new World() };
+});
+
+import { world } from '../../../src/scenes/worldScene';
 import {
   getInteractablePhysicals,
   getPhysicalInteractions
 } from '../../../src/world/controller';
 import { Item } from '../../../src/world/item';
-import { World } from '../../../src/world/world';
+// import { World } from '../../../src/world/world';
+import { Mob } from '../../../src/world/mob';
 import { ItemType } from '../../../src/worldDescription';
 import { Coord } from '@rt-potion/common';
 
 describe('Openable, smashable items have prompts to smash', () => {
-  let world: World | null = null;
+  // let world: World | null = null;
 
   beforeAll(() => {
     // Initialize world
-    world = new World();
+    // world = new World();
     world.load({
       tiles: [
         [0, 0, 0],
@@ -23,6 +34,23 @@ describe('Openable, smashable items have prompts to smash', () => {
       item_types: [],
       mob_types: []
     });
+
+    const publicCharacterId = '11111';
+
+    const player = new Mob(
+      world,
+      publicCharacterId,
+      'player1',
+      'player',
+      100,
+      { x: 1, y: 0 },
+      {},
+      {},
+      'alchemists'
+    );
+
+    world.mobs[publicCharacterId] = player;
+    world.addMobToGrid(player);
   });
 
   test('Proximity to gate results in "smash gate" prompt', () => {
@@ -134,6 +162,6 @@ describe('Openable, smashable items have prompts to smash', () => {
   });
 
   afterAll(() => {
-    world = null;
+    // world = null;
   });
 });


### PR DESCRIPTION
### Group: Bernette Chan, Harshini Karthikeyan, Chelsey Harper, Alex Ralston

## Summary
We've been working on implementing ownership (community and individual). In doing this, we found that the client and server weren't properly communicating item ownership (and mob community). 

Last week we synchronized ownership information for items between the client and server. Unfortunately, our method for communicating Mob Community was not optimal and we needed to address this issue a different way. Inconsistencies were still happening between client-side behavior and the authoritative server state.

This PR resolves the issue. 

## Changes
- modified: `packages/client/src/world/controller.ts`: Access player through world.mobs within getPhysicalInteractions.
- modified: `packages/client/src/sprite/sprite_mob.ts`: Added community_id.
- modified: `packages/client/src/world/mob.ts`: Added community_id.
- modified: `packages/client/test/items/uses/playerPermissibleInteractions.test.ts`: Mocked publicCharacterId and ensured proper world state initialization for getPhysicalInteractions.
- modified: `packages/client/test/items/uses/smashGate.test.ts`: Mocked publicCharacterId and ensured proper world state initialization for getPhysicalInteractions.