### PR TITLE
Bug Fix: Night Overlay Display

### DIFF
--- a/packages/client/src/scenes/worldScene.ts
+++ b/packages/client/src/scenes/worldScene.ts
@@ -375,10 +375,6 @@ export class WorldScene extends Phaser.Scene {
     this.terrainWidth = globalData.tiles[0].length;
     this.terrainHeight = globalData.tiles.length;
 
-    console.log('gobalData.tiles: ', globalData.tiles);
-    console.log('terrainWidth: ', this.terrainWidth);
-    console.log('terrain heigh: ', this.terrainHeight);
-
     const background = this.add.image(0, 0, 'background');
     background.setOrigin(0, 0);
     background.setScrollFactor(0); // Make it stay static
@@ -387,7 +383,6 @@ export class WorldScene extends Phaser.Scene {
 
     // Create a night overlay with lower depth
     this.nightOverlay = this.add.graphics();
-
     this.nightOverlay.fillRect(
       0,
       0,
@@ -540,7 +535,6 @@ export class WorldScene extends Phaser.Scene {
       this.nightOverlay.clear();
       // Dark blue with max 50% opacity
       this.nightOverlay.fillStyle(0x000033, this.nightOpacity);
-
       this.nightOverlay.fillRect(
         0,
         0,

--- a/packages/client/src/scenes/worldScene.ts
+++ b/packages/client/src/scenes/worldScene.ts
@@ -375,6 +375,10 @@ export class WorldScene extends Phaser.Scene {
     this.terrainWidth = globalData.tiles[0].length;
     this.terrainHeight = globalData.tiles.length;
 
+    console.log('gobalData.tiles: ', globalData.tiles);
+    console.log('terrainWidth: ', this.terrainWidth);
+    console.log('terrain heigh: ', this.terrainHeight);
+
     const background = this.add.image(0, 0, 'background');
     background.setOrigin(0, 0);
     background.setScrollFactor(0); // Make it stay static
@@ -383,6 +387,7 @@ export class WorldScene extends Phaser.Scene {
 
     // Create a night overlay with lower depth
     this.nightOverlay = this.add.graphics();
+
     this.nightOverlay.fillRect(
       0,
       0,
@@ -535,11 +540,12 @@ export class WorldScene extends Phaser.Scene {
       this.nightOverlay.clear();
       // Dark blue with max 50% opacity
       this.nightOverlay.fillStyle(0x000033, this.nightOpacity);
+
       this.nightOverlay.fillRect(
         0,
         0,
-        this.terrainWidth * TILE_SIZE,
-        this.terrainHeight * TILE_SIZE
+        this.terrainHeight * TILE_SIZE,
+        this.terrainWidth * TILE_SIZE
       );
     }
 


### PR DESCRIPTION
## Description
- Simple bug fix in worldScene.ts to fix incorrect passing of width and height parameters
- closes issue #528 

## Problem
- this solved the problem of the night overlay not fully covering all of water world

## Context
- no alternatives were considered as the error was quite small

## Impact
- this bug fix was a simple change of width/height mix up and does not require notification

## Testing
- bug is in the UI so I went through water world and went around the perimeter during night time and saw the whole area covered as expected
- repeated these steps for fire-world and test-world to double check

## Screenshots (if appropriate)
After
![Screenshot 2025-02-26 135910](https://github.com/user-attachments/assets/e23cc00a-1121-4b87-ac13-570d93c67517)

Before
![Screenshot 2025-02-26 132219](https://github.com/user-attachments/assets/e3d18b28-e552-41ce-9976-a31a6aedf8a0)
