### PR TITLE
documentation: ECONNREFUSED error

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,6 +143,8 @@ Your state may become out of sync for several reasons.
    ```
    to build a world named world-name.
 
+   note: to avoid 'ECONNREFUSED' error, ensure that auth-server is running with the 'pnpm dev' command.
+
 ### Run!
 
 1. In the **auth-server** package, execute:


### PR DESCRIPTION
## Description
Added README documentation to help avoid ECONNREFUSED error in server when building.

## Problem
closes issue #566 

## Context
When the 'pnpm run create world-name' command is ran in server there appears an AggregateError 'ECONNREFUSED'.

## Impact
This will allow devs the peace of mind knowing this error is not causing major issues during build time with a simple fix.

## Testing
No testing required - running auth server fixes it.

## Screenshots (if appropriate)
![image](https://github.com/user-attachments/assets/de5d6054-1571-48ca-b716-f72921535b7d)

