### PR TITLE
435 implement favorite item favorability

### DIFF
--- a/packages/common/src/serverBroadcast.ts
+++ b/packages/common/src/serverBroadcast.ts
@@ -44,7 +44,7 @@ export type MobChangeFavoriteData = {
   id: string;
   property: string;
   new_value: string;
-}
+};
 export type SpeakData = { id: string; message: string };
 export type ItemChangeData = { id: string; property: string; value: number };
 export type SetDatetimeData = { date: FantasyDateI };
@@ -81,10 +81,7 @@ export type BroadcastData =
       type: 'mob_change';
       data: MobChangeData;
     }
-  | {
-      type: 'mob_change_fav_item';
-      data: MobChangeFavoriteData;
-    }
+  | { type: 'mob_change_fav_item'; data: MobChangeFavoriteData }
   | { type: 'speak'; data: SpeakData }
   | {
       type: 'item_change';

--- a/packages/common/src/serverBroadcast.ts
+++ b/packages/common/src/serverBroadcast.ts
@@ -40,6 +40,11 @@ export type MobChangeData = {
   delta: number;
   new_value: number;
 };
+export type MobChangeFavoriteData = {
+  id: string;
+  property: string;
+  new_value: string;
+}
 export type SpeakData = { id: string; message: string };
 export type ItemChangeData = { id: string; property: string; value: number };
 export type SetDatetimeData = { date: FantasyDateI };
@@ -75,6 +80,10 @@ export type BroadcastData =
   | {
       type: 'mob_change';
       data: MobChangeData;
+    }
+  | {
+      type: 'mob_change_fav_item';
+      data: MobChangeFavoriteData;
     }
   | { type: 'speak'; data: SpeakData }
   | {

--- a/packages/json-generator/global.json
+++ b/packages/json-generator/global.json
@@ -973,7 +973,13 @@
       "carryable": false,
       "walkable": true,
       "flat": true,
-      "interactions": [],
+      "interactions": [
+        {
+            "description": "Enter portal",
+            "action": "enter",
+            "while_carried": false
+        }
+      ],
       "on_tick": [
         {
           "action": "spawn_mob",

--- a/packages/server/src/items/carryable.ts
+++ b/packages/server/src/items/carryable.ts
@@ -3,7 +3,6 @@ import { Community } from '../community/community';
 import { pubSub } from '../services/clientCommunication/pubsub';
 import { DB } from '../services/database';
 import { Item } from './item';
-import { Favorability } from '../favorability/favorability';
 
 export class Carryable {
   private item: Item;
@@ -45,8 +44,8 @@ export class Carryable {
 
     // Perform favorite item check
     if (this.item.type === to._favorite_item) {
-      var community_1 = from.community_id
-      var community_2 = to.community_id
+      var community_1 = from.community_id;
+      var community_2 = to.community_id;
 
       // If the mob is given their favorite item, increase favorability by 25
       Community.adjustFavor(community_1, community_2, 25);

--- a/packages/server/src/items/carryable.ts
+++ b/packages/server/src/items/carryable.ts
@@ -3,6 +3,7 @@ import { Community } from '../community/community';
 import { pubSub } from '../services/clientCommunication/pubsub';
 import { DB } from '../services/database';
 import { Item } from './item';
+import { Favorability } from '../favorability/favorability';
 
 export class Carryable {
   private item: Item;
@@ -43,7 +44,16 @@ export class Carryable {
     to.carrying = this.item;
 
     // Perform favorite item check
-    
+    if (this.item.type === to._favorite_item) {
+      var community_1 = from.community_id
+      var community_2 = to.community_id
+
+      // If the mob is given their favorite item, increase favorability by 25
+      Community.adjustFavor(community_1, community_2, 25);
+
+      // Randomize their next favorite item afterwards
+      to.changeFavoriteItem();
+    }
 
     // Publish the item transfer event
     pubSub.giveItem(this.item.id, from.id, to.id);

--- a/packages/server/src/items/carryable.ts
+++ b/packages/server/src/items/carryable.ts
@@ -19,6 +19,14 @@ export class Carryable {
     return undefined;
   }
 
+  /**
+   * Function implements the giving of an item from one mob to another.
+   * Performs checks and updates favorability accordingly as well.
+
+   * @param from Giver of the item
+   * @param to Receiver of the item
+   * @returns Either 1) False in which the transfer fails, or 2) True in which the transfer succeeds
+   */
   giveItem(from: Mob, to: Mob): boolean {
     // Check if the recipient mob is already carrying an item
     if (to.carrying) {
@@ -33,6 +41,9 @@ export class Carryable {
     // Transfer the item from the sender to the recipient
     from.carrying = undefined;
     to.carrying = this.item;
+
+    // Perform favorite item check
+    
 
     // Publish the item transfer event
     pubSub.giveItem(this.item.id, from.id, to.id);

--- a/packages/server/src/items/item.ts
+++ b/packages/server/src/items/item.ts
@@ -384,7 +384,10 @@ export class Item {
   static diffRandomItem(item_type: string): string {
     const carryable_items = [];
     for (const type in itemGenerator._itemTypes) {
-      if (itemGenerator._itemTypes[type].carryable == true && type != item_type) {
+      if (
+        itemGenerator._itemTypes[type].carryable == true &&
+        type != item_type
+      ) {
         carryable_items.push(type);
       }
     }

--- a/packages/server/src/items/item.ts
+++ b/packages/server/src/items/item.ts
@@ -377,6 +377,22 @@ export class Item {
     return item;
   }
 
+  /**
+   * Function returns a random item not including the item passed in.
+   * @returns A single carryable item, NOT including the item passed in.
+   */
+  static diffRandomItem(item_type: string): string {
+    const carryable_items = [];
+    for (const type in itemGenerator._itemTypes) {
+      if (itemGenerator._itemTypes[type].carryable == true && type != item_type) {
+        carryable_items.push(type);
+      }
+    }
+    const item =
+      carryable_items[Math.floor(Math.random() * carryable_items.length)];
+    return item;
+  }
+
   destroy(): void {
     DB.prepare(
       `

--- a/packages/server/src/mobs/mob.ts
+++ b/packages/server/src/mobs/mob.ts
@@ -682,6 +682,22 @@ export class Mob {
     pubSub.changeGold(this.id, amount, this._gold);
   }
 
+  /**
+   * Randomly chooses the favorite item of a mob, NOT including the mobs' current favorite item
+   */
+  changeFavoriteItem() {
+    const item = Item.diffRandomItem(this.favorite_item);
+    DB.prepare(
+      `
+        UPDATE mobs
+        SET favorite_item = :favorite_item
+        WHERE id = :id
+      `
+    ).run({ favorite_item: item, id: this.id })
+    this.favorite_item = item;
+    pubSub.changeFavoriteItem(this.id, item);
+  }
+
   destroy() {
     if (this.gold > 0 && this.position) {
       const position = Item.findEmptyPosition(this.position);

--- a/packages/server/src/mobs/mob.ts
+++ b/packages/server/src/mobs/mob.ts
@@ -693,7 +693,7 @@ export class Mob {
         SET favorite_item = :favorite_item
         WHERE id = :id
       `
-    ).run({ favorite_item: item, id: this.id })
+    ).run({ favorite_item: item, id: this.id });
     this.favorite_item = item;
     pubSub.changeFavoriteItem(this.id, item);
   }

--- a/packages/server/src/services/clientCommunication/ablyService.ts
+++ b/packages/server/src/services/clientCommunication/ablyService.ts
@@ -334,6 +334,22 @@ export class AblyService implements PubSub {
     });
   }
 
+  public changeFavoriteItem(key: string, item: string): void {
+    if (key == undefined || item == undefined) {
+      throw new Error(
+        `Sending invalid changeSpeed message ${key}, ${item}`
+      );
+    }
+    this.addToBroadcast({
+      type: 'mob_change_fav_item',
+      data: {
+        id: key,
+        property: 'favorite_item',
+        new_value: item
+      }
+    });
+  }
+
   public changeTargetTick(
     key: string,
     attribute: string,

--- a/packages/server/src/services/clientCommunication/ablyService.ts
+++ b/packages/server/src/services/clientCommunication/ablyService.ts
@@ -336,9 +336,7 @@ export class AblyService implements PubSub {
 
   public changeFavoriteItem(key: string, item: string): void {
     if (key == undefined || item == undefined) {
-      throw new Error(
-        `Sending invalid changeSpeed message ${key}, ${item}`
-      );
+      throw new Error(`Sending invalid changeSpeed message ${key}, ${item}`);
     }
     this.addToBroadcast({
       type: 'mob_change_fav_item',

--- a/packages/server/src/services/clientCommunication/pubsub.ts
+++ b/packages/server/src/services/clientCommunication/pubsub.ts
@@ -44,6 +44,7 @@ export interface PubSub {
   changeItemAttribute(itemKey: string, property: string, value: number): void;
   changeMaxHealth(key: string, maxHealth: number, newValue: number): void;
   changeSpeed(key: string, speed: number, newValue: number): void;
+  changeFavoriteItem(key: string, item: string): void;
   speak(key: string, message: string): void;
   setDateTime(fantasyDate: FantasyDate): void;
   kill(key: string): void;

--- a/packages/server/src/services/clientCommunication/stubbedPubSub.ts
+++ b/packages/server/src/services/clientCommunication/stubbedPubSub.ts
@@ -64,6 +64,8 @@ export class StubbedPubSub implements PubSub {
 
   changeSpeed(_key: string, _speed: number, _newValue: number): void {}
 
+  changeFavoriteItem(_key: string, _item: string): void {}
+
   speak(_key: string, _message: string): void {}
 
   setDateTime(_fantasyDate: FantasyDate): void {}

--- a/packages/server/test/mobs/favorability.test.ts
+++ b/packages/server/test/mobs/favorability.test.ts
@@ -5,6 +5,8 @@ import { DB } from '../../src/services/database';
 import { Coord } from '@rt-potion/common';
 import { Favorability } from '../../src/favorability/favorability';
 import { Mob } from '../../src/mobs/mob';
+import { Item } from '../../src/items/item';
+import { Carryable } from '../../src/items/carryable';
 
 beforeEach(() => {
   commonSetup();
@@ -147,6 +149,37 @@ describe('Favorability Tests', () => {
     var fav_item_2 = testplayer?._favorite_item
     expect(fav_item_1 === fav_item_2).toBe(false);
   });
+
+  test('Make sure favorability changes based on favorite item given', () => {
+    // initialize villager / player
+    const position: Coord = { x: 0, y: 0 };
+    const position2: Coord = { x: 1, y: 1 };
+    const position3: Coord = { x: 1, y: 0 };
+
+    mobFactory.makeMob('player', position, 'testPlayer', 'playertest');
+    mobFactory.makeMob('villager', position2, 'testVillager', 'villagertest');
+    var testplayer = Mob.getMob('testPlayer');
+    var testvillager = Mob.getMob('testVillager');
+    Community.makeFavor('alchemists', 'silverclaw', 100);
+
+    var fav_item = testvillager?._favorite_item
+
+    itemGenerator.createItem({ type: fav_item!, position: position3 });
+    var fav_item_id = Item.getItemIDAt(position3);
+    var the_item = Item.getItem(fav_item_id!);
+    var the_carryable_item = Carryable.fromItem(the_item!);
+    the_carryable_item!.pickup(testplayer!);
+
+    console.log(fav_item);
+
+    var is_given = the_carryable_item!.giveItem(testplayer!, testvillager!);
+
+    expect(is_given).toBe(true);
+    expect(Community.getFavor("alchemists", "silverclaw")).toBe(125);
+
+
+  });
+
 });
 
 afterEach(() => {

--- a/packages/server/test/mobs/favorability.test.ts
+++ b/packages/server/test/mobs/favorability.test.ts
@@ -144,10 +144,10 @@ describe('Favorability Tests', () => {
 
     mobFactory.makeMob('player', position, 'testPlayer', 'playertest');
     var testplayer = Mob.getMob('testPlayer');
-    var fav_item_1 = testplayer?._favorite_item
+    var fav_item_1 = testplayer?._favorite_item;
 
     testplayer?.changeFavoriteItem();
-    var fav_item_2 = testplayer?._favorite_item
+    var fav_item_2 = testplayer?._favorite_item;
     expect(fav_item_1 === fav_item_2).toBe(false);
   });
 
@@ -164,7 +164,7 @@ describe('Favorability Tests', () => {
 
     Community.makeFavor('alchemists', 'silverclaw', 100);
 
-    var fav_item = testvillager?._favorite_item
+    var fav_item = testvillager?._favorite_item;
 
     itemGenerator.createItem({ type: fav_item!, position: position3 });
     var fav_item_id = Item.getItemIDAt(position3);
@@ -177,9 +177,8 @@ describe('Favorability Tests', () => {
     var is_given = the_carryable_item!.giveItem(testplayer!, testvillager!);
 
     expect(is_given).toBe(true);
-    expect(Community.getFavor("alchemists", "silverclaw")).toBe(125);
+    expect(Community.getFavor('alchemists', 'silverclaw')).toBe(125);
   });
-
 });
 
 afterEach(() => {

--- a/packages/server/test/mobs/favorability.test.ts
+++ b/packages/server/test/mobs/favorability.test.ts
@@ -135,6 +135,18 @@ describe('Favorability Tests', () => {
     // testing whether the item actually a possible item type that could be generated
     expect(itemGenerator._itemTypes[testplayer_item].carryable).toBe(true);
   });
+  test('Update mob favorite item', () => {
+    // initialize player
+    const position: Coord = { x: 0, y: 0 };
+
+    mobFactory.makeMob('player', position, 'testPlayer', 'playertest');
+    var testplayer = Mob.getMob('testPlayer');
+    var fav_item_1 = testplayer?._favorite_item
+
+    testplayer?.changeFavoriteItem();
+    var fav_item_2 = testplayer?._favorite_item
+    expect(fav_item_1 === fav_item_2).toBe(false);
+  });
 });
 
 afterEach(() => {

--- a/packages/server/test/mobs/favorability.test.ts
+++ b/packages/server/test/mobs/favorability.test.ts
@@ -10,10 +10,11 @@ import { Carryable } from '../../src/items/carryable';
 
 beforeEach(() => {
   commonSetup();
-  Community.makeVillage('alchemists', 'Alchemists guild');
+  var alchemists = Community.makeVillage('alchemists', 'Alchemists guild');
   Community.makeVillage('blobs', 'Blobs');
-  Community.makeVillage('silverclaw', 'Village of Silverclaw');
+  var silverclaw = Community.makeVillage('silverclaw', 'Village of Silverclaw');
   Community.makeVillage('fighters', 'Village of Silverclaw');
+  Community.makeAlliance(alchemists, silverclaw);
   mobFactory.loadTemplates(world.mobTypes);
 });
 
@@ -160,6 +161,7 @@ describe('Favorability Tests', () => {
     mobFactory.makeMob('villager', position2, 'testVillager', 'villagertest');
     var testplayer = Mob.getMob('testPlayer');
     var testvillager = Mob.getMob('testVillager');
+
     Community.makeFavor('alchemists', 'silverclaw', 100);
 
     var fav_item = testvillager?._favorite_item
@@ -176,8 +178,6 @@ describe('Favorability Tests', () => {
 
     expect(is_given).toBe(true);
     expect(Community.getFavor("alchemists", "silverclaw")).toBe(125);
-
-
   });
 
 });


### PR DESCRIPTION
## Description
Implements favorability changes depending on whether the mob is given their favorite item, and randomizes that mobs' favorite item.

## Problem
There was no implementation for favorability changes depending on whether or not that mob is given their favorite item. This PR fixes that, and also implements a rule for making sure the mechanic cannot be abused.
Closes #435 

## Context
<!--- What alternatives were considered, and why was this approach chosen? -->
There weren't really many other alternatives considered, since the favorite item should be intrinsic to each mob. The implementation was relatively straightforward.
<!--- Mention any design decisions or trade-offs. -->

## Impact
<!--- Does this change break anything or require documentation updates? -->
No breaking changes.
<!--- How will this change affect other developers? Can that burden be minimized? --> 
Will not impact any other developers. The change is relatively localized.
<!--- Should they be notified (e.g., via Slack)? -->
No developers need to be notified of the change.

## Testing
<!--- Describe how you tested the changes -->
Tested to make sure the favorability between the players' community and mobs' community changes depending on whether or not they were given their favorite item. Made sure the mobs' favorite item changes afterward.
<!--- Mention automated tests, manual testing, or reasons for not testing -->
Automated testing was done to make sure the changes are consistent. Manual testing was done through console logging to make sure nothing broke even if automated testing passed.
