### PR TITLE
Refactor #394: Client-side Permissable Interactions

### DIFF
--- a/packages/client/src/sprite/sprite_mob.ts
+++ b/packages/client/src/sprite/sprite_mob.ts
@@ -29,6 +29,7 @@ export class SpriteMob extends Mob {
   speechBubbleHeight?: number;
   bubbleOffsetX?: number;
   bubbleOffsetY?: number;
+  id?: string;
 
   addCollisionListener(collisionListener: (physicals: Item[]) => void) {
     this.collisionListeners.push(collisionListener);
@@ -58,6 +59,7 @@ export class SpriteMob extends Mob {
     this.doing = mob.doing;
     this.unlocks = mob.unlocks;
     this.community_id = mob.community_id;
+    this.id = mob.id;
 
     if (this.subtype) {
       const parts = this.subtype.split('-');

--- a/packages/client/src/world/controller.ts
+++ b/packages/client/src/world/controller.ts
@@ -228,12 +228,12 @@ export function getCarriedItemInteractions(
 
 export function getPhysicalInteractions(
   physical: Physical,
-  carried?: Item
+  carried?: Item,
+  ownerId?: string
 ): Interactions[] {
   const interactions: Interactions[] = [];
   const item = physical as Item;
-  const player = world.mobs[publicCharacterId] as SpriteMob;
-  const isOwner = item.isOwnedBy(player.community_id);
+  const isOwner: boolean = ownerId ? item.isOwnedBy(ownerId) : true;
 
   // if the item can be picked up
   if (item.itemType.carryable) {
@@ -368,7 +368,7 @@ function collisionListener(physicals: Item[]) {
   interactableObjects.forEach((physical) => {
     interactions = [
       ...interactions,
-      ...getPhysicalInteractions(physical, carriedItem)
+      ...getPhysicalInteractions(physical, carriedItem, player.community_id)
     ];
   });
   // updates client only if interactions changes

--- a/packages/client/test/items/uses/playerPermissibleInteractions.test.ts
+++ b/packages/client/test/items/uses/playerPermissibleInteractions.test.ts
@@ -86,7 +86,6 @@ describe('Community ownership based interactions', () => {
   });
 
   test('Should allow community members to collect gold', () => {
-
     // Get interactable items within range of player
     const interactablePhysicals = getInteractablePhysicals(
       [potionStand],
@@ -102,7 +101,11 @@ describe('Community ownership based interactions', () => {
     // console.log('Interactable items in proximity: ', interactablePhysicals);
 
     // Get all interactions available for potion stand
-    const interactions = getPhysicalInteractions(potionStand, undefined, player.community_id);
+    const interactions = getPhysicalInteractions(
+      potionStand,
+      undefined,
+      player.community_id
+    );
     // console.log('Interactions available: ', interactions);
 
     // Collect gold should be an interaction given the defined permissions
@@ -114,7 +117,11 @@ describe('Community ownership based interactions', () => {
 
   test('Should prevent community members from purchasing potions', () => {
     // Get interactions available for the potion stand
-    const interactions = getPhysicalInteractions(potionStand, undefined, player.community_id);
+    const interactions = getPhysicalInteractions(
+      potionStand,
+      undefined,
+      player.community_id
+    );
 
     // Check that purchase is NOT an available interaction
     expect(

--- a/packages/client/test/items/uses/playerPermissibleInteractions.test.ts
+++ b/packages/client/test/items/uses/playerPermissibleInteractions.test.ts
@@ -1,30 +1,22 @@
-jest.mock('../../../src/worldMetadata', () => ({
-  publicCharacterId: '11111'
-}));
-
-jest.mock('../../../src/scenes/worldScene', () => {
-  const { World } = jest.requireActual('../../../src/world/world');
-  return { world: new World() };
-});
-
-import { world } from '../../../src/scenes/worldScene';
 import {
   getInteractablePhysicals,
   getPhysicalInteractions
 } from '../../../src/world/controller';
 import { Item } from '../../../src/world/item';
-// import { World } from '../../../src/world/world';
+import { World } from '../../../src/world/world';
 import { Mob } from '../../../src/world/mob';
 import { ItemType } from '../../../src/worldDescription';
 import { Coord } from '@rt-potion/common';
 
 describe('Community ownership based interactions', () => {
-  // let world: World | null = null;
+  let world: World | null = null;
   let potionStand: Item;
+  let player: Mob;
+  let playerPos: Coord;
 
   beforeAll(() => {
     // Initialize world
-    // world = new World();
+    world = new World();
     world.load({
       tiles: [
         [0, 0, 0],
@@ -36,20 +28,20 @@ describe('Community ownership based interactions', () => {
       mob_types: []
     });
 
+    // Put player in world to allow controller to test client side permissions
     const publicCharacterId = '11111';
-
-    const player = new Mob(
+    playerPos = { x: 1, y: 0 };
+    player = new Mob(
       world,
       publicCharacterId,
       'player1',
       'player',
       100,
-      { x: 1, y: 1 },
+      playerPos,
       {},
       {},
       'alchemists'
     );
-
     world.mobs[publicCharacterId] = player;
     world.addMobToGrid(player);
 
@@ -91,17 +83,9 @@ describe('Community ownership based interactions', () => {
       potionStandItemType,
       'alchemists'
     );
-
-    console.log('publicCharacterId:', publicCharacterId);
-    console.log('world.mobs:', world.mobs);
-    console.log(
-      'world.mobs[publicCharacterId]:',
-      world.mobs[publicCharacterId]
-    );
   });
 
   test('Should allow community members to collect gold', () => {
-    const playerPos: Coord = { x: 1, y: 0 };
 
     // Get interactable items within range of player
     const interactablePhysicals = getInteractablePhysicals(
@@ -118,7 +102,7 @@ describe('Community ownership based interactions', () => {
     // console.log('Interactable items in proximity: ', interactablePhysicals);
 
     // Get all interactions available for potion stand
-    const interactions = getPhysicalInteractions(potionStand);
+    const interactions = getPhysicalInteractions(potionStand, undefined, player.community_id);
     // console.log('Interactions available: ', interactions);
 
     // Collect gold should be an interaction given the defined permissions
@@ -130,7 +114,7 @@ describe('Community ownership based interactions', () => {
 
   test('Should prevent community members from purchasing potions', () => {
     // Get interactions available for the potion stand
-    const interactions = getPhysicalInteractions(potionStand);
+    const interactions = getPhysicalInteractions(potionStand, undefined, player.community_id);
 
     // Check that purchase is NOT an available interaction
     expect(
@@ -139,6 +123,6 @@ describe('Community ownership based interactions', () => {
   });
 
   afterAll(() => {
-    // world = null;
+    world = null;
   });
 });

--- a/packages/client/test/items/uses/smashGate.test.ts
+++ b/packages/client/test/items/uses/smashGate.test.ts
@@ -1,29 +1,18 @@
-jest.mock('../../../src/worldMetadata', () => ({
-  publicCharacterId: '11111'
-}));
-
-jest.mock('../../../src/scenes/worldScene', () => {
-  const { World } = jest.requireActual('../../../src/world/world');
-  return { world: new World() };
-});
-
-import { world } from '../../../src/scenes/worldScene';
 import {
   getInteractablePhysicals,
   getPhysicalInteractions
 } from '../../../src/world/controller';
 import { Item } from '../../../src/world/item';
-// import { World } from '../../../src/world/world';
-import { Mob } from '../../../src/world/mob';
+import { World } from '../../../src/world/world';
 import { ItemType } from '../../../src/worldDescription';
 import { Coord } from '@rt-potion/common';
 
 describe('Openable, smashable items have prompts to smash', () => {
-  // let world: World | null = null;
+  let world: World | null = null;
 
   beforeAll(() => {
     // Initialize world
-    // world = new World();
+    world = new World();
     world.load({
       tiles: [
         [0, 0, 0],
@@ -34,23 +23,6 @@ describe('Openable, smashable items have prompts to smash', () => {
       item_types: [],
       mob_types: []
     });
-
-    const publicCharacterId = '11111';
-
-    const player = new Mob(
-      world,
-      publicCharacterId,
-      'player1',
-      'player',
-      100,
-      { x: 1, y: 0 },
-      {},
-      {},
-      'alchemists'
-    );
-
-    world.mobs[publicCharacterId] = player;
-    world.addMobToGrid(player);
   });
 
   test('Proximity to gate results in "smash gate" prompt', () => {
@@ -70,8 +42,6 @@ describe('Openable, smashable items have prompts to smash', () => {
         }
       ]
     };
-
-    //const player1 = new Mob(world!, 'mob1', 'Player1', 'player', 100, playerPos, 2, {});
 
     // Instantiate the gate object
     const gate = new Item(world!, 'gate1', { x: 1, y: 1 }, gateItemType);
@@ -162,6 +132,6 @@ describe('Openable, smashable items have prompts to smash', () => {
   });
 
   afterAll(() => {
-    // world = null;
+    world = null;
   });
 });


### PR DESCRIPTION
### Group: Bernette Chan, Harshini Karthikeyan, Chelsey Harper, Alex Ralston

## Summary
Previously, the controller was using global variables to determine which interactions should be available to players on the client side.

This refactor makes it such that ownership identifiers are passed into getPhysicalInteractions(), making it simpler to implement individual ownership. Also this will make unit testing cleaner.

## Changes
- modified `packages/client/src/world/controller.ts`: Refactor getPhysicalInteractions to recieve an ownerId to determine permissible interactions such that it is not relying on global variables.
- modified `packages/client/src/sprite/sprite_mob.ts`: Add id field to sprite_mob.
- modified `packages/client/test/items/uses/playerPermissibleInteractions.test.ts`: Remove globally defined mock variables.
- modified `packages/client/test/items/uses/smashGate.test.ts`: Revert to original stats.