### PR TITLE
552 fix leaderboad display

### DIFF
--- a/packages/client/src/config.ts
+++ b/packages/client/src/config.ts
@@ -9,6 +9,7 @@ import { ChatOverlayScene } from './scenes/chatOverlayScene';
 import { BrewScene } from './scenes/brewScene';
 import { PortalMenuScene } from './scenes/portalMenuScene';
 import { LeaderboardScene } from './scenes/leaderboardScene';
+import { MiniLeaderboardScene } from './scenes/miniLeaderboardScene';
 import { PortalLoadingScene } from './scenes/portalLoadingScene';
 
 export const SCREEN_WIDTH = 480;
@@ -39,7 +40,8 @@ const config: Phaser.Types.Core.GameConfig = {
     BrewScene,
     PortalMenuScene,
     PortalLoadingScene,
-    LeaderboardScene
+    LeaderboardScene,
+    MiniLeaderboardScene
   ]
 };
 

--- a/packages/client/src/scenes/leaderboardScene.ts
+++ b/packages/client/src/scenes/leaderboardScene.ts
@@ -48,8 +48,6 @@ export class LeaderboardScene extends Phaser.Scene {
 
     // Click Handler
     closeButton.on('pointerdown', () => {
-      console.log(`Now Showing Leaderboard`);
-
       // Stop showing full leaderboard
       this.scene.stop('LeaderboardScene');
 

--- a/packages/client/src/scenes/leaderboardScene.ts
+++ b/packages/client/src/scenes/leaderboardScene.ts
@@ -1,4 +1,5 @@
 import { leaderboardData } from '../world/controller';
+import { miniButtonStyle } from './miniLeaderboardScene';
 
 const DEPTH_BASE = 100;
 const MAX_ROWS = 3;
@@ -31,6 +32,30 @@ export class LeaderboardScene extends Phaser.Scene {
       }
     );
     this.titleText.setDepth(DEPTH_BASE + 1);
+
+    // Create Button For Closing
+    const closeButton = this.add.text(
+      this.background.x + this.background.width - 35, 
+      this.background.y + 18, 
+      'Hide',
+      miniButtonStyle
+    );
+
+    // Set Button Interactivity
+    closeButton.setInteractive({ useHandCursor: true });
+    closeButton.setOrigin(0.5);
+    closeButton.setDepth(DEPTH_BASE + 2);
+
+    // Click Handler
+    closeButton.on('pointerdown', () => {
+        console.log(`Now Showing Leaderboard`);
+
+        // Stop showing full leaderboard
+        this.scene.stop('LeaderboardScene');
+
+        // Start showing mini leaderboard
+        this.scene.start('MiniLeaderboardScene');
+    });
 
     this.renderLeaderboard();
   }

--- a/packages/client/src/scenes/leaderboardScene.ts
+++ b/packages/client/src/scenes/leaderboardScene.ts
@@ -35,8 +35,8 @@ export class LeaderboardScene extends Phaser.Scene {
 
     // Create Button For Closing
     const closeButton = this.add.text(
-      this.background.x + this.background.width - 35, 
-      this.background.y + 18, 
+      this.background.x + this.background.width - 35,
+      this.background.y + 18,
       'Hide',
       miniButtonStyle
     );
@@ -48,13 +48,13 @@ export class LeaderboardScene extends Phaser.Scene {
 
     // Click Handler
     closeButton.on('pointerdown', () => {
-        console.log(`Now Showing Leaderboard`);
+      console.log(`Now Showing Leaderboard`);
 
-        // Stop showing full leaderboard
-        this.scene.stop('LeaderboardScene');
+      // Stop showing full leaderboard
+      this.scene.stop('LeaderboardScene');
 
-        // Start showing mini leaderboard
-        this.scene.start('MiniLeaderboardScene');
+      // Start showing mini leaderboard
+      this.scene.start('MiniLeaderboardScene');
     });
 
     this.renderLeaderboard();

--- a/packages/client/src/scenes/loadWorldScene.ts
+++ b/packages/client/src/scenes/loadWorldScene.ts
@@ -264,7 +264,7 @@ export class LoadWorldScene extends Phaser.Scene {
           this.scene.start('WorldScene');
           this.scene.start('UxScene');
           this.scene.start('FrameScene');
-          this.scene.start('LeaderboardScene');
+          this.scene.start('MiniLeaderboardScene');
           setGameState('worldLoaded');
         }
 
@@ -310,7 +310,7 @@ export class LoadWorldScene extends Phaser.Scene {
     this.scene.start('WorldScene');
     this.scene.start('UxScene');
     this.scene.start('FrameScene');
-    this.scene.start('LeaderboardScene');
+    this.scene.start('MiniLeaderboardScene');
     setGameState('worldLoaded');
   }
 

--- a/packages/client/src/scenes/miniLeaderboardScene.ts
+++ b/packages/client/src/scenes/miniLeaderboardScene.ts
@@ -1,0 +1,63 @@
+import { SCREEN_HEIGHT, SCREEN_WIDTH } from '../config';
+
+const DEPTH_BASE = 100;
+
+export const miniButtonStyle = {
+    fontSize: '24px',
+    color: '#ffffff',
+    backgroundColor: '#28a745', // Green background
+    padding: {
+      x: 20,
+      y: 10
+    },
+    align: 'center'
+  };
+
+export class MiniLeaderboardScene extends Phaser.Scene {
+  private background?: Phaser.GameObjects.Rectangle;
+  private titleText?: Phaser.GameObjects.Text;
+
+  constructor() {
+    super({ key: 'MiniLeaderboardScene' });
+  }
+
+  create() {
+    // Create a background for the leaderboard
+    this.background = this.add.rectangle(18, 15, 220, 70, 0x000000, 0.7);
+    this.background.setOrigin(0, 0);
+    this.background.setDepth(DEPTH_BASE);
+
+    // Add title
+    this.titleText = this.add.text(
+      this.background.x + 10,
+      this.background.y + 10,
+      'Leaderboard',
+      {
+        fontSize: '18px',
+        color: '#ffffff',
+        fontStyle: 'bold'
+      }
+    );
+    this.titleText.setDepth(DEPTH_BASE + 1);
+
+    const closeButton = this.add.text(
+          SCREEN_WIDTH / 2,
+          SCREEN_HEIGHT * 0.7,
+          'Open',
+          miniButtonStyle
+        );
+
+    // Click Handler
+    closeButton.on('pointerdown', () => {
+
+        console.log(`Now Showing Leaderboard`);
+        
+        // Stop showing mini leaderboard
+        this.scene.stop('leaderboardMiniScene');
+        
+        // Start showing full leaderboard
+        this.scene.start('leaderboardScene');
+    
+    });
+  }
+}

--- a/packages/client/src/scenes/miniLeaderboardScene.ts
+++ b/packages/client/src/scenes/miniLeaderboardScene.ts
@@ -53,8 +53,6 @@ export class MiniLeaderboardScene extends Phaser.Scene {
 
     // Click Handler
     openButton.on('pointerdown', () => {
-      console.log(`Now Showing Leaderboard`);
-
       // Stop showing mini leaderboard
       this.scene.stop('MiniLeaderboardScene');
 

--- a/packages/client/src/scenes/miniLeaderboardScene.ts
+++ b/packages/client/src/scenes/miniLeaderboardScene.ts
@@ -1,15 +1,15 @@
 const DEPTH_BASE = 100;
 
 export const miniButtonStyle = {
-    fontSize: '12px',
-    color: '#ffffff',
-    backgroundColor: '#808080', // Green background
-    padding: {
-      x: 7.5,
-      y: 2.5
-    },
-    align: 'center'
-  };
+  fontSize: '12px',
+  color: '#ffffff',
+  backgroundColor: '#808080', // Green background
+  padding: {
+    x: 7.5,
+    y: 2.5
+  },
+  align: 'center'
+};
 
 export class MiniLeaderboardScene extends Phaser.Scene {
   private background?: Phaser.GameObjects.Rectangle;
@@ -40,8 +40,8 @@ export class MiniLeaderboardScene extends Phaser.Scene {
 
     // Create Button For Opening
     const openButton = this.add.text(
-      this.background.x + this.background.width - 35, 
-      this.background.y + 18, 
+      this.background.x + this.background.width - 35,
+      this.background.y + 18,
       'Show',
       miniButtonStyle
     );
@@ -53,13 +53,13 @@ export class MiniLeaderboardScene extends Phaser.Scene {
 
     // Click Handler
     openButton.on('pointerdown', () => {
-        console.log(`Now Showing Leaderboard`);
+      console.log(`Now Showing Leaderboard`);
 
-        // Stop showing mini leaderboard
-        this.scene.stop('MiniLeaderboardScene');
+      // Stop showing mini leaderboard
+      this.scene.stop('MiniLeaderboardScene');
 
-        // Start showing full leaderboard
-        this.scene.start('LeaderboardScene');
+      // Start showing full leaderboard
+      this.scene.start('LeaderboardScene');
     });
   }
 }

--- a/packages/client/src/scenes/miniLeaderboardScene.ts
+++ b/packages/client/src/scenes/miniLeaderboardScene.ts
@@ -1,14 +1,12 @@
-import { SCREEN_HEIGHT, SCREEN_WIDTH } from '../config';
-
 const DEPTH_BASE = 100;
 
 export const miniButtonStyle = {
-    fontSize: '24px',
+    fontSize: '12px',
     color: '#ffffff',
-    backgroundColor: '#28a745', // Green background
+    backgroundColor: '#808080', // Green background
     padding: {
-      x: 20,
-      y: 10
+      x: 7.5,
+      y: 2.5
     },
     align: 'center'
   };
@@ -23,7 +21,7 @@ export class MiniLeaderboardScene extends Phaser.Scene {
 
   create() {
     // Create a background for the leaderboard
-    this.background = this.add.rectangle(18, 15, 220, 70, 0x000000, 0.7);
+    this.background = this.add.rectangle(18, 15, 220, 35, 0x000000, 0.7);
     this.background.setOrigin(0, 0);
     this.background.setDepth(DEPTH_BASE);
 
@@ -40,24 +38,28 @@ export class MiniLeaderboardScene extends Phaser.Scene {
     );
     this.titleText.setDepth(DEPTH_BASE + 1);
 
-    const closeButton = this.add.text(
-          SCREEN_WIDTH / 2,
-          SCREEN_HEIGHT * 0.7,
-          'Open',
-          miniButtonStyle
-        );
+    // Create Button For Opening
+    const openButton = this.add.text(
+      this.background.x + this.background.width - 35, 
+      this.background.y + 18, 
+      'Show',
+      miniButtonStyle
+    );
+
+    // Set Button Interactivity
+    openButton.setInteractive({ useHandCursor: true });
+    openButton.setOrigin(0.5);
+    openButton.setDepth(DEPTH_BASE + 2);
 
     // Click Handler
-    closeButton.on('pointerdown', () => {
-
+    openButton.on('pointerdown', () => {
         console.log(`Now Showing Leaderboard`);
-        
+
         // Stop showing mini leaderboard
-        this.scene.stop('leaderboardMiniScene');
-        
+        this.scene.stop('MiniLeaderboardScene');
+
         // Start showing full leaderboard
-        this.scene.start('leaderboardScene');
-    
+        this.scene.start('LeaderboardScene');
     });
   }
 }


### PR DESCRIPTION
## Description
Added button feature to show and hide leaderboard (See Screenshots)


## Problem
The leaderboard was taking up a large portion of the screen. This change allows users to better move around the map with their cursor and is a quality of life change.

## Context
You could move the leaderboard into a tab, however this would defeat the purpose of having it show on the main screen. Ultimately chose implementing buttons as it is a quick solution that accomplishes the goal. 

## Impact
Does not impact other dev teams or devs.

## Testing
Tested the screenshots through manual testing as it UI. Please see screenshots for two different states of button.


## Screenshots (if appropriate)
![OpenLeaderboard](https://github.com/user-attachments/assets/02123351-a4bc-4fe6-8e1b-488e0fb13622)
![CloseLeaderboard](https://github.com/user-attachments/assets/46b8acda-1ee0-484a-bb9c-4b52f0d9eb96)
