### PR TITLE
publish chat messages to clients

### DIFF
--- a/packages/auth-server/src/authController.ts
+++ b/packages/auth-server/src/authController.ts
@@ -62,6 +62,7 @@ const authController = async (req: Request, res: Response) => {
       capabilities['world-' + world] = ['subscribe', 'presence'];
       capabilities[publicCharacterId + '-' + world] = ['publish', 'subscribe'];
       capabilities['communication-' + world] = ['publish', 'subscribe'];
+      capabilities['chat-' + world] = ['publish', 'subscribe'];
 
       tokenParams = {
         capability: capabilities,

--- a/packages/client/src/services/ablySetup.ts
+++ b/packages/client/src/services/ablySetup.ts
@@ -1,11 +1,13 @@
 import { Realtime, Types } from 'ably';
-import { WorldScene } from '../scenes/worldScene';
+import { WorldScene, world } from '../scenes/worldScene';
 import { publicCharacterId, characterId } from '../worldMetadata';
 import { setupPlayerSubscriptions } from './serverToPlayer';
 import { setupBroadcast } from './serverToBroadcast';
+import { SpriteMob } from '../sprite/sprite_mob';
 
 export let broadcastChannel: Types.RealtimeChannelCallbacks;
 export let playerChannel: Types.RealtimeChannelCallbacks;
+export let chatChannel: Types.RealtimeChannelCallbacks;
 
 const SERVER_URL = process.env.SERVER_URL; //Cannot use getEnv in the client package https://webpack.js.org/guides/environment-variables/
 let channelsBoundToWorld: boolean = false;
@@ -36,6 +38,7 @@ export function setupAbly(): Promise<string> {
 
       broadcastChannel = ably.channels.get(`world-${worldID}`);
       playerChannel = ably.channels.get(`${publicCharacterId}-${worldID}`);
+      chatChannel = ably.channels.get(`chat-${worldID}`);
 
       resolve(worldID);
       console.log('Ably client initialized successfully.', worldID);
@@ -52,4 +55,14 @@ export function bindAblyToWorldScene(scene: WorldScene) {
 
   setupBroadcast(broadcastChannel, scene);
   setupPlayerSubscriptions(playerChannel, scene);
+
+  chatChannel.subscribe('chat', (payload: Types.Message) => {
+    const mob_id = payload.data.mob_id;
+    if (publicCharacterId === mob_id) return;
+
+    const mob = world.mobs[mob_id];
+    if (mob) {
+      (mob as SpriteMob).showSpeechBubble(payload.data.message, true);
+    }
+  });
 }

--- a/packages/client/src/services/playerToServer.ts
+++ b/packages/client/src/services/playerToServer.ts
@@ -3,13 +3,20 @@ import { Mob } from '../world/mob';
 import { world } from '../scenes/worldScene';
 import { currentCharacter, publicCharacterId } from '../worldMetadata';
 import { SpriteMob } from '../sprite/sprite_mob';
-import { broadcastChannel, playerChannel } from './ablySetup';
+import { broadcastChannel, playerChannel, chatChannel } from './ablySetup';
 
 export function publishPlayerMessage<T extends keyof PlayerToServerMessageMap>(
   type: T,
   payload: PlayerToServerMessageMap[T]
 ) {
   playerChannel.publish(type, payload);
+}
+
+export function publishChatMessage(payload: {
+  mob_id: string;
+  message: string;
+}) {
+  chatChannel.publish('chat', payload);
 }
 
 export function requestChat(mob: Mob) {
@@ -38,6 +45,7 @@ export function speak(message: string, response: number) {
 // Function for players (only takes a message)
 export function chatPlayer(message: string) {
   showSpeech(message);
+  publishChatMessage({ mob_id: publicCharacterId, message });
 }
 
 export function fight(message: string, attack: number) {


### PR DESCRIPTION
## Description
Created another ably channel for chat messages to display chat bubble when client receives messages.

## Problem
Players will now be able to communicate via text chat.

## Context
Before this change, the message was not being sent anywhere to publish to other clients. It was just showing up on a singular client's side.

## Testing
Testing not required.
To have confidence that it worked with other clients, we opened up an incognito tab to simulate multiple clients subscribing to the ably channel.

## Screenshots (if appropriate)
<img width="620" alt="image" src="https://github.com/user-attachments/assets/1ebca1a5-8758-4e2f-ace7-27020585c37a" />
