### PR TITLE
Bug: Added checks so we never check attributes for dead mobs

### DIFF
--- a/packages/server/src/items/potionEffects.ts
+++ b/packages/server/src/items/potionEffects.ts
@@ -146,6 +146,10 @@ function giveRandomEffect(mob: Mob) {
       return true;
     case 1:
       // Reduce Health by 20 or to 1
+      if (!mob || !Mob.getMob(mob.id)) {
+        //console.error(`${mob.name} is no longer valid or does not exist in the database.`);
+        return;  // Exit early
+      }
       if (mob.health > 20) {
         mob.changeHealth(-20);
       } else {

--- a/packages/server/src/mobs/plans/flee.ts
+++ b/packages/server/src/mobs/plans/flee.ts
@@ -67,7 +67,14 @@ export class Flee implements Plan {
 
     this.enemy = Mob.getMob(closerEnemyID)!;
 
-    //console.log(`fleeing eval ${npc.name} ${npc.personality.traits[PersonalityTraits.Bravery]} ${npc.attributes['health']} ${this.enemy.attributes['health']}`)
+    if (!this) {
+      //console.error(`${this} is no longer valid or does not exist in the database.`);
+      return 0;  // Exit early
+    }
+    if (!npc || !Mob.getMob(npc.id)) {
+      //console.error(`${npc.name} is no longer valid or does not exist in the database.`);
+      return 0;  // Exit early
+    }
     const utility =
       (100 - npc.personality.traits[PersonalityTraits.Bravery]) *
       (this.enemy.health / npc.health);

--- a/packages/server/src/mobs/plans/heal.ts
+++ b/packages/server/src/mobs/plans/heal.ts
@@ -19,6 +19,10 @@ export class Heal extends PlanMeans {
   }
 
   benefit(npc: Mob): number {
+    if (!npc || !Mob.getMob(npc.id)) {
+      //console.error(`${npc.name} is no longer valid or does not exist in the database.`);
+      return -Infinity;  // Exit early
+    }
     if (npc.health >= 100) {
       // If health is full, no need to heal
       return -Infinity;

--- a/packages/server/src/mobs/plans/hunt.ts
+++ b/packages/server/src/mobs/plans/hunt.ts
@@ -32,8 +32,15 @@ export class Hunt implements Plan {
       }
 
       // attack/fight each other
+      //console.log(`changing ${this.enemy!.name} health in hunt execute by ${npc.name}`)
       this.enemy!.changeHealth(adjustedEnemyDamage);
       npc.changeHealth(adjustedNpcDamage);
+
+      // Check if the NPC is still alive after taking damage
+      if (!npc || !Mob.getMob(npc.id)) {
+        console.error(`${npc.name} has died after taking damage.`);
+        return false;  // Exit early
+      }
 
       // get slowEnemy debuff count
       try {
@@ -52,7 +59,7 @@ export class Hunt implements Plan {
           this.enemy!.changeEffect(speedDelta, speedDuration, 'speed');
         }
       } catch {
-        console.log('Could not get slowEnemy in hunt');
+        console.log(`Could not get slowEnemy in hunt: ${npc.name}`);
       }
 
       return false;
@@ -80,6 +87,11 @@ export class Hunt implements Plan {
     if (!closerEnemyID) return -Infinity;
 
     this.enemy = Mob.getMob(closerEnemyID)!;
+
+    if (!this.enemy) {
+      console.error(`Enemy with ID ${closerEnemyID} does not exist anymore.`);
+      return -Infinity; // Exit early if no enemy found
+    }
 
     var utility =
       npc.personality.traits[PersonalityTraits.Aggression] *


### PR DESCRIPTION
## Description
Added checks to see if dead mob is no longer in the database within files potionEffects, mob, flee, heal, and hunt to avoid referencing undefined attributes.

## Problem
closes #586 

## Context
Had to be patched - reference #585 fix.

## Impact
No documentation required, will not affect developers.  

## Testing
No formal testing necessary, just ran the game and checked if the checks appeared in console log.

## Screenshots (if appropriate)
![image](https://github.com/user-attachments/assets/cef996bb-542a-41e5-8cf8-60eb3821529d)
![image](https://github.com/user-attachments/assets/70099e3d-6cb1-411a-b637-121b70255bf9)

