### PR TITLE
fix: stop poison from crashing game server

### DIFF
--- a/packages/server/src/mobs/mob.ts
+++ b/packages/server/src/mobs/mob.ts
@@ -195,6 +195,9 @@ export class Mob {
       `
     ).get({ id: this.id }) as { poisoned: number };
 
+    if (!mob) {
+      return 0; // mob no longer exists, return 0
+    }
     return mob.poisoned;
   }
 


### PR DESCRIPTION
## Description
One line fix to prevent poison from crashing server. 

## Problem
So the server stops crashing

## Context
Just hacking it in so we stop server from crashing.

## Impact
Server stops crashing

## Testing
It stopped crashing. I should have written a unit test, but I will make the students write one.

