### PR TITLE
Fixed problem with wall destruction decision making.

### DIFF
--- a/packages/client/src/world/controller.ts
+++ b/packages/client/src/world/controller.ts
@@ -341,15 +341,19 @@ export function getInteractablePhysicals(
 
   // nearby non-walkable items
   let nearbyObjects = physicals.filter(
-    (p) => !p.itemType.walkable && p.itemType.layout_type !== 'fence'
+    (p) => !p.itemType.walkable && 
+            p.itemType.layout_type !== 'fence' &&
+            p.itemType.layout_type !== 'wall'
   );
 
-  let fences = physicals.filter((p) => p.itemType.layout_type === 'fence');
+  let walls = physicals.filter((p) => p.itemType.layout_type === 'fence' ||
+                                      p.itemType.layout_type === 'wall' ||
+                                      p.itemType.type === 'partial-wall');
 
   let nearbyBaskets = physicals.filter((p) => p.itemType.type === 'basket');
 
-  if (fences.length > 1) {
-    fences = [getClosestPhysical(fences, playerPos)];
+  if (walls.length > 1) {
+    walls = [getClosestPhysical(walls, playerPos)];
   }
 
   // find distinct non-walkable objects next to player
@@ -364,7 +368,7 @@ export function getInteractablePhysicals(
     ...unique_nearbyObjects,
     ...nearbyOpenableObjects,
     ...nearbyBaskets,
-    ...fences
+    ...walls
   ];
   interactableObjects = interactableObjects.filter(
     (item, index, self) =>


### PR DESCRIPTION
## Description
Altered code that would choose the first item in a list to choose instead the closest item in a list when looking to smash walls. 

## Problem
This solves a problem with not destroying a wall, partial or full. This should prioritize walls that are closer to the player as opposed to those diagonal to the player.
Closes 584

## Context
The other alternative chosen was to change this functionality for all static items, but I don't know how to do it without breaking it. I tried in the past with fences, but it would result in the inability to break anything at all. This means that this problem likely still persists with anything that is not a Fence, wall, or partial wall (and a basket because that is already covered.)

## Impact
This should not have any impact on other development.

## Testing
I tested this by loading in the game and checking the cases. there is no automated testing for controller.ts
