### PR TITLE
Transparency of ship when character walks behind it

### DIFF
--- a/packages/client/src/scenes/worldScene.ts
+++ b/packages/client/src/scenes/worldScene.ts
@@ -563,7 +563,7 @@ export class WorldScene extends Phaser.Scene {
         } else {
           ship.sprite.setAlpha(1);
         }
-      });  
+      });
     }
 
     if (fantasyDate) {

--- a/packages/client/src/scenes/worldScene.ts
+++ b/packages/client/src/scenes/worldScene.ts
@@ -29,6 +29,7 @@ import {
 } from '../utils/developerCheats';
 import { buttonStyle, nameButtonHoverStyle } from './loadWorldScene';
 import { Item } from '../world/item';
+import { SpriteItem } from '../sprite/sprite_item';
 
 export let world: World;
 let needsAnimationsLoaded: boolean = true;
@@ -541,6 +542,28 @@ export class WorldScene extends Phaser.Scene {
         const spriteHouse = house as SpriteHouse;
         spriteHouse.animate(Math.floor(x), Math.floor(y));
       });
+
+      Object.values(world.items).forEach((shipwreck) => {
+        const ship = shipwreck as SpriteItem;
+        const heroX = Math.floor(x);
+        const heroY = Math.floor(y);
+
+        // Calculate the width and height in tiles
+        const shipWidthTiles = 110 / TILE_SIZE;
+        const shipHeightTiles = 115 / TILE_SIZE;
+
+        if (
+          ship.itemType.type === 'shipwreck' &&
+          heroX > 27 - shipWidthTiles / 2 - 1 &&
+          heroX < 27 + shipWidthTiles / 2 &&
+          heroY > 28 - shipHeightTiles / 2 &&
+          heroY < 28 + shipHeightTiles / 2 - 1
+        ) {
+          ship.sprite.setAlpha(0.5);
+        } else {
+          ship.sprite.setAlpha(1);
+        }
+      });  
     }
 
     if (fantasyDate) {

--- a/world_assets/water-world/server/world_specific.json
+++ b/world_assets/water-world/server/world_specific.json
@@ -126,7 +126,6 @@
               { "type": "anemone", "coord": { "x": 42, "y": 33 } },
               { "type": "coral", "coord": { "x": 29, "y": 25 } },
               { "type": "coral", "coord": { "x": 22, "y": 30 } },
-              { "type": "coral", "coord": { "x": 27, "y": 28 } },
               { "type": "slime-blob", "coord": {"x": 14, "y": 38}},
               { "type": "seaweed", "coord": { "x": 4, "y": 35 } },
               { "type": "pearl", "coord": {"x": 13, "y": 38}},


### PR DESCRIPTION
## Description
Transparency to the shipwreck when character walks behind it.

## Problem
Character was not visible behind the shipwreck

## Context
Alternative consideration was to disable walking behind the shipwreck.

## Impact
No dev impact.

## Testing
Manual testing on personal env.

## Screenshots (if appropriate)
<img width="520" alt="image" src="https://github.com/user-attachments/assets/689217a0-d979-400b-9295-aa4bd12b0f07" />