### PR TITLE
feat: Added Community Favorabilites to Player Info UI

### DIFF
--- a/packages/client/src/scenes/uxScene.ts
+++ b/packages/client/src/scenes/uxScene.ts
@@ -65,6 +65,7 @@ export class UxScene extends Phaser.Scene {
   defenseText: Phaser.GameObjects.Text | null = null;
   speedText: Phaser.GameObjects.Text | null = null;
   affiliationText: Phaser.GameObjects.Text | null = null;
+  favorabilitiesText: Phaser.GameObjects.Text | null = null;
   stubbornnessText: Phaser.GameObjects.Text | null = null;
   braveryText: Phaser.GameObjects.Text | null = null;
   aggressionText: Phaser.GameObjects.Text | null = null;
@@ -348,6 +349,17 @@ export class UxScene extends Phaser.Scene {
         'Date: reading position of sun and stars'
       );
       this.infoContainer.add(this.dateText);
+      console.log('Favorabilities:');
+      console.log(currentCharacter.favorabilities);
+      this.favorabilitiesText = this.add.text(
+        15,
+        250,
+        'Favorabilities:\n' +
+          Object.entries(currentCharacter.favorabilities)
+            .map(([community, value]) => `${community}: ${value}`)
+            .join('\n') // Formats each key-value pair on a new line
+      );
+      this.infoContainer.add(this.favorabilitiesText);
 
       // Color pickers
       const colors = ['Eye Color', 'Belly Color', 'Fur Color'];
@@ -773,6 +785,12 @@ export class UxScene extends Phaser.Scene {
       this.sleepyText?.setText('Sleepy: ' + currentCharacter.sleepy);
       this.extroversionText?.setText(
         'Extroversion: ' + currentCharacter.extroversion
+      );
+      this.favorabilitiesText?.setText(
+        'Favorabilities:\n' +
+          Object.entries(currentCharacter.favorabilities)
+            .map(([community, value]) => `${community}: ${value}`)
+            .join('\n')
       );
       this.refreshInventoryStats();
     }

--- a/packages/client/src/scenes/uxScene.ts
+++ b/packages/client/src/scenes/uxScene.ts
@@ -101,6 +101,7 @@ export class UxScene extends Phaser.Scene {
   fightContainer: Phaser.GameObjects.Container | null = null;
   recipeContainer: Phaser.GameObjects.Container | null = null;
   effectsContainer: Phaser.GameObjects.Container | null = null;
+  favorabilitiesContainer: Phaser.GameObjects.Container | null = null;
 
   chatSounds: Phaser.Sound.BaseSound[] = [];
   inventoryContainer: Phaser.GameObjects.Container | null = null;
@@ -175,6 +176,7 @@ export class UxScene extends Phaser.Scene {
     this.recipeContainer = this.add.container(0, 40);
     this.effectsContainer = this.add.container(0, 40);
     this.inventoryContainer = this.add.container(0, 40);
+    this.favorabilitiesContainer = this.add.container(0, 40);
 
     const tabWidth = 104;
     const tabHeight = 40;
@@ -349,17 +351,6 @@ export class UxScene extends Phaser.Scene {
         'Date: reading position of sun and stars'
       );
       this.infoContainer.add(this.dateText);
-      console.log('Favorabilities:');
-      console.log(currentCharacter.favorabilities);
-      this.favorabilitiesText = this.add.text(
-        15,
-        250,
-        'Favorabilities:\n' +
-          Object.entries(currentCharacter.favorabilities)
-            .map(([community, value]) => `${community}: ${value}`)
-            .join('\n') // Formats each key-value pair on a new line
-      );
-      this.infoContainer.add(this.favorabilitiesText);
 
       // Color pickers
       const colors = ['Eye Color', 'Belly Color', 'Fur Color'];
@@ -429,6 +420,16 @@ export class UxScene extends Phaser.Scene {
 
       this.fightText = this.add.text(160, 35, 'Items / FIGHT');
       this.fightContainer.add(this.fightText);
+
+      this.favorabilitiesText = this.add.text(
+        15,
+        40,
+        'Favorabilities:\n' +
+          Object.entries(currentCharacter.favorabilities)
+            .map(([community, value]) => `${community}: ${value}`)
+            .join('\n') // Formats each key-value pair on a new line
+      );
+      this.favorabilitiesContainer.add(this.favorabilitiesText);
 
       // recipe text
       this.recipeText = this.add.text(160, 35, 'POTION RECIPES');
@@ -682,7 +683,7 @@ export class UxScene extends Phaser.Scene {
             ]);*/
     }
 
-    const menuKeys = ['1', '2', '3', '4', 'r', '@'];
+    const menuKeys = ['1', '2', '3', '4', 'r', 'f', '@'];
 
     this.input.keyboard?.on('keydown', (event: KeyboardEvent) => {
       const curKey = event.key.toLowerCase();
@@ -725,6 +726,10 @@ export class UxScene extends Phaser.Scene {
             case 'r':
               this.showRecipeTab();
               console.log('Pressed R');
+              break;
+            case 'f':
+              this.showFavorabilitiesTab();
+              console.log('Pressed F');
               break;
             default:
               console.log('Other key pressed');
@@ -813,6 +818,7 @@ export class UxScene extends Phaser.Scene {
     this.handbookBackButton?.setVisible(false);
     this.actionNextButton?.setVisible(false);
     this.actionBackButton?.setVisible(false);
+    this.favorabilitiesContainer?.setVisible(false);
     this.setInteractions(currentInteractions);
     this.scene.stop('BrewScene');
     this.inventoryContainer?.setVisible(false);
@@ -831,6 +837,7 @@ export class UxScene extends Phaser.Scene {
     this.handbookBackButton?.setVisible(false);
     this.actionNextButton?.setVisible(true);
     this.actionBackButton?.setVisible(false);
+    this.favorabilitiesContainer?.setVisible(false);
     this.setInteractions(currentInteractions);
     this.scene.stop('BrewScene');
     this.inventoryContainer?.setVisible(false);
@@ -849,6 +856,7 @@ export class UxScene extends Phaser.Scene {
     this.handbookBackButton?.setVisible(false);
     this.actionNextButton?.setVisible(false);
     this.actionBackButton?.setVisible(false);
+    this.favorabilitiesContainer?.setVisible(false);
     this.setInteractions(currentInteractions);
     this.scene.stop('BrewScene');
     this.inventoryContainer?.setVisible(false);
@@ -867,6 +875,7 @@ export class UxScene extends Phaser.Scene {
     this.handbookBackButton?.setVisible(false);
     this.actionNextButton?.setVisible(false);
     this.actionBackButton?.setVisible(true);
+    this.favorabilitiesContainer?.setVisible(false);
     this.setInteractions(currentInteractions);
     this.scene.stop('BrewScene');
     this.inventoryContainer?.setVisible(false);
@@ -885,8 +894,27 @@ export class UxScene extends Phaser.Scene {
     this.handbookBackButton?.setVisible(false);
     this.actionNextButton?.setVisible(false);
     this.actionBackButton?.setVisible(false);
+    this.favorabilitiesContainer?.setVisible(false);
     this.setInteractions(currentInteractions);
     this.updateTabStyles('handbook');
+  }
+
+  showFavorabilitiesTab() {
+    this.infoContainer?.setVisible(false);
+    this.itemsContainer?.setVisible(false);
+    this.chatContainer?.setVisible(false);
+    this.fightContainer?.setVisible(false);
+    this.recipeContainer?.setVisible(false);
+    this.effectsContainer?.setVisible(false);
+    this.handbookNextButton?.setVisible(false);
+    this.handbookBackButton?.setVisible(false);
+    this.actionNextButton?.setVisible(false);
+    this.actionBackButton?.setVisible(false);
+    this.favorabilitiesContainer?.setVisible(true);
+    this.setInteractions(currentInteractions);
+    this.scene.stop('BrewScene');
+    this.inventoryContainer?.setVisible(false);
+    this.updateTabStyles('favorabilities');
   }
 
   // Method to show the Page Flips
@@ -902,6 +930,7 @@ export class UxScene extends Phaser.Scene {
     this.handbookBackButton?.setVisible(true);
     this.actionNextButton?.setVisible(false);
     this.actionBackButton?.setVisible(false);
+    this.favorabilitiesContainer?.setVisible(false);
     this.setInteractions(currentInteractions);
     this.updateTabStyles('handbook');
   }
@@ -918,12 +947,19 @@ export class UxScene extends Phaser.Scene {
     this.handbookBackButton?.setVisible(false);
     this.actionNextButton?.setVisible(false);
     this.actionBackButton?.setVisible(false);
+    this.favorabilitiesContainer?.setVisible(false);
     this.updateTabStyles('inventory');
   }
 
   // Update the styles of the tab buttons based on the active tab
   updateTabStyles(
-    activeTab: 'player' | 'actions' | 'chat' | 'inventory' | 'handbook'
+    activeTab:
+      | 'player'
+      | 'actions'
+      | 'chat'
+      | 'inventory'
+      | 'handbook'
+      | 'favorabilities'
   ) {
     if (
       this.actionsTabButton &&

--- a/packages/client/src/sprite/sprite_mob.ts
+++ b/packages/client/src/sprite/sprite_mob.ts
@@ -49,6 +49,7 @@ export class SpriteMob extends Mob {
       mob.position,
       mob.attributes,
       mob.personalities,
+      mob.favorabilities,
       mob.community_id
     );
     this.scene = scene;

--- a/packages/client/src/world/mob.ts
+++ b/packages/client/src/world/mob.ts
@@ -11,6 +11,7 @@ export class Mob extends Physical {
   carrying?: string;
   attributes: Record<string, number> = {};
   personalities: Record<string, number> = {};
+  favorabilities: Record<string, number> = {};
   unlocks: string[] = [];
   doing: string = '';
   community_id?: string;
@@ -24,6 +25,7 @@ export class Mob extends Physical {
     position: Coord | null,
     attributes: Record<string, number>,
     personalities: Record<string, number>,
+    favorabilities: Record<string, number>,
     community_id?: string
   ) {
     super(world, key, type, position);
@@ -38,6 +40,9 @@ export class Mob extends Physical {
     }
     for (const [key, value] of Object.entries(personalities)) {
       this.personalities[key] = value;
+    }
+    for (const [key, value] of Object.entries(favorabilities)) {
+      this.favorabilities[key] = value;
     }
 
     if (community_id) {

--- a/packages/client/src/worldMetadata.ts
+++ b/packages/client/src/worldMetadata.ts
@@ -123,6 +123,13 @@ export class Character {
     return world.mobs[publicCharacterId].personalities['extroversion'];
   }
 
+  get favorabilities(): Record<string, number> {
+    if (!world || !world.mobs[publicCharacterId]) {
+      return {};
+    }
+    return world.mobs[publicCharacterId].favorabilities;
+  }
+
   get isCarrying(): string | undefined {
     if (!world || !world.mobs[publicCharacterId]) {
       return undefined;

--- a/packages/client/test/items/uses/playerBasketInteractions.test.ts
+++ b/packages/client/test/items/uses/playerBasketInteractions.test.ts
@@ -38,6 +38,7 @@ describe('Community ownership based interactions', () => {
       playerPos,
       {},
       {},
+      {},
       'alchemists'
     );
     world.mobs[publicCharacterId] = player;

--- a/packages/client/test/items/uses/playerCarriedItems.test.ts
+++ b/packages/client/test/items/uses/playerCarriedItems.test.ts
@@ -40,6 +40,7 @@ describe('"Give" action item interaction tests', () => {
       100,
       { x: 1, y: 1 },
       {},
+      {},
       {}
     );
   });

--- a/packages/client/test/items/uses/playerCharacterPermissibleInteractions.test.ts
+++ b/packages/client/test/items/uses/playerCharacterPermissibleInteractions.test.ts
@@ -41,6 +41,7 @@ describe('Character ownership based interactions', () => {
       ownerPos,
       {},
       {},
+      {},
       ownerCommunity
     );
     world.mobs[ownerId] = owner;

--- a/packages/client/test/items/uses/playerCommunityPermissibleInteractions.test.ts
+++ b/packages/client/test/items/uses/playerCommunityPermissibleInteractions.test.ts
@@ -40,6 +40,7 @@ describe('Community ownership based interactions', () => {
       playerPos,
       {},
       {},
+      {},
       'alchemists'
     );
     world.mobs[publicCharacterId] = player;

--- a/packages/client/test/scenes/uxSceneChat.test.ts
+++ b/packages/client/test/scenes/uxSceneChat.test.ts
@@ -67,6 +67,7 @@ describe('Chat UI updates based on chatting state', () => {
       100,
       { x: 1, y: 1 },
       {},
+      {},
       {}
     );
     const npc1 = new Mob(
@@ -76,6 +77,7 @@ describe('Chat UI updates based on chatting state', () => {
       'npc',
       100,
       { x: 2, y: 2 },
+      {},
       {},
       {}
     );
@@ -109,6 +111,7 @@ describe('Chat UI updates based on chatting state', () => {
       100,
       { x: 1, y: 1 },
       {},
+      {},
       {}
     );
     const npc = new Mob(
@@ -118,6 +121,7 @@ describe('Chat UI updates based on chatting state', () => {
       'npc',
       100,
       { x: 2, y: 2 },
+      {},
       {},
       {}
     );
@@ -145,6 +149,7 @@ describe('Chat UI updates based on chatting state', () => {
       100,
       { x: 1, y: 1 },
       {},
+      {},
       {}
     );
     const npc1 = new Mob(
@@ -154,6 +159,7 @@ describe('Chat UI updates based on chatting state', () => {
       'npc',
       100,
       { x: 2, y: 2 },
+      {},
       {},
       {}
     );
@@ -175,6 +181,7 @@ describe('Chat UI updates based on chatting state', () => {
       'npc',
       100,
       { x: 3, y: 3 },
+      {},
       {},
       {}
     );

--- a/packages/client/test/scenes/uxSceneFight.test.ts
+++ b/packages/client/test/scenes/uxSceneFight.test.ts
@@ -66,6 +66,7 @@ describe('Fight UI updates based on fighting state', () => {
       100,
       { x: 1, y: 1 },
       {},
+      {},
       {}
     );
     const npc1 = new Mob(
@@ -75,6 +76,7 @@ describe('Fight UI updates based on fighting state', () => {
       'npc',
       100,
       { x: 2, y: 2 },
+      {},
       {},
       {}
     );
@@ -108,6 +110,7 @@ describe('Fight UI updates based on fighting state', () => {
       100,
       { x: 1, y: 1 },
       {},
+      {},
       {}
     );
     const npc = new Mob(
@@ -117,6 +120,7 @@ describe('Fight UI updates based on fighting state', () => {
       'npc',
       100,
       { x: 2, y: 2 },
+      {},
       {},
       {}
     );
@@ -144,6 +148,7 @@ describe('Fight UI updates based on fighting state', () => {
       100,
       { x: 1, y: 1 },
       {},
+      {},
       {}
     );
     const npc1 = new Mob(
@@ -153,6 +158,7 @@ describe('Fight UI updates based on fighting state', () => {
       'npc',
       100,
       { x: 2, y: 2 },
+      {},
       {},
       {}
     );
@@ -174,6 +180,7 @@ describe('Fight UI updates based on fighting state', () => {
       'npc',
       100,
       { x: 3, y: 3 },
+      {},
       {},
       {}
     );

--- a/packages/client/test/world/mob.test.ts
+++ b/packages/client/test/world/mob.test.ts
@@ -29,6 +29,7 @@ const createTestMob = (): Mob => {
     1,
     { x: 0, y: 0 },
     {},
+    {},
     {}
   );
   mob.path = TEST_OLD_PATH;

--- a/packages/common/src/mob.ts
+++ b/packages/common/src/mob.ts
@@ -15,4 +15,5 @@ export type MobI = {
   attributes: Record<string, number>;
   unlocks: string[];
   doing: string;
+  favorabilities: Record<string, number>;
 };

--- a/packages/server/src/community/community.ts
+++ b/packages/server/src/community/community.ts
@@ -103,6 +103,38 @@ export class Community {
     }
     return favorNum.favor;
   }
+
+  static getAllFavorsForCommunity(communityId: string): Record<string, number> {
+    const results = DB.prepare(
+      `
+      SELECT community_1_id, community_2_id, favor
+      FROM favorability
+      WHERE community_1_id = :communityId OR community_2_id = :communityId
+    `
+    ).all({ communityId }) as {
+      community_1_id: string;
+      community_2_id: string;
+      favor: number;
+    }[];
+
+    const favorabilities: Record<string, number> = {};
+
+    for (const row of results) {
+      const otherCommunity =
+        row.community_1_id === communityId
+          ? row.community_2_id
+          : row.community_1_id;
+
+      if (favorabilities[otherCommunity] !== undefined) {
+        favorabilities[otherCommunity] += row.favor;
+      } else {
+        favorabilities[otherCommunity] = row.favor;
+      }
+    }
+
+    return favorabilities;
+  }
+
   /**
    * Creates a favorability relation between two communities, and initializes it by an amount
    *

--- a/packages/server/src/mobs/mob.ts
+++ b/packages/server/src/mobs/mob.ts
@@ -40,6 +40,7 @@ export type MobData = {
   carrying_id: string;
   community_id: string;
   favorite_item: string;
+  favorabilities: Record<string, number>;
 };
 
 interface MobParams {
@@ -58,6 +59,7 @@ interface MobParams {
   subtype: string;
   currentAction?: string;
   carrying?: string;
+  favorabilities?: Record<string, number>;
   path: Coord[];
   target?: Coord;
 }
@@ -942,6 +944,7 @@ export class Mob {
       subtype: mob.subtype,
       currentAction: mob.current_action,
       carrying: mob.carrying_id,
+      favorabilities: mob.favorabilities,
       path: mob.path ? JSON.parse(mob.path) : [],
       target:
         mob.target_x && mob.target_y

--- a/packages/server/src/services/clientCommunication/ablyService.ts
+++ b/packages/server/src/services/clientCommunication/ablyService.ts
@@ -353,6 +353,23 @@ export class AblyService implements PubSub {
     });
   }
 
+  public changeFavorability(key: string, favor: number): void {
+    if (key == undefined || favor == undefined) {
+      throw new Error(
+        `Sending invalid changeFavorability message ${key}, ${favor}`
+      );
+    }
+    this.addToBroadcast({
+      type: 'mob_change',
+      data: {
+        id: key,
+        property: 'favorability',
+        delta: favor,
+        new_value: favor
+      }
+    });
+  }
+
   public changeFavoriteItem(key: string, item: string): void {
     if (key == undefined || item == undefined) {
       throw new Error(`Sending invalid changeSpeed message ${key}, ${item}`);

--- a/packages/server/src/services/clientCommunication/clientMarshalling.ts
+++ b/packages/server/src/services/clientCommunication/clientMarshalling.ts
@@ -11,6 +11,7 @@ import { ItemAttributeData, ItemData } from '../../items/item';
 import { Mob, MobData } from '../../mobs/mob';
 import { FantasyDate } from '../../date/fantasyDate';
 import { Personality, Personalities } from '../../mobs/traits/personality';
+import { Community } from '../../community/community';
 
 export function getHousesAbly(): HouseI[] {
   const houseDatas = DB.prepare(
@@ -76,6 +77,7 @@ function mobDataToMob(mobData: MobData): MobI {
       attack: mobData.attack,
       defense: mobData.defense
     },
+    favorabilities: mobData.favorabilities,
     unlocks: mobData.community_id ? [mobData.community_id] : [],
     doing: mobData.current_action
   };
@@ -143,6 +145,10 @@ export function getMobsAbly(): MobI[] {
       sleepy: personalityData?.sleepy ?? 0,
       extroversion: personalityData?.extroversion ?? 0
     });
+
+    mobData.favorabilities = Community.getAllFavorsForCommunity(
+      mobData.community_id
+    );
 
     return mobDataToMob(mobData);
   });
@@ -231,6 +237,10 @@ export function getMobAbly(key: string): MobI {
     sleepy: personalityData.sleepy ?? 0,
     extroversion: personalityData.extroversion ?? 0
   });
+
+  mobData.favorabilities = Community.getAllFavorsForCommunity(
+    mobData.community_id
+  );
 
   return mobDataToMob(mobData);
 }

--- a/packages/server/src/services/clientCommunication/pubsub.ts
+++ b/packages/server/src/services/clientCommunication/pubsub.ts
@@ -45,6 +45,7 @@ export interface PubSub {
   changeMaxHealth(key: string, maxHealth: number, newValue: number): void;
   changeSpeed(key: string, speed: number, newValue: number): void;
   changeFavoriteItem(key: string, item: string): void;
+  changeFavorability(key: string, favor: number): void;
   speak(key: string, message: string): void;
   setDateTime(fantasyDate: FantasyDate): void;
   kill(key: string): void;

--- a/packages/server/src/services/clientCommunication/stubbedPubSub.ts
+++ b/packages/server/src/services/clientCommunication/stubbedPubSub.ts
@@ -66,6 +66,8 @@ export class StubbedPubSub implements PubSub {
 
   changeFavoriteItem(_key: string, _item: string): void {}
 
+  changeFavorability(_key: string, _favor: number): void {}
+
   speak(_key: string, _message: string): void {}
 
   setDateTime(_fantasyDate: FantasyDate): void {}


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
Added a new feature where the user (alchemist) can see what favorability they have with each community (blobs, silverclaw, fighters, and future communities)

## Problem
<!--- Why is this change required? What problem does it solve? -->
<!--- You can just link to the issue if applicable with "Closes #XYZ" -->
Closes #568 

## Context
<!--- What alternatives were considered, and why was this approach chosen? -->
<!--- Mention any design decisions or trade-offs. -->
We implemented this where the player can press the **_F key_** and the numbers will appear. Originally, we believed that it should be in the Player tab, but we recognized that it will make more cluttered than it should be. We have chosen this approach as we believe that it should be easily found, in case the player wants to keep track of favorability when doing some type of action. Like what is done with the potions handbook, this reduces the amount of tabs in the UI. 

A new attribute, favorabilities, was added into the `mob.ts` in the `common` folder for this implementation.

## Impact
<!--- Does this change break anything or require documentation updates? -->
<!--- How will this change affect other developers? Can that burden be minimized? --> 
<!--- Should they be notified (e.g., via Slack)? -->
This change added a new parameter for mobs so it affected some previous test cases which has been resolved by us.

## Testing
<!--- Describe how you tested the changes -->
<!--- Mention automated tests, manual testing, or reasons for not testing -->
Because this is mainly a change in the UI, no tests were made.

## Screenshots (if appropriate)
<!--- Remove this section if not appropriate -->
Result:
<img width="454" alt="image" src="https://github.com/user-attachments/assets/632ee00e-e417-47cc-896d-e1d8ca23caec" />
