### PR TITLE
472 refactor ownedby ownedbycommunity

### DIFF
--- a/packages/client/src/sprite/sprite_item.ts
+++ b/packages/client/src/sprite/sprite_item.ts
@@ -17,7 +17,7 @@ export class SpriteItem extends Item {
   hasPickedupFrame: boolean = false;
   healthBar?: Phaser.GameObjects.Graphics;
   maxHealth?: number;
-  ownedBy?: string;
+  ownedByCommunity?: string;
 
   constructor(scene: WorldScene, item: ItemI) {
     const itemType = scene.itemTypes[item.type];
@@ -34,7 +34,7 @@ export class SpriteItem extends Item {
     this.house = item.house;
     this.carried_by = item.carried_by;
     this.lock = item.lock;
-    this.ownedBy = item.ownedBy;
+    this.ownedByCommunity = item.ownedByCommunity;
 
     // copy over all attributes
     for (const key in item.attributes) {

--- a/packages/client/src/world/controller.ts
+++ b/packages/client/src/world/controller.ts
@@ -247,7 +247,7 @@ export function getPhysicalInteractions(
 ): Interactions[] {
   const interactions: Interactions[] = [];
   const item = physical as Item;
-  const isOwner: boolean = ownerId ? item.isOwnedBy(ownerId) : true;
+  const isOwner: boolean = ownerId ? item.isOwnedByCommunity(ownerId) : true;
 
   // if the item can be picked up
   if (item.itemType.carryable) {

--- a/packages/client/src/world/item.ts
+++ b/packages/client/src/world/item.ts
@@ -14,18 +14,18 @@ export class Item extends Physical {
   templateType?: string;
   house?: string;
   lock?: string;
-  ownedBy?: string;
+  ownedByCommunity?: string;
 
   constructor(
     world: World,
     key: string,
     position: Coord | null,
     itemType: ItemType,
-    ownedBy?: string
+    ownedByCommunity?: string
   ) {
     super(world, key, itemType.type, position);
     this.itemType = itemType;
-    this.ownedBy = ownedBy;
+    this.ownedByCommunity = ownedByCommunity;
 
     if (position) {
       world.addItemToGrid(this);
@@ -39,8 +39,8 @@ export class Item extends Physical {
     return this.itemType.walkable ? true : false;
   }
 
-  isOwnedBy(community_id?: string): boolean {
-    return this.ownedBy === community_id;
+  isOwnedByCommunity(community_id?: string): boolean {
+    return this.ownedByCommunity === community_id;
   }
 
   destroy(world: World) {

--- a/packages/client/test/items/uses/playerBasketInteractions.test.ts
+++ b/packages/client/test/items/uses/playerBasketInteractions.test.ts
@@ -161,7 +161,7 @@ describe('Community ownership based interactions', () => {
   });
 
   test('Should allow community members to add items to basket if affiliated', () => {
-    basket.ownedBy = 'alchemists';
+    basket.ownedByCommunity = 'alchemists';
     // Get interactions available for the basket (now owned by alchemists to match the player)
     const interactions = getPhysicalInteractions(
       basket,
@@ -176,7 +176,7 @@ describe('Community ownership based interactions', () => {
   });
 
   test('Should prevent community members from getting items from basket if not affiliated', () => {
-    basket.ownedBy = 'silverclaw';
+    basket.ownedByCommunity = 'silverclaw';
     // Get interactions available for the basket
     const interactions = getPhysicalInteractions(
       basket,
@@ -191,7 +191,7 @@ describe('Community ownership based interactions', () => {
   });
 
   test('Should allow community members to get items from the basket if affiliated', () => {
-    basket.ownedBy = 'alchemists';
+    basket.ownedByCommunity = 'alchemists';
     // Get interactions available for the basket (now owned by alchemists to match the player)
     const interactions = getPhysicalInteractions(
       basket,

--- a/packages/common/src/item.ts
+++ b/packages/common/src/item.ts
@@ -11,5 +11,5 @@ export type ItemI = {
   house?: string;
   lock?: string;
   carried_by?: string;
-  ownedBy?: string;
+  ownedByCommunity?: string;
 };

--- a/packages/server/src/community/house.ts
+++ b/packages/server/src/community/house.ts
@@ -91,7 +91,7 @@ export class House {
     itemGenerator.createItem({
       type: 'door',
       position: doorPos,
-      ownedBy: village,
+      ownedByCommunity: village,
       house,
       lock: village.id
     });
@@ -100,13 +100,13 @@ export class House {
       itemGenerator.createItem({
         type: 'wall',
         position: { x: top_left.x, y },
-        ownedBy: village,
+        ownedByCommunity: village,
         house
       });
       itemGenerator.createItem({
         type: 'wall',
         position: { x: top_left.x + width, y },
-        ownedBy: village,
+        ownedByCommunity: village,
         house
       });
     }
@@ -117,7 +117,7 @@ export class House {
         itemGenerator.createItem({
           type: 'wall',
           position: coord1,
-          ownedBy: village,
+          ownedByCommunity: village,
           house
         });
       }
@@ -126,7 +126,7 @@ export class House {
         itemGenerator.createItem({
           type: 'wall',
           position: coord2,
-          ownedBy: village,
+          ownedByCommunity: village,
           house
         });
       }

--- a/packages/server/src/generate/generateWorld.ts
+++ b/packages/server/src/generate/generateWorld.ts
@@ -96,7 +96,9 @@ export function loadDefaults(global: ServerWorldDescription) {
     itemGenerator.createItem({
       type: item.type,
       position: item.coord,
-      ownedByCommunity: item.community ? communityMap[item.community] : undefined,
+      ownedByCommunity: item.community
+        ? communityMap[item.community]
+        : undefined,
       lock: item.lock,
       attributes: item.options
     });

--- a/packages/server/src/generate/generateWorld.ts
+++ b/packages/server/src/generate/generateWorld.ts
@@ -96,7 +96,7 @@ export function loadDefaults(global: ServerWorldDescription) {
     itemGenerator.createItem({
       type: item.type,
       position: item.coord,
-      ownedBy: item.community ? communityMap[item.community] : undefined,
+      ownedByCommunity: item.community ? communityMap[item.community] : undefined,
       lock: item.lock,
       attributes: item.options
     });
@@ -118,7 +118,7 @@ export function loadDefaults(global: ServerWorldDescription) {
       itemGenerator.createItem({
         type: container.type,
         position: container.coord,
-        ownedBy: communityMap[container.community],
+        ownedByCommunity: communityMap[container.community],
         attributes: {
           templateType: container.itemType,
           items: container.count,

--- a/packages/server/src/items/item.ts
+++ b/packages/server/src/items/item.ts
@@ -408,7 +408,11 @@ export class Item {
   validateOwnership(mob: Mob, interaction: string): boolean {
     // console.log(`${item.type} belongs to ${item.owned_by}`);
     // if no one owns the item or if the mob owns it, return true
-    if (!this.owned_by_community || mob.community_id === this.owned_by_community) return true;
+    if (
+      !this.owned_by_community ||
+      mob.community_id === this.owned_by_community
+    )
+      return true;
 
     console.warn(
       `Mob ${mob.name} (${mob.id}) from ${mob.community_id} community ` +

--- a/packages/server/src/items/item.ts
+++ b/packages/server/src/items/item.ts
@@ -27,7 +27,7 @@ export interface ItemData {
   house_id?: string;
   lock?: string;
   drops_item?: string; // i was here :3
-  owned_by?: string;
+  owned_by_community?: string;
 }
 
 export interface ItemAttributeData {
@@ -43,7 +43,7 @@ interface ItemParams {
   itemType: ItemType;
   subtype?: string;
   lock?: string;
-  ownedBy?: Community;
+  ownedByCommunity?: Community;
   house?: House;
   attributes: Record<string, string | number>;
   carriedBy?: Mob;
@@ -58,7 +58,7 @@ export class Item {
   public readonly drops_item;
   private attributes: ItemAttributes = {};
 
-  public readonly owned_by?: string;
+  public readonly owned_by_community?: string;
 
   public readonly lock?: string;
   public readonly house?: string;
@@ -70,7 +70,7 @@ export class Item {
     itemType,
     subtype,
     lock,
-    ownedBy,
+    ownedByCommunity,
     house,
     attributes = {}
   }: ItemParams) {
@@ -81,7 +81,7 @@ export class Item {
     this.lock = lock;
     this.subtype = subtype;
     this.house = house?.id;
-    this.owned_by = ownedBy?.id;
+    this.owned_by_community = ownedByCommunity?.id;
     this.drops_item = itemType.drops_item;
 
     for (const [key, value] of Object.entries(attributes)) {
@@ -106,8 +106,8 @@ export class Item {
       itemType: itemGenerator.getItemType(itemData.type),
       subtype: itemData.subtype,
       lock: itemData.lock,
-      ownedBy: itemData.owned_by
-        ? Community.getVillage(itemData.owned_by)
+      ownedByCommunity: itemData.owned_by_community
+        ? Community.getVillage(itemData.owned_by_community)
         : undefined,
       attributes: attributes
     });
@@ -116,11 +116,11 @@ export class Item {
   }
 
   static insertIntoDB(item: ItemParams) {
-    // console.log(`Inserting ${item.id} into DB with ownership: ${item.ownedBy?.id}`);
+    // console.log(`Inserting ${item.id} into DB with ownership: ${item.ownedByCommunity?.id}`);
     DB.prepare(
       `
-            INSERT INTO items (id, type, subtype, position_x, position_y, owned_by, house_id, lock)
-            VALUES (:id, :type, :subtype, :position_x, :position_y, :owned_by, :house_id, :lock);
+            INSERT INTO items (id, type, subtype, position_x, position_y, owned_by_community, house_id, lock)
+            VALUES (:id, :type, :subtype, :position_x, :position_y, :owned_by_community, :house_id, :lock);
             `
     ).run({
       id: item.id,
@@ -128,7 +128,7 @@ export class Item {
       subtype: item.subtype,
       position_x: item.position ? item.position.x : null,
       position_y: item.position ? item.position.y : null,
-      owned_by: item.ownedBy?.id,
+      owned_by_community: item.ownedByCommunity?.id,
       house_id: item.house?.id,
       lock: item.lock
     });
@@ -189,7 +189,7 @@ export class Item {
                 items.position_y,
                 mobs.id as carried_by,
                 items.lock,
-                items.owned_by
+                items.owned_by_community
             FROM items
             LEFT JOIN mobs ON mobs.carrying_id = items.id
             WHERE items.id = :id;
@@ -408,11 +408,11 @@ export class Item {
   validateOwnership(mob: Mob, interaction: string): boolean {
     // console.log(`${item.type} belongs to ${item.owned_by}`);
     // if no one owns the item or if the mob owns it, return true
-    if (!this.owned_by || mob.community_id === this.owned_by) return true;
+    if (!this.owned_by_community || mob.community_id === this.owned_by_community) return true;
 
     console.warn(
       `Mob ${mob.name} (${mob.id}) from ${mob.community_id} community ` +
-        `is not authorized to ${interaction} from ${this.type} owned by ${this.owned_by}`
+        `is not authorized to ${interaction} from ${this.type} owned by ${this.owned_by_community}`
     );
     return false;
   }
@@ -426,7 +426,7 @@ export class Item {
             position_y INTEGER, 
             lock TEXT,
             house_id TEXT REFERENCES houses (id) ON DELETE SET NULL,
-            owned_by TEXT REFERENCES community (id) ON DELETE SET NULL,
+            owned_by_community TEXT REFERENCES community (id) ON DELETE SET NULL,
             stored_by TEXT REFERENCES mobs (id) ON DELETE SET NULL, 
             UNIQUE (position_x, position_y)
         );

--- a/packages/server/src/items/itemGenerator.ts
+++ b/packages/server/src/items/itemGenerator.ts
@@ -12,7 +12,7 @@ type CreateItemParams = {
   position?: Coord;
   subtype?: string;
   lock?: string;
-  ownedBy?: Community;
+  ownedByCommunity?: Community;
   house?: House;
   attributes?: Record<string, string | number>;
   carriedBy?: Mob;
@@ -60,7 +60,7 @@ export class ItemGenerator {
     type,
     subtype,
     position,
-    ownedBy,
+    ownedByCommunity,
     house,
     attributes,
     carriedBy,
@@ -86,7 +86,7 @@ export class ItemGenerator {
       itemType,
       subtype,
       lock,
-      ownedBy,
+      ownedByCommunity,
       house,
       attributes: attributes || {},
       carriedBy

--- a/packages/server/src/items/purchasable.ts
+++ b/packages/server/src/items/purchasable.ts
@@ -58,8 +58,8 @@ export class Purchasable {
     }
 
     // Get favorability
-    const ownedBy = this.item.owned_by ?? '';
-    const favor = Community.getFavor(mob.community_id, ownedBy);
+    const ownedByCommunity = this.item.owned_by_community ?? '';
+    const favor = Community.getFavor(mob.community_id, ownedByCommunity);
 
     // Base price settings
     const baseMaxPrice = 20;

--- a/packages/server/src/items/uses/create.ts
+++ b/packages/server/src/items/uses/create.ts
@@ -10,7 +10,7 @@ export class Create {
       type: type,
       subtype: createItem.subtype,
       position: creator.position,
-      ownedBy: creatorCommunity,
+      ownedByCommunity: creatorCommunity,
       attributes: {
         templateType: createItem.type,
         items: 1,

--- a/packages/server/src/mobs/mob.ts
+++ b/packages/server/src/mobs/mob.ts
@@ -888,7 +888,7 @@ export class Mob {
             SELECT items.id
             FROM item_attributes
             JOIN items ON item_attributes.item_id = items.id
-            JOIN mobView ON mobView.community_id = items.owned_by
+            JOIN mobView ON mobView.community_id = items.owned_by_community
             WHERE mobView.id = :id and item_attributes.attribute = 'items'
         `
     ).all({ id: this.id }) as { id: string }[];
@@ -902,7 +902,7 @@ export class Mob {
             SELECT items.id
             FROM item_attributes
             JOIN items ON item_attributes.item_id = items.id
-            JOIN mobView ON mobView.community_id = items.owned_by
+            JOIN mobView ON mobView.community_id = items.owned_by_community
             WHERE item_attributes.attribute = 'items' AND mobView.id = :id
         `
     ).get({ type, id: this.id }) as { id: string };

--- a/packages/server/src/services/clientCommunication/clientMarshalling.ts
+++ b/packages/server/src/services/clientCommunication/clientMarshalling.ts
@@ -162,7 +162,7 @@ function itemDataToItem(
     position: { x: itemData.position_x, y: itemData.position_y },
     lock: itemData.lock,
     house: itemData.house_id,
-    ownedBy: itemData.owned_by,
+    ownedByCommunity: itemData.owned_by_community,
     carried_by: Mob.findCarryingMobID(itemData.id),
     attributes: itemAttributeData.reduce(
       (acc, attribute) => {
@@ -245,7 +245,7 @@ export function getItemAbly(key: string): ItemI {
             items.position_y,
             items.house_id,
             items.lock,
-            items.owned_by,
+            items.owned_by_community,
             mobs.id carrying_id
         FROM items
         LEFT JOIN mobs ON mobs.carrying_id = items.id
@@ -277,7 +277,7 @@ export function getItemsAbly(): ItemI[] {
             items.position_y,
             items.house_id,
             items.lock,
-            items.owned_by,
+            items.owned_by_community,
             mobs.id carrying_id
         FROM items
         LEFT JOIN mobs ON mobs.carrying_id = items.id;

--- a/packages/server/test/actions/create.test.ts
+++ b/packages/server/test/actions/create.test.ts
@@ -51,7 +51,7 @@ describe('Create', () => {
       type: type,
       subtype: mockItem.subtype,
       position: mockMob.position,
-      ownedBy: mockCommunity,
+      ownedByCommunity: mockCommunity,
       attributes: {
         templateType: mockItem.type,
         items: 1,

--- a/packages/server/test/items/stand/itemCommunityOwnershipPotionStandInteractions.test.ts
+++ b/packages/server/test/items/stand/itemCommunityOwnershipPotionStandInteractions.test.ts
@@ -30,7 +30,10 @@ describe('Potion Stand Ownership Tests', () => {
         type: 'potion-stand',
         subtype: '255',
         position: standPosition,
-        ownedByCommunity: new Community('silverclaw', 'Village of the Silverclaw'),
+        ownedByCommunity: new Community(
+          'silverclaw',
+          'Village of the Silverclaw'
+        ),
         attributes: {
           templateType: 'potion',
           items: 0,

--- a/packages/server/test/items/stand/itemCommunityOwnershipPotionStandInteractions.test.ts
+++ b/packages/server/test/items/stand/itemCommunityOwnershipPotionStandInteractions.test.ts
@@ -30,7 +30,7 @@ describe('Potion Stand Ownership Tests', () => {
         type: 'potion-stand',
         subtype: '255',
         position: standPosition,
-        ownedBy: new Community('silverclaw', 'Village of the Silverclaw'),
+        ownedByCommunity: new Community('silverclaw', 'Village of the Silverclaw'),
         attributes: {
           templateType: 'potion',
           items: 0,

--- a/packages/server/test/potions/favorabilityBasedPotionPurchase.test.ts
+++ b/packages/server/test/potions/favorabilityBasedPotionPurchase.test.ts
@@ -29,7 +29,7 @@ describe('Favorability-Based Purchase Tests', () => {
       type: 'potion-stand',
       subtype: '255',
       position: standPosition,
-      ownedBy: Community.getVillage('alchemists'),
+      ownedByCommunity: Community.getVillage('alchemists'),
       attributes: {
         templateType: 'potion',
         subtype: '255',
@@ -81,7 +81,7 @@ describe('Favorability-Based Purchase Tests', () => {
       type: 'potion-stand',
       subtype: '255',
       position: standPosition,
-      ownedBy: Community.getVillage('alchemists'),
+      ownedByCommunity: Community.getVillage('alchemists'),
       attributes: {
         templateType: 'potion',
         subtype: '255',
@@ -133,7 +133,7 @@ describe('Favorability-Based Purchase Tests', () => {
       type: 'potion-stand',
       subtype: '255',
       position: standPosition,
-      ownedBy: Community.getVillage('alchemists'),
+      ownedByCommunity: Community.getVillage('alchemists'),
       attributes: {
         templateType: 'potion',
         subtype: '255',
@@ -185,7 +185,7 @@ describe('Favorability-Based Purchase Tests', () => {
       type: 'potion-stand',
       subtype: '255',
       position: standPosition,
-      ownedBy: Community.getVillage('alchemists'),
+      ownedByCommunity: Community.getVillage('alchemists'),
       attributes: {
         templateType: 'potion',
         subtype: '255',
@@ -237,7 +237,7 @@ describe('Favorability-Based Purchase Tests', () => {
       type: 'potion-stand',
       subtype: '255',
       position: standPosition,
-      ownedBy: Community.getVillage('alchemists'),
+      ownedByCommunity: Community.getVillage('alchemists'),
       attributes: {
         templateType: 'potion',
         subtype: '255',

--- a/packages/server/test/walls/startWall.test.ts
+++ b/packages/server/test/walls/startWall.test.ts
@@ -32,7 +32,7 @@ describe('StartWall', () => {
       itemType: 'wall' as unknown as Item['itemType'],
       type: 'building',
       drops_item: 'partial-wall',
-      owned_by: 'mob1',
+      owned_by_community: 'mob1',
       destroy: jest.fn(),
       validateOwnership: jest.fn(),
       setAttribute: jest.fn(),


### PR DESCRIPTION
## Description
Every instance of ownedBy was changed to ownedByCommunity so that we may introduce ownedByCharacter for individual ownership of items. 

## Problem
We previously implemented community based ownership. We also need to create the possibility of individual ownership of items. In order to do this, we can use ownedBy logic already in use, but we need two instances of each ownedBy attribute: one for community and one for an individual. 

Closes issue #472 

## Context
We could've overwritten community based ownership to implement individual, but there are features that now rely on community based ownership and we didn't want to introduce problems. 

## Impact
The only team that might be impacted by this is the favorability team. But none of their previously written code is affected. 

We will notify them of the change. 

## Testing
Since this is a refactor, the relevant tests were also refactored to ensure that they still work. No additional testing is needed. 

