### PR TITLE
Keybinds for common interactions. Issue #578

### DIFF
--- a/packages/client/src/scenes/worldScene.ts
+++ b/packages/client/src/scenes/worldScene.ts
@@ -53,7 +53,13 @@ export class WorldScene extends Phaser.Scene {
   terrainWidth: number = 0;
   terrainHeight: number = 0;
   nightOpacity: number = 0;
-  keys: { [key: string]: boolean } = { w: false, a: false, s: false, d: false, e: false };
+  keys: { [key: string]: boolean } = {
+    w: false,
+    a: false,
+    s: false,
+    d: false,
+    e: false
+  };
   prevKeys: { [key: string]: boolean } = {
     w: false,
     a: false,

--- a/packages/client/src/scenes/worldScene.ts
+++ b/packages/client/src/scenes/worldScene.ts
@@ -454,7 +454,6 @@ export class WorldScene extends Phaser.Scene {
     });
 
     const movementKeys = ['w', 'a', 's', 'd'];
-    const actionKeys = ['e']; 
 
     this.input.keyboard?.on('keydown', (event: KeyboardEvent) => {
       if (!world.mobs[publicCharacterId]) {

--- a/packages/client/src/scenes/worldScene.ts
+++ b/packages/client/src/scenes/worldScene.ts
@@ -15,11 +15,13 @@ import { World } from '../world/world';
 import { GRAY } from './pauseScene';
 import { publishPlayerPosition } from '../services/playerToServer';
 import { getNightSkyOpacity } from '../utils/nightOverlayHandler';
+import { interact } from '../services/playerToServer';
 import {
   ItemType,
   parseWorldFromJson,
   WorldDescription
 } from '../worldDescription';
+
 import { UxScene } from './uxScene';
 import { setGameState, setInventoryCallback } from '../world/controller';
 import {
@@ -51,12 +53,13 @@ export class WorldScene extends Phaser.Scene {
   terrainWidth: number = 0;
   terrainHeight: number = 0;
   nightOpacity: number = 0;
-  keys: { [key: string]: boolean } = { w: false, a: false, s: false, d: false };
+  keys: { [key: string]: boolean } = { w: false, a: false, s: false, d: false, e: false };
   prevKeys: { [key: string]: boolean } = {
     w: false,
     a: false,
     s: false,
-    d: false
+    d: false,
+    e: false
   };
   lastKeyUp = '';
   lastPublishTime: number = 0;
@@ -451,6 +454,7 @@ export class WorldScene extends Phaser.Scene {
     });
 
     const movementKeys = ['w', 'a', 's', 'd'];
+    const actionKeys = ['e']; 
 
     this.input.keyboard?.on('keydown', (event: KeyboardEvent) => {
       if (!world.mobs[publicCharacterId]) {
@@ -461,6 +465,26 @@ export class WorldScene extends Phaser.Scene {
       if (movementKeys.includes(curKey)) {
         this.keys[curKey] = true;
         this.lastKeyUp = curKey;
+      }
+
+      if (curKey === 'e') {
+        const player = world.mobs[publicCharacterId];
+        if (player && player.position) {
+          if (player.carrying) {
+            const carriedItem = world.items[player.carrying];
+            if (carriedItem) {
+              interact(carriedItem.key, 'drop', null);
+            }
+          } else {
+            const pickupItem = world.getItemAt(
+              Math.floor(player.position.x),
+              Math.floor(player.position.y)
+            );
+            if (pickupItem) {
+              interact(pickupItem.key, 'pickup', null);
+            }
+          }
+        }
       }
 
       if (event.shiftKey && event.code === 'KeyF') {


### PR DESCRIPTION
## Description
Adding a short cut keyboard interactions on top of the WASD including and not limited to:
1. Picking up item with keyboard on <e/E> 
2. Dropping item with keyboard on <e/E> (if item is on hands)

## Problem
In the current state of the game, it becomes difficult to toggle actions using on game buttons, so adding a feature to play the game using the keyboard adds smooth and intuitive user interaction. 

## Context
Initial thought was to have a separate **Keyboard** buttons for each interaction, but from UX perspective it would be harder for the user to remember all possible hotkeys, so we used **Apple's Home Button** idea to toggle the same button for different tasks depending on the state of the process.

## Impact
1. This might require a HotKey Documentation update
2. During the client side testing, it will be easier and faster for developers and clients to interact with objects.
3. Not necessarily to notify, but great if they all know of this feature.

## Testing
<!--- Describe how you tested the changes -->
<!--- Mention automated tests, manual testing, or reasons for not testing -->
1. As of right now, there were only manual testings of interacting with objects through HotKeys under different conditions.

