### PR TITLE
[BugFix] Filter Blobs from Chat Options

### DIFF
--- a/packages/client/src/world/controller.ts
+++ b/packages/client/src/world/controller.ts
@@ -144,7 +144,7 @@ export function areListsEqual(list1: Mob[], list2: Mob[]): boolean {
 
 export function mobRangeListener(mobs: Mob[]) {
   if (chatCompanionCallback && !chatting) {
-    const filteredMobs = mobs.filter((mob) => mob.type !== 'player');
+    const filteredMobs = mobs.filter((mob) => (mob.type !== 'player') && (mob.type !== 'blob'));
     filteredMobs.sort((a, b) => a.key.localeCompare(b.key));
     if (!areListsEqual(filteredMobs, lastChatCompanions)) {
       chatCompanionCallback(filteredMobs);

--- a/packages/client/src/world/controller.ts
+++ b/packages/client/src/world/controller.ts
@@ -144,7 +144,9 @@ export function areListsEqual(list1: Mob[], list2: Mob[]): boolean {
 
 export function mobRangeListener(mobs: Mob[]) {
   if (chatCompanionCallback && !chatting) {
-    const filteredMobs = mobs.filter((mob) => (mob.type !== 'player') && (mob.type !== 'blob'));
+    const filteredMobs = mobs.filter(
+      (mob) => mob.type !== 'player' && mob.type !== 'blob'
+    );
     filteredMobs.sort((a, b) => a.key.localeCompare(b.key));
     if (!areListsEqual(filteredMobs, lastChatCompanions)) {
       chatCompanionCallback(filteredMobs);

--- a/packages/client/test/scenes/uxSceneChat.test.ts
+++ b/packages/client/test/scenes/uxSceneChat.test.ts
@@ -140,6 +140,59 @@ describe('Chat UI updates based on chatting state', () => {
     expect(mockChatCallback).not.toHaveBeenCalled();
   });
 
+  test('should not trigger callback if the blob added', () => {
+    const player1 = new Mob(
+      world!,
+      'mob1',
+      'Player1',
+      'player',
+      100,
+      { x: 1, y: 1 },
+      {},
+      {},
+      {}
+    );
+    const npc = new Mob(
+      world!,
+      'mob2',
+      'NPC1',
+      'npc',
+      100,
+      { x: 2, y: 2 },
+      {},
+      {},
+      {}
+    );
+    const mobs = [player1, npc];
+
+    setChatting(false);
+
+    mobRangeListener(mobs);
+
+    const expectedFilteredMobs = [npc];
+    expect(mockChatCallback).toHaveBeenCalledWith(expectedFilteredMobs);
+
+    mockChatCallback.mockClear();
+
+    const blob = new Mob(
+      world!,
+      'mob3',
+      'BLOB1',
+      'blob',
+      100,
+      { x: 2, y: 2 },
+      {},
+      {},
+      {}
+    );
+
+    const new_mobs = [player1, npc, blob];
+
+    mobRangeListener(new_mobs);
+
+    expect(mockChatCallback).not.toHaveBeenCalled();
+  });
+
   test('should update chat companions when a second mob enters range', () => {
     const player1 = new Mob(
       world!,


### PR DESCRIPTION
## Description
Filters the blobs out of chat options.

## Problem
You should not be able to talk to the blobs, they exist solely for combat in the current implementation.

## Impact
This will remove blobs from chat options and have no external impacts

## Testing
- Unit Testing
- Manual Testing