### PR TITLE
Fix: added permissions to baskets 

### DIFF
--- a/packages/client/src/world/controller.ts
+++ b/packages/client/src/world/controller.ts
@@ -277,7 +277,7 @@ export function getPhysicalInteractions(
           carried &&
           carried.itemType.name.localeCompare(
             item.attributes.templateType.toString()
-          )) ||
+          ) === 0) ||
         interaction.action != 'add_item'
       ) {
         interactions.push({

--- a/packages/client/test/items/uses/playerBasketInteractions.test.ts
+++ b/packages/client/test/items/uses/playerBasketInteractions.test.ts
@@ -1,6 +1,4 @@
-import {
-  getPhysicalInteractions
-} from '../../../src/world/controller';
+import { getPhysicalInteractions } from '../../../src/world/controller';
 import { Item } from '../../../src/world/item';
 import { World } from '../../../src/world/world';
 import { Mob } from '../../../src/world/mob';
@@ -53,29 +51,29 @@ describe('Community ownership based interactions', () => {
       templated: true,
       walkable: false,
       show_template_at: {
-            "x": 0,
-            "y": 7
-        },
+        x: 0,
+        y: 7
+      },
       interactions: [
         {
-          description: "Get $item_name",
-          action: "get_item",
+          description: 'Get $item_name',
+          action: 'get_item',
           while_carried: false,
           conditions: [
             {
-              attribute_name: "items",
+              attribute_name: 'items',
               value: 0,
-              comparison: "greater_than"
+              comparison: 'greater_than'
             }
           ]
         },
         {
-          description: "Add $item_name",
-          action: "add_item",
+          description: 'Add $item_name',
+          action: 'add_item',
           while_carried: false,
           permissions: {
-              "community": true,
-              "other": false
+            community: true,
+            other: false
           }
         }
       ],
@@ -90,46 +88,45 @@ describe('Community ownership based interactions', () => {
       basketItemType,
       'silverclaw'
     );
-    
+
     // Manually assign basket template type
-    basket.attributes.templateType = "Log";
+    basket.attributes.templateType = 'Log';
 
     // Create log ItemType
     const logItemType: ItemType = {
-        name: 'Log',
-        type: 'log',
-        item_group: 'fence',
-        layout_type: 'opens',
-        carryable: true,
-        smashable: true,
-        walkable: true,
-        flat: true,
-        attributes: [
-            {
-                name: "health",
-                value: 1
-            }
-        ],
-        interactions: [
-            {
-                description: "Start wall",
-                action: "start_wall",
-                while_carried: true
-            },
-            {
-                description: "Build wall",
-                action: "build_wall",
-                while_carried: true,
-                requires_item: "partial-wall"
-            }
-        ]
-      };
-  
-      // Instantiate log object
-      log = new Item(world!, 'log1', { x: 1, y: 2 }, logItemType);
+      name: 'Log',
+      type: 'log',
+      item_group: 'fence',
+      layout_type: 'opens',
+      carryable: true,
+      smashable: true,
+      walkable: true,
+      flat: true,
+      attributes: [
+        {
+          name: 'health',
+          value: 1
+        }
+      ],
+      interactions: [
+        {
+          description: 'Start wall',
+          action: 'start_wall',
+          while_carried: true
+        },
+        {
+          description: 'Build wall',
+          action: 'build_wall',
+          while_carried: true,
+          requires_item: 'partial-wall'
+        }
+      ]
+    };
+
+    // Instantiate log object
+    log = new Item(world!, 'log1', { x: 1, y: 2 }, logItemType);
   });
 
-  
   test('Should prevent community members from adding items to basket if not affiliated', () => {
     // Get interactions available for the basket
     const interactions = getPhysicalInteractions(
@@ -146,7 +143,7 @@ describe('Community ownership based interactions', () => {
 
   test('Should allow community members to add items to basket if affiliated', () => {
     // Get interactions available for the basket (now owned by alchemists to match the player)
-    basket.ownedBy = "alchemists"
+    basket.ownedBy = 'alchemists';
     const interactions = getPhysicalInteractions(
       basket,
       log,

--- a/packages/client/test/items/uses/playerBasketInteractions.test.ts
+++ b/packages/client/test/items/uses/playerBasketInteractions.test.ts
@@ -1,0 +1,165 @@
+import {
+  getPhysicalInteractions
+} from '../../../src/world/controller';
+import { Item } from '../../../src/world/item';
+import { World } from '../../../src/world/world';
+import { Mob } from '../../../src/world/mob';
+import { ItemType } from '../../../src/worldDescription';
+import { Coord } from '@rt-potion/common';
+
+describe('Community ownership based interactions', () => {
+  let world: World | null = null;
+  let basket: Item;
+  let log: Item;
+  let player: Mob;
+  let playerPos: Coord;
+
+  beforeAll(() => {
+    // Initialize world
+    world = new World();
+    world.load({
+      tiles: [
+        [0, 0, 0],
+        [0, 0, 0],
+        [0, 0, 0]
+      ],
+      terrain_types: [{ id: 0, name: 'Grass', walkable: true }],
+      item_types: [],
+      mob_types: []
+    });
+
+    // Put player in world to allow controller to test client side permissions
+    const publicCharacterId = '11111';
+    playerPos = { x: 1, y: 0 };
+    player = new Mob(
+      world,
+      publicCharacterId,
+      'player1',
+      'player',
+      100,
+      playerPos,
+      {},
+      {},
+      'alchemists'
+    );
+    world.mobs[publicCharacterId] = player;
+    world.addMobToGrid(player);
+
+    // Create basket ItemType
+    const basketItemType: ItemType = {
+      name: 'Basket',
+      type: 'basket',
+      carryable: false,
+      templated: true,
+      walkable: false,
+      show_template_at: {
+            "x": 0,
+            "y": 7
+        },
+      interactions: [
+        {
+          description: "Get $item_name",
+          action: "get_item",
+          while_carried: false,
+          conditions: [
+            {
+              attribute_name: "items",
+              value: 0,
+              comparison: "greater_than"
+            }
+          ]
+        },
+        {
+          description: "Add $item_name",
+          action: "add_item",
+          while_carried: false,
+          permissions: {
+              "community": true,
+              "other": false
+          }
+        }
+      ],
+      attributes: []
+    };
+
+    // Instantiate basket object
+    basket = new Item(
+      world!,
+      'basket',
+      { x: 1, y: 1 },
+      basketItemType,
+      'silverclaw'
+    );
+    
+    // Manually assign basket template type
+    basket.attributes.templateType = "Log";
+
+    // Create log ItemType
+    const logItemType: ItemType = {
+        name: 'Log',
+        type: 'log',
+        item_group: 'fence',
+        layout_type: 'opens',
+        carryable: true,
+        smashable: true,
+        walkable: true,
+        flat: true,
+        attributes: [
+            {
+                name: "health",
+                value: 1
+            }
+        ],
+        interactions: [
+            {
+                description: "Start wall",
+                action: "start_wall",
+                while_carried: true
+            },
+            {
+                description: "Build wall",
+                action: "build_wall",
+                while_carried: true,
+                requires_item: "partial-wall"
+            }
+        ]
+      };
+  
+      // Instantiate log object
+      log = new Item(world!, 'log1', { x: 1, y: 2 }, logItemType);
+  });
+
+  
+  test('Should prevent community members from adding items to basket if not affiliated', () => {
+    // Get interactions available for the basket
+    const interactions = getPhysicalInteractions(
+      basket,
+      log,
+      player.community_id
+    );
+
+    // Check that add_item is NOT an available interaction
+    expect(
+      interactions.some((interaction) => interaction.action === 'add_item')
+    ).toBe(false);
+  });
+
+  test('Should allow community members to add items to basket if affiliated', () => {
+    // Get interactions available for the basket (now owned by alchemists to match the player)
+    basket.ownedBy = "alchemists"
+    const interactions = getPhysicalInteractions(
+      basket,
+      log,
+      player.community_id
+    );
+
+    // Check that add_item IS an available interaction
+    expect(
+      interactions.some((interaction) => interaction.action === 'add_item')
+    ).toBe(true);
+  });
+
+  afterAll(() => {
+    world = null;
+  });
+});

--- a/packages/json-generator/global.json
+++ b/packages/json-generator/global.json
@@ -1319,7 +1319,11 @@
         {
           "description": "Add $item_name",
           "action": "add_item",
-          "while_carried": false
+          "while_carried": false,
+          "permissions": {
+            "community": true,
+            "other": false
+          }
         }
       ],
       "description": "Stores items for the community."

--- a/packages/server/data/global.json
+++ b/packages/server/data/global.json
@@ -1303,7 +1303,11 @@
                 {
                     "description": "Add $item_name",
                     "action": "add_item",
-                    "while_carried": false
+                    "while_carried": false,
+                    "permissions": {
+                        "community": true,
+                        "other": false
+                    }
                 }
             ],
             "description": "Stores items for the community."


### PR DESCRIPTION
Added permissions to baskets in respective global.json files to prevent non-affiliated species from having the button to add to baskets. I wrote unit tests, but here is UI/UX proof that the buttons correctly disappear now.

## Before:

<img width="507" alt="Screenshot 2025-02-20 at 10 01 15 PM" src="https://github.com/user-attachments/assets/43585340-92f0-41ec-9b62-8e12465ef448" />


## After:

<img width="506" alt="Screenshot 2025-02-21 at 12 17 29 AM" src="https://github.com/user-attachments/assets/b3d42cdd-0c69-4229-8fbd-aebfae4bace9" />


