### PR TITLE
392 adding explicit restart instructions for terraform

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,20 +106,21 @@ Use `./tf.ps1 <any_terraform_command>`
 │ /bin/bash: -c: line 9: syntax error near unexpected token `|'
 ' /bin/bash: -c: line 9: `    | jq -r '.status')`
 
-If you see this error:
->Error: Invalid template interpolation value
-│
-│   on main.tf line 176, in resource "local_file" "server_env":
-│  172:   content         = <<-EOT
-│  173:     ABLY_API_KEY=${ably_api_key.root.key}
-│  174:     AUTH_SERVER_URL=http://localhost:3000
-│  175:     SUPABASE_URL=https://${supabase_project.potions.id}.supabase.co
-│  176:     SUPABASE_SERVICE_KEY=${data.supabase_apikeys.dev.service_role_key}
-│  177:   EOT
-│
-│ The expression result is null. Cannot include a null value in a string template.
+**TERRAFORM STATE PROBLEMS**
 
-You need to manually delete your /terraform/terraform.tfstate file and /terraform/terraform.tfstate.backup. Then, in their respective dashboards, delete your supabase potions-dev project and ably potions-dev projects. Then, rerun /tf.ps1 for Windows and /tf.sh for MacOS.
+Your state may become out of sync for several reasons. 
+
+1. If you manually delete or create projects in provider dashboards
+2. You delete your state file without also deleting all provisioned resources (Supabase or Ably projects)
+3. You change your credentials while resources are still provisioned (up and running)
+4. Any other way in which resources change without running a terraform command
+
+**HOW TO RESYNC YOUR STATE**
+
+1. You need to manually delete your /terraform/terraform.tfstate file and /terraform/terraform.tfstate.backup. 
+2. In their respective dashboards, delete your supabase potions-dev project and ably potions-dev projects. 
+3. In extreme cases, delete any running Docker containers or images associated with terraform using Docker Desktop. If this is necessary please reach out to Alfred Madere or Nick Perlich on Slack so we can find the root of the problem.
+4. Rerun /tf.ps1 for Windows or /tf.sh for MacOS.
 
 ### Build
 1. In your root folder, execute:

--- a/README.md
+++ b/README.md
@@ -106,6 +106,21 @@ Use `./tf.ps1 <any_terraform_command>`
 │ /bin/bash: -c: line 9: syntax error near unexpected token `|'
 ' /bin/bash: -c: line 9: `    | jq -r '.status')`
 
+If you see this error:
+>Error: Invalid template interpolation value
+│
+│   on main.tf line 176, in resource "local_file" "server_env":
+│  172:   content         = <<-EOT
+│  173:     ABLY_API_KEY=${ably_api_key.root.key}
+│  174:     AUTH_SERVER_URL=http://localhost:3000
+│  175:     SUPABASE_URL=https://${supabase_project.potions.id}.supabase.co
+│  176:     SUPABASE_SERVICE_KEY=${data.supabase_apikeys.dev.service_role_key}
+│  177:   EOT
+│
+│ The expression result is null. Cannot include a null value in a string template.
+
+You need to manually delete your /terraform/terraform.tfstate file and /terraform/terraform.tfstate.backup. Then, in their respective dashboards, delete your supabase potions-dev project and ably potions-dev projects. Then, rerun /tf.ps1 for Windows and /tf.sh for MacOS.
+
 ### Build
 1. In your root folder, execute:
    ```

--- a/tf.ps1
+++ b/tf.ps1
@@ -83,7 +83,7 @@ if ($exitCode -ne 0) {
          Write-Host "If you had to time out the run of apply, check to make sure your supabase db password is correct."
     }
     else {
-         Write-Host "We haven't handle this case yet: An unknown error occurred. Please review the output above. For most issues, doing the following will solve them: You need to manually delete your /terraform/terraform.tfstate file and /terraform/terraform.tfstate.backup. Then, in their respective dashboards, delete your supabase potions-dev project and ably potions-dev projects. Then, rerun /tf.ps1 for Windows and /tf.sh for MacOS." -ForegroundColor Red
+         Write-Host "We haven't handle this case yet: An unknown error occurred. Please review the output above. In most cases, this is due to out of sync terraform state. Please refer to the section of the README called SYNCING TERRAFORM STATE." -ForegroundColor Red
     }
     Write-Host "========================================" -ForegroundColor Red
     exit $exitCode

--- a/tf.ps1
+++ b/tf.ps1
@@ -83,7 +83,7 @@ if ($exitCode -ne 0) {
          Write-Host "If you had to time out the run of apply, check to make sure your supabase db password is correct."
     }
     else {
-         Write-Host "We haven't handle this case yet: An unknown error occurred. Please review the output above." -ForegroundColor Red
+         Write-Host "We haven't handle this case yet: An unknown error occurred. Please review the output above. For most issues, doing the following will solve them: You need to manually delete your /terraform/terraform.tfstate file and /terraform/terraform.tfstate.backup. Then, in their respective dashboards, delete your supabase potions-dev project and ably potions-dev projects. Then, rerun /tf.ps1 for Windows and /tf.sh for MacOS." -ForegroundColor Red
     }
     Write-Host "========================================" -ForegroundColor Red
     exit $exitCode

--- a/tf.sh
+++ b/tf.sh
@@ -59,7 +59,7 @@ if [ $exitCode -ne 0 ]; then
     elif echo "$output" | grep -q "Project status did not reach ACTIVE_HEALTHY within."; then
          echo -e "\033[31mIf you had to time out the run of apply, check to make sure your supabase db password is correct.\033[0m"
     else
-         echo -e "\033[31mWe haven't handle this case yet: An unknown error occurred. Please review the output above. For most issues, doing the following will solve them: You need to manually delete your /terraform/terraform.tfstate file and /terraform/terraform.tfstate.backup. Then, in their respective dashboards, delete your supabase potions-dev project and ably potions-dev projects. Then, rerun /tf.ps1 for Windows and /tf.sh for MacOS.\033[0m"
+         echo -e "\033[31mWe haven't handle this case yet: An unknown error occurred. Please review the output above. In most cases, this is due to out of sync terraform state. Please refer to the section of the README called SYNCING TERRAFORM STATE.\033[0m"
     fi
     exit $exitCode
 fi

--- a/tf.sh
+++ b/tf.sh
@@ -59,7 +59,7 @@ if [ $exitCode -ne 0 ]; then
     elif echo "$output" | grep -q "Project status did not reach ACTIVE_HEALTHY within."; then
          echo -e "\033[31mIf you had to time out the run of apply, check to make sure your supabase db password is correct.\033[0m"
     else
-         echo -e "\033[31mWe haven't handle this case yet: An unknown error occurred. Please review the output above.\033[0m"
+         echo -e "\033[31mWe haven't handle this case yet: An unknown error occurred. Please review the output above. For most issues, doing the following will solve them: You need to manually delete your /terraform/terraform.tfstate file and /terraform/terraform.tfstate.backup. Then, in their respective dashboards, delete your supabase potions-dev project and ably potions-dev projects. Then, rerun /tf.ps1 for Windows and /tf.sh for MacOS.\033[0m"
     fi
     exit $exitCode
 fi


### PR DESCRIPTION
Added explicit instructions in a new readme section called TERRAFORM STATE SYNC PROBLEMS to address an issue a student had with terraform. Also, added better error handling for this case.