### PR TITLE
fix: The effects UI is set to not visible when switching to fight tab

### DIFF
--- a/packages/client/src/scenes/uxScene.ts
+++ b/packages/client/src/scenes/uxScene.ts
@@ -678,6 +678,10 @@ export class UxScene extends Phaser.Scene {
     this.statsContainer?.setVisible(false);
     this.itemsContainer?.setVisible(false);
     this.chatContainer?.setVisible(false);
+    this.recipeContainer?.setVisible(false);
+    this.effectsContainer?.setVisible(false);
+    this.nextButton?.setVisible(false);
+    this.backButton?.setVisible(false);
     this.fightContainer?.setVisible(true);
     this.updateTabStyles('fight');
   }


### PR DESCRIPTION
Group: Darren Hong, Andrew Mei

Bug Fix for #364 

**Description**: The effects UI for the Handbook tab stayed when switching over to the Fight tab. We fixed this by setting the problematic containers to not be visible when switching to the Fight tab in `uxScene.ts`.

Before:
![image](https://github.com/user-attachments/assets/1b55ec00-b02c-4167-89f0-c8d87e0a59a9)

After:
![image](https://github.com/user-attachments/assets/a73f7cbd-f6ae-4966-9397-df63e754202a)


