### PR TITLE
fix: move sun outside of villager world

### DIFF
--- a/packages/server/data/test-world_specific.json
+++ b/packages/server/data/test-world_specific.json
@@ -409,7 +409,7 @@
     { "type": "blueberry-bush", "coord": { "x": 26, "y": 31 } },
     { "type": "portal", "coord": { "x": 15, "y": 38 } },
     { "type": "cloud", "coord": { "x": 15, "y": 22 } },
-    { "type": "sun", "coord": { "x": 35, "y": 16 } },
+    { "type": "sun", "coord": { "x": 28, "y": 25 } },
     { "type": "cannon", "coord": { "x": 42, "y": 42 } },
     { "type": "cauldron", "coord": { "x": 20, "y": 15 } }
   ],


### PR DESCRIPTION
As explained in issue #[496](https://github.com/sloalchemist/potions/issues/496), the sun (which spawns sun-drops) was placed inside the village, which is only immediately accessible to players who are "villagers" (as [explained to me by Josh Queja](https://github.com/sloalchemist/potions/issues/494). Though it would be possible for non-villagers to smash gate/fence to access village, we felt that this was burdensome and not fun playing. 