### PR TITLE
Fix: breaking log based potion stands doesn't create a null potion

### DIFF
--- a/packages/server/src/items/uses/create.ts
+++ b/packages/server/src/items/uses/create.ts
@@ -6,17 +6,24 @@ import { Community } from '../../community/community';
 export class Create {
   static createItemFrom(createItem: Item, creator: Mob, type: string): boolean {
     const creatorCommunity = Community.getVillage(creator.community_id);
+    let typeAttribute = {
+      templateType: createItem.type,
+      items: 1,
+      capacity: 20
+    };
+
+    // There should be no potion count for no potions
+    if (createItem.type === 'log') {
+      typeAttribute.items = 0;
+    }
+
     itemGenerator.createItem({
       type: type,
       subtype: createItem.subtype,
       position: creator.position,
       ownedByCommunity: creatorCommunity,
       ownedByCharacter: creator.id,
-      attributes: {
-        templateType: createItem.type,
-        items: 1,
-        capacity: 20
-      }
+      attributes: typeAttribute
     });
 
     createItem.destroy();

--- a/packages/server/test/actions/create.test.ts
+++ b/packages/server/test/actions/create.test.ts
@@ -75,4 +75,24 @@ describe('Create', () => {
       capacity: 20
     });
   });
+
+  test('should not create item with log', () => {
+    const type = 'new-item-type';
+    const logType = {
+      type: 'log',
+      subtype: 'log',
+      destroy: jest.fn()
+    } as unknown as jest.Mocked<Item>;
+    Create.createItemFrom(logType, mockMob, type);
+
+    const createItemCall = (
+      itemGeneratorModule.itemGenerator.createItem as jest.Mock
+    ).mock.calls[0][0];
+
+    expect(createItemCall.attributes).toEqual({
+      templateType: logType.type,
+      items: 0,
+      capacity: 20
+    });
+  });
 });


### PR DESCRIPTION
## Description
Updated create.ts to properly create a potion stand from a log. 

## Problem
This prevents a null type potion from being created on smashing the potion stand. 

## Context
Modifying the creation of a market stand in create.ts seemed to be more general than modifying the behavior of smashable.ts to only check if the type is a log. 

## Impact
Minimal impact, only added an additional check to prevent a default item count to be 1. 
However, a new function to add potions to this empty market should be added in another pr. 

## Testing
Passed all automatic testing.
Add test, if potion still created when a log created market is smashed. 

