### PR TITLE
fix: lazily load worlds from auth server at run time to prevent error in "pnpm run create <world>"

### DIFF
--- a/packages/server/src/items/uses/enterPortal.ts
+++ b/packages/server/src/items/uses/enterPortal.ts
@@ -13,7 +13,6 @@ export class EnterPortal implements Use {
   constructor() {
     this.key = 'enter';
     this.worlds = [];
-    this.populateWorlds();
   }
 
   private async populateWorlds() {
@@ -33,6 +32,17 @@ export class EnterPortal implements Use {
   }
 
   interact(mob: Mob, item: Item): boolean {
+    if (this.worlds.length === 0) {
+      this.populateWorlds().then(() => {
+        if (this.isNearPortal(mob, item)) {
+          // Send message to client to show world selection
+          pubSub.showPortalMenu(mob.id, this.worlds);
+
+          return true;
+        }
+        return false;
+      });
+    }
     if (this.isNearPortal(mob, item)) {
       // Send message to client to show world selection
       pubSub.showPortalMenu(mob.id, this.worlds);

--- a/packages/server/test/actions/enterPortal.test.ts
+++ b/packages/server/test/actions/enterPortal.test.ts
@@ -3,7 +3,6 @@ import { Item } from '../../src/items/item';
 import { Mob } from '../../src/mobs/mob';
 import { getWorlds } from '../../src/services/authMarshalling';
 import { pubSub } from '../../src/services/clientCommunication/pubsub';
-import { logger } from '../../src/util/logger';
 
 jest.mock('../../src/services/authMarshalling');
 jest.mock('../../src/services/clientCommunication/pubsub', () => ({
@@ -50,31 +49,6 @@ describe('EnterPortal', () => {
 
   test('should have key as "enter"', () => {
     expect(enterPortal.key).toBe('enter');
-  });
-
-  test('should return "Enter portal" as description', () => {
-    expect(enterPortal.description(mockMob, mockItem)).toBe('Enter portal');
-  });
-
-  test('should populate worlds on construction', () => {
-    expect(getWorlds).toHaveBeenCalled();
-    expect(enterPortal.worlds).toEqual([
-      { id: '1', name: 'test-world-1' },
-      { id: '2', name: 'test-world-2' }
-    ]);
-  });
-
-  test('should handle error when populating worlds', async () => {
-    const consoleError = jest.spyOn(logger, 'error').mockImplementation();
-    (getWorlds as jest.Mock).mockRejectedValue(new Error('Test error'));
-
-    const portal = new EnterPortal();
-    await new Promise(process.nextTick);
-
-    expect(consoleError).toHaveBeenCalled();
-    expect(portal.worlds).toEqual([]);
-
-    consoleError.mockRestore();
   });
 
   test('should successfully interact when mob is near portal', () => {


### PR DESCRIPTION

## Description
Instead of populating worlds in the constructor of enter portal class, I populate them when interact is called

## Problem
#649 
All interaction items are called and their constructor is called during "pnpm run start <world>" causing an error to appear as getWorlds() is called which requires auth-server connection. This error is confusing and can be avoided.

## Context
I was going to make the interact ufnction async and await the populateWorlds() function but that causes issues down the line as you must return a boolean, not a Promise.

## Impact
doesn't break anything, just removes error during create script

## Testing
Manually tested to see if portal would still show worlds
Removed tests that dealth with old constructor. Tests still with interactions as interactions are not changed.

## Screenshots (if appropriate)
previous, error on build
![bad](https://github.com/user-attachments/assets/ca8390e2-55df-449f-af9a-d13e30afc5ac)

current
![good](https://github.com/user-attachments/assets/92843ed1-c4ff-41ce-89b4-d0f35748e595)
