### PR TITLE
fix: typo in coverage badge link

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Potions the Game
 
-[![OtterWise Coverage](https://img.shields.io/endpoint?url=https://otterwise.app/badge/github/sloalchemist/potions/coverage)](https://otterwise.app/github/smbock42/CSC-487)
+[![OtterWise Coverage](https://img.shields.io/endpoint?url=https://otterwise.app/badge/github/sloalchemist/potions/coverage)](https://otterwise.app/github/sloaclehmist/potions)
 
 ## Introduction
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Potions the Game
 
-[![OtterWise Coverage](https://img.shields.io/endpoint?url=https://otterwise.app/badge/github/sloalchemist/potions/coverage)](https://otterwise.app/github/sloaclehmist/potions)
+[![OtterWise Coverage](https://img.shields.io/endpoint?url=https://otterwise.app/badge/github/sloalchemist/potions/coverage)](https://otterwise.app/github/sloalchemist/potions)
 
 ## Introduction
 


### PR DESCRIPTION
This pull request includes a minor update to the `README.md` file. The change corrects the URL for the OtterWise coverage badge to point to the correct repository.

* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L3-R3): Updated the OtterWise coverage badge URL to point to the correct repository.