### PR TITLE
fix: log error rather than crash when mob not found on persistence

### DIFF
--- a/packages/server/src/services/clientCommunication/ablyService.ts
+++ b/packages/server/src/services/clientCommunication/ablyService.ts
@@ -591,7 +591,8 @@ export class AblyService implements PubSub {
     console.log('Updating state info for', username);
     const player = Mob.getMob(username);
     if (!player) {
-      throw new Error('no player found ' + username);
+      console.error(`No player found, unable to persist player state: ${username}`);
+      return;
     }
     let health_for_update = player.health;
     let gold_for_update = player.gold;

--- a/packages/server/src/services/clientCommunication/ablyService.ts
+++ b/packages/server/src/services/clientCommunication/ablyService.ts
@@ -591,7 +591,9 @@ export class AblyService implements PubSub {
     console.log('Updating state info for', username);
     const player = Mob.getMob(username);
     if (!player) {
-      console.error(`No player found, unable to persist player state: ${username}`);
+      console.error(
+        `No player found, unable to persist player state: ${username}`
+      );
       return;
     }
     let health_for_update = player.health;


### PR DESCRIPTION


## Description
World persistence blows up right now if the player dies at an inopportune time.

## Problem
Patches the issues above to not crash. I'm logging an error instead and I abort from the persistence method.

## Context
This persistence & presence code is not great. I'm sure there is a better solution but trying to get the server to stay up.

## Impact
Server stops crashing.

## Testing
I retriggered the error and it no longer crashes. Seems to work much better now.
