### PR TITLE
fix: add inventory refresh on character refresh

### DIFF
--- a/packages/client/src/scenes/uxScene.ts
+++ b/packages/client/src/scenes/uxScene.ts
@@ -714,6 +714,7 @@ export class UxScene extends Phaser.Scene {
       this.extroversionText?.setText(
         'Extroversion: ' + currentCharacter.extroversion
       );
+      this.refreshInventoryStats();
     }
   }
 


### PR DESCRIPTION
## Description
Fixed it so that the inventory UI would be reset to 0/12 after death

## Problem
Closes #545 

## Testing
Tested manually through grabbing and stashing an item and then dying by blobs and seeing the inventory ui be reset to 0/12