### PR TITLE
fix: Made portal button not appear for worlds down or for current world

### DIFF
--- a/packages/client/src/scenes/portalMenuScene.ts
+++ b/packages/client/src/scenes/portalMenuScene.ts
@@ -7,14 +7,14 @@ import { stat } from 'fs';
 export class PortalMenuScene extends Phaser.Scene {
   constructor() {
     super({ key: 'PortalMenuScene' });
-    }
-    
-    world_map = new Map<string, number>([
-        ['fire-world', 3],
-        ['water-world', 4],
-        ['test-world', 5]
-      ]);
-    
+  }
+
+  world_map = new Map<string, number>([
+    ['fire-world', 3],
+    ['water-world', 4],
+    ['test-world', 5]
+  ]);
+
   changeWorld(world_id: string) {
     leaveWorld(world_id);
     sessionStorage.setItem('traveling_through_portal', 'true');
@@ -63,53 +63,53 @@ export class PortalMenuScene extends Phaser.Scene {
     );
     title.setOrigin(0.5);
 
-      const worldName = getWorldID();
-      let count = 0;
-      // Add world selection buttons
-      availableWorlds.forEach((world, index) => {
-        if (worldName == world.name) {
-            return;
-          }
-    
-          // If world uptime ID in world_map is incorrect, do not create button
-          const uptimeWorldID = this.world_map.get(world.name);
-          if (!uptimeWorldID) {
-            console.log(`${world.name} uptime ID does not match that in world_map`);
-            return;
-          }
-    
-          // If world server is down, do not create button for the server
-          this.fetchData(uptimeWorldID).then((status) => {
-            if (status === 'Down') {
-              return;
-            }
-    
-            const button = this.add.text(
-              SCREEN_WIDTH / 2,
-              SCREEN_HEIGHT / 3 + count * 60,
-              world.name,
-              buttonStyle
-            );
-    
-            count += 1;
-            button.setInteractive({ useHandCursor: true });
-            button.setOrigin(0.5);
-    
-            // Hover effects
-            button.on('pointerover', () => {
-              button.setStyle(nameButtonHoverStyle);
-            });
-            button.on('pointerout', () => {
-              button.setStyle(buttonStyle);
-            });
-    
-            // Click handler
-            button.on('pointerdown', () => {
-              console.log(`Selected world: ${world.name} with id ${world.id}`);
-              this.changeWorld(world.name);
-              this.scene.stop('PortalMenuScene');
-            });
-          });
+    const worldName = getWorldID();
+    let count = 0;
+    // Add world selection buttons
+    availableWorlds.forEach((world, index) => {
+      if (worldName == world.name) {
+        return;
+      }
+
+      // If world uptime ID in world_map is incorrect, do not create button
+      const uptimeWorldID = this.world_map.get(world.name);
+      if (!uptimeWorldID) {
+        console.log(`${world.name} uptime ID does not match that in world_map`);
+        return;
+      }
+
+      // If world server is down, do not create button for the server
+      this.fetchData(uptimeWorldID).then((status) => {
+        if (status === 'Down') {
+          return;
+        }
+
+        const button = this.add.text(
+          SCREEN_WIDTH / 2,
+          SCREEN_HEIGHT / 3 + count * 60,
+          world.name,
+          buttonStyle
+        );
+
+        count += 1;
+        button.setInteractive({ useHandCursor: true });
+        button.setOrigin(0.5);
+
+        // Hover effects
+        button.on('pointerover', () => {
+          button.setStyle(nameButtonHoverStyle);
+        });
+        button.on('pointerout', () => {
+          button.setStyle(buttonStyle);
+        });
+
+        // Click handler
+        button.on('pointerdown', () => {
+          console.log(`Selected world: ${world.name} with id ${world.id}`);
+          this.changeWorld(world.name);
+          this.scene.stop('PortalMenuScene');
+        });
+      });
     });
 
     // Add close button
@@ -134,13 +134,13 @@ export class PortalMenuScene extends Phaser.Scene {
     closeButton.on('pointerdown', () => {
       this.scene.stop('PortalMenuScene');
     });
-    }
-    
-      // Uses uptime API to find out status of servers
+  }
+
+  // Uses uptime API to find out status of servers
   async fetchData(uptimeID: number): Promise<string> {
     const response = await fetch(
       `https://status.vosburg.us/api/badge/${uptimeID}/status`
-      );
+    );
 
     if (!response.ok) {
       throw new Error(`HTTP Error requesting uptime data ${response.status}`);
@@ -150,17 +150,17 @@ export class PortalMenuScene extends Phaser.Scene {
 
     // Only xml available, must parse text for "Status Down" message
     const parser = new DOMParser();
-    const svgDoc = parser.parseFromString(svg, "image/svg+xml");
-    const textNodes = svgDoc.querySelectorAll("text");
+    const svgDoc = parser.parseFromString(svg, 'image/svg+xml');
+    const textNodes = svgDoc.querySelectorAll('text');
 
     for (const node of Array.from(textNodes)) {
       const text = node.textContent?.trim();
-      if (text === "Up" || text === "Down") {
+      if (text === 'Up' || text === 'Down') {
         console.log(`Status found: ${text}`);
         return text;
       }
-      }
-      
-      return "Down";
+    }
+
+    return 'Down';
   }
 }

--- a/packages/client/src/scenes/portalMenuScene.ts
+++ b/packages/client/src/scenes/portalMenuScene.ts
@@ -1,13 +1,26 @@
 import { SCREEN_HEIGHT, SCREEN_WIDTH } from '../config';
 import { buttonStyle, nameButtonHoverStyle } from './loadWorldScene';
 import { availableWorlds } from '../world/controller';
-import { updateWorld } from '../services/playerToServer';
 import { getWorldID } from '../worldMetadata';
+import { leaveWorld } from '../services/playerToServer';
+import { stat } from 'fs';
 export class PortalMenuScene extends Phaser.Scene {
   constructor() {
     super({ key: 'PortalMenuScene' });
+    }
+    
+    world_map = new Map<string, number>([
+        ['fire-world', 3],
+        ['water-world', 4],
+        ['test-world', 5]
+      ]);
+    
+  changeWorld(world_id: string) {
+    leaveWorld(world_id);
+    sessionStorage.setItem('traveling_through_portal', 'true');
+    sessionStorage.setItem('traveling_to', world_id);
+    window.location.reload();
   }
-
   create() {
     // Add semi-transparent black background
     const overlay = this.add.rectangle(
@@ -50,39 +63,53 @@ export class PortalMenuScene extends Phaser.Scene {
     );
     title.setOrigin(0.5);
 
-    // Add world selection buttons
-    availableWorlds.forEach((world, index) => {
-      const button = this.add.text(
-        SCREEN_WIDTH / 2,
-        SCREEN_HEIGHT / 3 + index * 60,
-        world.name,
-        buttonStyle
-      );
-      button.setInteractive({ useHandCursor: true });
-      button.setOrigin(0.5);
-
-      // Hover effects
-      button.on('pointerover', () => {
-        button.setStyle(nameButtonHoverStyle);
-      });
-      button.on('pointerout', () => {
-        button.setStyle(buttonStyle);
-      });
-
-      // Click handler
-      button.on('pointerdown', () => {
-        // TODO: Implement world transition
-        console.log(`Selected world: ${world.name} with id ${world.id}`);
-
-        if (world.name === getWorldID()) {
-          // only switch if going to a new world
-          this.scene.stop('PortalMenuScene');
-        } else {
-          updateWorld(world.name);
-          this.scene.stop('PortalMenuScene');
-          this.scene.start('PortalLoadingScene');
-        }
-      });
+      const worldName = getWorldID();
+      let count = 0;
+      // Add world selection buttons
+      availableWorlds.forEach((world, index) => {
+        if (worldName == world.name) {
+            return;
+          }
+    
+          // If world uptime ID in world_map is incorrect, do not create button
+          const uptimeWorldID = this.world_map.get(world.name);
+          if (!uptimeWorldID) {
+            console.log(`${world.name} uptime ID does not match that in world_map`);
+            return;
+          }
+    
+          // If world server is down, do not create button for the server
+          this.fetchData(uptimeWorldID).then((status) => {
+            if (status === 'Down') {
+              return;
+            }
+    
+            const button = this.add.text(
+              SCREEN_WIDTH / 2,
+              SCREEN_HEIGHT / 3 + count * 60,
+              world.name,
+              buttonStyle
+            );
+    
+            count += 1;
+            button.setInteractive({ useHandCursor: true });
+            button.setOrigin(0.5);
+    
+            // Hover effects
+            button.on('pointerover', () => {
+              button.setStyle(nameButtonHoverStyle);
+            });
+            button.on('pointerout', () => {
+              button.setStyle(buttonStyle);
+            });
+    
+            // Click handler
+            button.on('pointerdown', () => {
+              console.log(`Selected world: ${world.name} with id ${world.id}`);
+              this.changeWorld(world.name);
+              this.scene.stop('PortalMenuScene');
+            });
+          });
     });
 
     // Add close button
@@ -107,5 +134,33 @@ export class PortalMenuScene extends Phaser.Scene {
     closeButton.on('pointerdown', () => {
       this.scene.stop('PortalMenuScene');
     });
+    }
+    
+      // Uses uptime API to find out status of servers
+  async fetchData(uptimeID: number): Promise<string> {
+    const response = await fetch(
+      `https://status.vosburg.us/api/badge/${uptimeID}/status`
+      );
+
+    if (!response.ok) {
+      throw new Error(`HTTP Error requesting uptime data ${response.status}`);
+    }
+
+    const svg = await response.text();
+
+    // Only xml available, must parse text for "Status Down" message
+    const parser = new DOMParser();
+    const svgDoc = parser.parseFromString(svg, "image/svg+xml");
+    const textNodes = svgDoc.querySelectorAll("text");
+
+    for (const node of Array.from(textNodes)) {
+      const text = node.textContent?.trim();
+      if (text === "Up" || text === "Down") {
+        console.log(`Status found: ${text}`);
+        return text;
+      }
+      }
+      
+      return "Down";
   }
 }

--- a/packages/client/src/scenes/portalMenuScene.ts
+++ b/packages/client/src/scenes/portalMenuScene.ts
@@ -3,7 +3,7 @@ import { buttonStyle, nameButtonHoverStyle } from './loadWorldScene';
 import { availableWorlds } from '../world/controller';
 import { getWorldID } from '../worldMetadata';
 import { leaveWorld } from '../services/playerToServer';
-import { stat } from 'fs';
+
 export class PortalMenuScene extends Phaser.Scene {
   constructor() {
     super({ key: 'PortalMenuScene' });
@@ -66,7 +66,7 @@ export class PortalMenuScene extends Phaser.Scene {
     const worldName = getWorldID();
     let count = 0;
     // Add world selection buttons
-    availableWorlds.forEach((world, index) => {
+    availableWorlds.forEach((world) => {
       if (worldName == world.name) {
         return;
       }


### PR DESCRIPTION
## Description
When clicking "Enter Portal" no longer shows worlds that are down, checks health of server, and does not show current world.

## Problem
1. Doesn't show current world which you wouldn't need to tp to as you are on
2. If user were to tp to world that is down, there would be no way to change their world id in the production database back to a world that could host them. Essentially, that character is lost until the world comes back up.
3. Closes #554 

## Context
Not checking world health status. 
I have hardcoded the world-names to their IDs on the uptime service. Do no believe this is a problem as no new worlds will be added and our worlds on that service will not be edited or deleted.

## Impact
No breaking

If developers are trying to change world locally, they would be able to if they ran the servers themselves, but now, if a user is running a server locally, and attempts to run another server and click the portal, despite the server being up locally, it would determine whether or not to show the portal option based on production server.

## Testing
Manually tested changes, read the network traffic and used logs to see if requests are working and delivering the expected results

## Screenshots (if appropriate)
Previous, show every option
![old](https://github.com/user-attachments/assets/6b19e775-4c4b-4d14-8465-9b62ea325968)

Current, show available options (servers are up)
![notcurrent](https://github.com/user-attachments/assets/ccd2e034-fb60-46d9-a9f7-35ae02e2ee4f)

Current when no servers are up. Production is down currently
![EverytingDown](https://github.com/user-attachments/assets/2750582b-0f3a-439b-b257-49958cc3196d)
