### PR TITLE
Fix Player Not Found Bug When Updating Player State 

### DIFF
--- a/packages/server/src/services/clientCommunication/ablyService.ts
+++ b/packages/server/src/services/clientCommunication/ablyService.ts
@@ -88,7 +88,7 @@ export class AblyService implements PubSub {
       this.broadcastReloadPageTrigger();
     });
 
-    this.broadcastChannel.presence.subscribe('leave', (presenceMsg) => {
+    this.broadcastChannel.presence.subscribe('leave', async (presenceMsg) => {
       // if MAINTAIN_WORLD_OPTION is passed from client, do not change world;
       // undefined will be recieved if the client unexpectedly disconnects (ex: refreshing page)
       // we should also stay in the same world in this case
@@ -99,7 +99,7 @@ export class AblyService implements PubSub {
           : presenceMsg.data.target_world_id;
       logger.log('Target World Received:', presenceMsg.data.target_world_id);
       logger.log('Target World Being Sent:', target_world_id);
-      this.sendPersistenceRequest(
+      await this.sendPersistenceRequest(
         presenceMsg.clientId,
         this.userDict.get(presenceMsg.clientId),
         target_world_id
@@ -110,7 +110,6 @@ export class AblyService implements PubSub {
       );
 
       const player = Mob.getMob(presenceMsg.clientId);
-      // logger.log("player when leaving:", player);
       player?.removePlayer();
     });
 
@@ -592,10 +591,9 @@ export class AblyService implements PubSub {
     logger.log('Updating state info for', username);
     const player = Mob.getMob(username);
     if (!player) {
-      logger.error(
+      throw Error(
         `No player found, unable to persist player state: ${username}`
       );
-      return;
     }
     let health_for_update = player.health;
     let gold_for_update = player.gold;


### PR DESCRIPTION
## Description
When a player leaves the game (or loses focus), the server updates the player data in the DB and then removes the player from the world. The server awaits the update in order to ensure the order is correct.

## Problem
Previously these two actions had no guaranteed order, resulting in a race case where the player upload would crash the server since it was trying to upload information from a player that was not in the world. This is a more permanent solution to #597

## Context
This approach was chosen give the simplicity of it. This approach seemed obvious, so no others were considered.

## Impact
No impact on developers. Servers should stop crashing when the game loses focus.

## Testing
I manually lost focus 25 times, and the race case error did not hit. This, plus the logic of it, makes me think it has been solved for.
