### PR TITLE
Improve Pathfinding When Target is Unwalkable

### DIFF
--- a/packages/common/src/pathFinder.ts
+++ b/packages/common/src/pathFinder.ts
@@ -383,11 +383,13 @@ export class PathFinder {
 
       // Sort by proximity to player, allowing for closest neighbors to be looked at first
       neighbors.sort((coord1, coord2) => {
-        const dist1 = Math.pow(start.x - coord1.x, 2) + Math.pow(start.y - coord1.y, 2);
-        const dist2 = Math.pow(start.x - coord2.x, 2) + Math.pow(start.y - coord2.y, 2);
+        const dist1 =
+          Math.pow(start.x - coord1.x, 2) + Math.pow(start.y - coord1.y, 2);
+        const dist2 =
+          Math.pow(start.x - coord2.x, 2) + Math.pow(start.y - coord2.y, 2);
         return dist1 - dist2;
       });
-      
+
       for (const neighbor of neighbors) {
         const neighborKey = `${neighbor.x},${neighbor.y}`;
 

--- a/packages/common/src/pathFinder.ts
+++ b/packages/common/src/pathFinder.ts
@@ -349,7 +349,7 @@ export class PathFinder {
    *
    * @throws If no walkable tile is found.
    */
-  private findNearestWalkableTile(target: Coord): Coord {
+  private findNearestWalkableTile(start: Coord, target: Coord): Coord {
     const directions = [
       { x: 1, y: 0 },
       { x: -1, y: 0 },
@@ -371,11 +371,24 @@ export class PathFinder {
         return current;
       }
 
+      // Find all neighbors
+      const neighbors: Coord[] = [];
       for (const direction of directions) {
         const neighbor = {
           x: current.x + direction.x,
           y: current.y + direction.y
         };
+        neighbors.push(neighbor);
+      }
+
+      // Sort by proximity to player, allowing for closest neighbors to be looked at first
+      neighbors.sort((coord1, coord2) => {
+        const dist1 = Math.pow(start.x - coord1.x, 2) + Math.pow(start.y - coord1.y, 2);
+        const dist2 = Math.pow(start.x - coord2.x, 2) + Math.pow(start.y - coord2.y, 2);
+        return dist1 - dist2;
+      });
+      
+      for (const neighbor of neighbors) {
         const neighborKey = `${neighbor.x},${neighbor.y}`;
 
         if (!visited.has(neighborKey)) {
@@ -425,7 +438,7 @@ export class PathFinder {
 
     if (!fuzzy && !this.isWalkable(unlocks, end.x, end.y)) {
       try {
-        end = this.findNearestWalkableTile(end);
+        end = this.findNearestWalkableTile(start, end);
       } catch {
         // Return an empty path if no walkable tile is found
         return [];

--- a/packages/common/test/pathFinder.test.ts
+++ b/packages/common/test/pathFinder.test.ts
@@ -3,7 +3,8 @@ import { PathFinder } from '../src/pathFinder';
 describe('PathFinder', () => {
   let pathFinder: PathFinder;
   let pathFinder2: PathFinder;
-  let pathFinder3: PathFinder;
+  let pathFinder3: PathFinder;  
+  let pathFinder4: PathFinder;
 
   const tiles = [
     [0, 0, 0],
@@ -23,6 +24,12 @@ describe('PathFinder', () => {
     [-1, -1, -1]
   ];
 
+  const tiles4 = [
+    [0, 0, 0],
+    [0, 0, 0],
+    [0, -1, 0]
+  ];
+
   const terrain_types = [
     { id: 0, name: 'Ground', walkable: true },
     { id: -1, name: 'Wall', walkable: false }
@@ -32,6 +39,7 @@ describe('PathFinder', () => {
     pathFinder = new PathFinder(tiles, terrain_types);
     pathFinder2 = new PathFinder(tiles2, terrain_types);
     pathFinder3 = new PathFinder(tiles3, terrain_types);
+    pathFinder4 = new PathFinder(tiles4, terrain_types);
   });
 
   test('should initialize with correct walkable map', () => {
@@ -163,6 +171,16 @@ describe('PathFinder', () => {
     const end = { x: 2, y: 2 }; // unwalkable
     const walkableEnd = { x: 2, y: 1 }; // closest walkable tile
     const path = pathFinder2.generatePath([], start, end, false);
+    expect(path).not.toHaveLength(0);
+    expect(path).toContainEqual(walkableEnd);
+    expect(path).not.toContainEqual(end);
+  });
+
+  test('generatePath should return path to closest walkable tile if the goal is not walkable (#3)', () => {
+    const start = { x: 0, y: 1 };
+    const end = { x: 2, y: 1 }; // unwalkable
+    const walkableEnd = { x: 1, y: 1 }; // closest walkable tile
+    const path = pathFinder4.generatePath([], start, end, false);
     expect(path).not.toHaveLength(0);
     expect(path).toContainEqual(walkableEnd);
     expect(path).not.toContainEqual(end);

--- a/packages/common/test/pathFinder.test.ts
+++ b/packages/common/test/pathFinder.test.ts
@@ -3,7 +3,7 @@ import { PathFinder } from '../src/pathFinder';
 describe('PathFinder', () => {
   let pathFinder: PathFinder;
   let pathFinder2: PathFinder;
-  let pathFinder3: PathFinder;  
+  let pathFinder3: PathFinder;
   let pathFinder4: PathFinder;
 
   const tiles = [


### PR DESCRIPTION
## Description
Updated the findNearestWalkableTile function to return targets closest to the player when there are multiple options for the closest tile to the original target.

## Problem
Before this changes, when you clicked on an unwalkable tile, you would pathfind to the closest tile to your target. However, when there were multiple closest tiles, you would always go to the rightmost one (due to how the breadth first search was implemented). Instead, when there are multiple options, the player should pathfind to the tile closest to them. 

## Context
Simply sorting the 8 neighbors by proximity to the player ensures that closest options are considered first. Sorting can be slow, but since the input is small, this change is not felt by the player. One option considered was looking at everything on the queue, then returning the smallest one, but that could be very slow if the queue gets large.

## Impact
No change for developers. They will enjoy better pathfinding when playing the game.

## Testing
Added an additional unit test. With the previous implementation, this test would fail because it would pathfind to the position to the right of the target, but now it finds the best one for the player
