### PR TITLE
Adding in shipwreck to water world

### DIFF
--- a/packages/json-generator/global.json
+++ b/packages/json-generator/global.json
@@ -658,6 +658,13 @@
       ]
     },
     {
+      "name": "Shipwreck",
+      "type": "shipwreck",
+      "carryable": false,
+      "walkable": false,
+      "interactions": []
+    },
+    {
       "name": "Volcano",
       "type": "volcano",
       "description": "a volcano that will erupt",

--- a/packages/server/global.json
+++ b/packages/server/global.json
@@ -643,6 +643,13 @@
             ]
         },
         {
+            "name": "Shipwreck",
+            "type": "shipwreck",
+            "carryable": false,
+            "walkable": false,
+            "interactions": []
+        },
+        {
             "name": "Volcano",
             "type": "volcano",
             "description": "a volcano that will erupt",

--- a/world_assets/global/client/global.json
+++ b/world_assets/global/client/global.json
@@ -517,6 +517,11 @@
                     "action": "build_wall",
                     "while_carried": true,
                     "requires_item": "partial-wall"
+                },
+                {
+                    "description": "Create Market",
+                    "action": "create_market",
+                    "while_carried": true
                 }
             ]
         },
@@ -629,6 +634,13 @@
                     }
                 }
             ]
+        },
+        {
+            "name": "Shipwreck",
+            "type": "shipwreck",
+            "carryable": false,
+            "walkable": false,
+            "interactions": []
         },
         {
             "name": "Volcano",

--- a/world_assets/global/server/global.json
+++ b/world_assets/global/server/global.json
@@ -526,6 +526,11 @@
                     "action": "build_wall",
                     "while_carried": true,
                     "requires_item": "partial-wall"
+                },
+                {
+                    "description": "Create Market",
+                    "action": "create_market",
+                    "while_carried": true
                 }
             ]
         },
@@ -641,6 +646,13 @@
                     }
                 }
             ]
+        },
+        {
+            "name": "Shipwreck",
+            "type": "shipwreck",
+            "carryable": false,
+            "walkable": false,
+            "interactions": []
         },
         {
             "name": "Volcano",

--- a/world_assets/water-world/server/world_specific.json
+++ b/world_assets/water-world/server/world_specific.json
@@ -126,7 +126,6 @@
               { "type": "anemone", "coord": { "x": 42, "y": 33 } },
               { "type": "coral", "coord": { "x": 29, "y": 25 } },
               { "type": "coral", "coord": { "x": 22, "y": 30 } },
-              { "type": "coral", "coord": { "x": 27, "y": 28 } },
 
               { "type": "seaweed", "coord": { "x": 4, "y": 35 } },
 
@@ -145,7 +144,8 @@
               { "type": "starfish", "coord": { "x": 15, "y": 4 } },
               { "type": "starfish", "coord": { "x": 20, "y": 2 } },
               { "type": "starfish", "coord": { "x": 22, "y": 3 } },
-              { "type": "starfish", "coord": { "x": 26, "y": 2 } }
+              { "type": "starfish", "coord": { "x": 26, "y": 2 } },
+              { "type": "shipwreck", "coord": { "x": 27, "y":  28} } 
           ],
       "regions": [
         {


### PR DESCRIPTION
## Description
The visual of the shipwreck is now visible in Oozon. the next steps will be to make the ship transparent when the character walks behind it.

## Problem
World Enhancement

## Context
World Enhancement

## Impact
The changes were tested through temporary local asset files instead of pulling from GitHub Pages. The world_assets folder files have been updated and therefore will reflect the changes in GitHub Pages. All appropriate files were edited to add the new item, therefore no impact should occur.

## Testing
Replaced GitHub Pages assets with local ones temporarily to test the new item placement.

## Screenshots (if appropriate)
![image](https://github.com/user-attachments/assets/6eb067db-6560-4030-81dd-c8cbb084d3cc)

