### PR TITLE
653 certain terraform errors arent being caught by custom error handling

### DIFF
--- a/tf.ps1
+++ b/tf.ps1
@@ -64,6 +64,9 @@ if ($exitCode -ne 0) {
     if ($output -match "The following organization members have reached their maximum limits") {
          Write-Host " You have more than 1 active Supabase project in your organization." -ForegroundColor Red
     }
+    elseif($output -match "Ably API token cannot be an empty string.") {
+         Write-Host "Make sure you have followed the README instructions to create your tf.tfvars file."
+    }
     elseif ($output -match "CRLF line endings detected") {
          Write-Host " The files listed above have CRLF line endings. Please change the line endings to LF." -ForegroundColor Red
     }
@@ -83,7 +86,7 @@ if ($exitCode -ne 0) {
          Write-Host "If you had to time out the run of apply, check to make sure your supabase db password is correct."
     }
     else {
-         Write-Host "We haven't handle this case yet: An unknown error occurred. Please review the output above. In most cases, this is due to out of sync terraform state. Please refer to the section of the README called SYNCING TERRAFORM STATE." -ForegroundColor Red
+         Write-Host "We haven't handle this case yet: An unknown error occurred. Check to make sure Docker Desktop is running, and if that doesn't work, please review the output above. In most cases, this is due to out of sync terraform state. Please refer to the section of the README called SYNCING TERRAFORM STATE." -ForegroundColor Red
     }
     Write-Host "========================================" -ForegroundColor Red
     exit $exitCode

--- a/tf.ps1
+++ b/tf.ps1
@@ -67,6 +67,12 @@ if ($exitCode -ne 0) {
     elseif($output -match "Ably API token cannot be an empty string.") {
          Write-Host "Make sure you have followed the README instructions to create your tf.tfvars file."
     }
+     elseif($output -match "Could not create resource, unexpected error") {
+          Write-Host "You need to delete any ably app that uses the same ably access token."
+     }
+     elseif($output -match "Unable to create project") {
+          Write-Host "You need to delete any supabase projects with the same name as the one you are creating."
+     }
     elseif ($output -match "CRLF line endings detected") {
          Write-Host " The files listed above have CRLF line endings. Please change the line endings to LF." -ForegroundColor Red
     }

--- a/tf.sh
+++ b/tf.sh
@@ -58,8 +58,10 @@ if [ $exitCode -ne 0 ]; then
          echo -e "\033[31mCheck to make sure you correctly copied your supabase organization id.\033[0m"
     elif echo "$output" | grep -q "Project status did not reach ACTIVE_HEALTHY within."; then
          echo -e "\033[31mIf you had to time out the run of apply, check to make sure your supabase db password is correct.\033[0m"
+    elif echo "$output" | grep -q "Ably API token cannot be an empty string."; then
+         echo -e "\033[31mMake sure you have followed the README instructions to create your tf.tfvars file.\033[0m"
     else
-         echo -e "\033[31mWe haven't handle this case yet: An unknown error occurred. Please review the output above. In most cases, this is due to out of sync terraform state. Please refer to the section of the README called SYNCING TERRAFORM STATE.\033[0m"
+         echo -e "\033[31mWe haven't handle this case yet: An unknown error occurred. Check to make sure Docker Desktop is running, and if that doesn't work, please review the output above. In most cases, this is due to out of sync terraform state. Please refer to the section of the README called SYNCING TERRAFORM STATE.\033[0m"
     fi
     exit $exitCode
 fi

--- a/tf.sh
+++ b/tf.sh
@@ -60,6 +60,10 @@ if [ $exitCode -ne 0 ]; then
          echo -e "\033[31mIf you had to time out the run of apply, check to make sure your supabase db password is correct.\033[0m"
     elif echo "$output" | grep -q "Ably API token cannot be an empty string."; then
          echo -e "\033[31mMake sure you have followed the README instructions to create your tf.tfvars file.\033[0m"
+     elif echo "$output" | grep -q "Unable to create project"; then
+         echo -e "\033[31mYou need to delete any supabase projects with the same name as the one you are creating.\033[0m"
+     elif echo "$output" | grep -q "Could not create resource, unexpected error"; then
+         echo -e "\033[31mYou need to delete any ably app that uses the same ably access token.\033[0m"
     else
          echo -e "\033[31mWe haven't handle this case yet: An unknown error occurred. Check to make sure Docker Desktop is running, and if that doesn't work, please review the output above. In most cases, this is due to out of sync terraform state. Please refer to the section of the README called SYNCING TERRAFORM STATE.\033[0m"
     fi


### PR DESCRIPTION
## Description
Added new custom error messages for various errors related to tf.ps1 and tf.sh scripts 

## Problem
This is important so that developers unfamiliar with the terraform workflow can get back to work faster instead of having to worry about debugging. 
"Closes #653 " 

## Context
No alternatives were considered as this method has worked for previously handled errors. 
Extra messages were added so there was no change to the design or tradeoffs of the current method of error handling. 

## Impact
This change does not break anything and does not require documentation because it essentially is documentation.
This change should make it easier for developers to get to the point of being able to work on the project faster.
Nobody needs to be notified.

## Testing
Changes were not tested beyond checking to see that the custom error message pops up when the error is intentionally created
This change does not need to be tested as nothing new was added and the system already worked. It was simply made to catch more errors.

