### PR TITLE
fix: auth server start points to wrong place

### DIFF
--- a/packages/auth-server/package.json
+++ b/packages/auth-server/package.json
@@ -10,7 +10,7 @@
     "format": "prettier --config ../../.prettierrc 'src/**/*.ts' --write",
     "clean": "rimraf dist",
     "build": "tsc",
-    "start": "node dist/index.js",
+    "start": "node dist/src/index.js",
     "dev": "nodemon --watch src --exec ts-node src/index.ts"
   },
   "keywords": [],


### PR DESCRIPTION
## Description
Auth server was refactored to have tests, but the package.json wasn't updated to have start point to the new src folder.

## Problem
Auth server doesn't start.

## Context
Made it point to the right place.

## Impact
Auth server starts

## Testing
It works!
