### PR TITLE
Fix #636: Individual based ownership interactions not applied to client side via global.jsons

### DIFF
--- a/packages/client/static/global.json
+++ b/packages/client/static/global.json
@@ -1063,9 +1063,10 @@
                 {
                     "description": "Add $item_name",
                     "action": "add_item",
-                    "while_carried": false,
+                    "while_carried": true,
                     "permissions": {
-                        "community": true,
+                        "community": false,
+                        "character": true,
                         "other": false
                     }
                 },
@@ -1081,7 +1082,8 @@
                         }
                     ],
                     "permissions": {
-                        "community": true,
+                        "community": false,
+                        "character": true,
                         "other": false
                     }
                 },
@@ -1097,7 +1099,8 @@
                         }
                     ],
                     "permissions": {
-                        "community": true,
+                        "community": false,
+                        "character": true,
                         "other": false
                     }
                 },
@@ -1113,7 +1116,8 @@
                         }
                     ],
                     "permissions": {
-                        "community": true,
+                        "community": false,
+                        "character": true,
                         "other": false
                     }
                 },
@@ -1129,7 +1133,8 @@
                         }
                     ],
                     "permissions": {
-                        "community": true,
+                        "community": false,
+                        "character": true,
                         "other": false
                     }
                 },
@@ -1143,7 +1148,12 @@
                             "value": 0,
                             "comparison": "greater_than"
                         }
-                    ]
+                    ],
+                    "permissions": {
+                        "community": false,
+                        "character": false,
+                        "other": true
+                    }
                 },
                 {
                     "description": "Destroy stand",

--- a/packages/json-generator/global.json
+++ b/packages/json-generator/global.json
@@ -1070,7 +1070,8 @@
           "action": "add_item",
           "while_carried": false,
           "permissions": {
-            "community": true,
+            "community": false,
+            "character": true,
             "other": false
           }
         },
@@ -1086,7 +1087,8 @@
             }
           ],
           "permissions": {
-            "community": true,
+            "community": false,
+            "character": true,
             "other": false
           }
         },
@@ -1102,7 +1104,8 @@
             }
           ],
           "permissions": {
-            "community": true,
+            "community": false,
+            "character": true,
             "other": false
           }
         },
@@ -1118,7 +1121,8 @@
             }
           ],
           "permissions": {
-            "community": true,
+            "community": false,
+            "character": true,
             "other": false
           }
         },
@@ -1134,7 +1138,8 @@
             }
           ],
           "permissions": {
-            "community": true,
+            "community": false,
+            "character": true,
             "other": false
           }
         },
@@ -1148,7 +1153,12 @@
               "value": 0,
               "comparison": "greater_than"
             }
-          ]
+          ],
+          "permissions": {
+            "community": false,
+            "character": false,
+            "other": true
+          }
         },
         {
           "description": "Destroy stand",

--- a/packages/json-generator/src/schema.ts
+++ b/packages/json-generator/src/schema.ts
@@ -35,8 +35,9 @@ const interactionTypeSchema = z.object({
   action: z.string(),
   permissions: z
     .object({
-      community: z.boolean(),
-      other: z.boolean()
+      community: z.boolean().optional(),
+      character: z.boolean().optional(),
+      other: z.boolean().optional()
     })
     .optional(),
   while_carried: z.boolean(),

--- a/packages/json-generator/test/expectedClient.json
+++ b/packages/json-generator/test/expectedClient.json
@@ -1065,7 +1065,8 @@
           "action": "add_item",
           "while_carried": false,
           "permissions": {
-            "community": true,
+            "community": false,
+            "character": true,
             "other": false
           }
         },
@@ -1081,7 +1082,8 @@
             }
           ],
           "permissions": {
-            "community": true,
+            "community": false,
+            "character": true,
             "other": false
           }
         },
@@ -1097,7 +1099,8 @@
             }
           ],
           "permissions": {
-            "community": true,
+            "community": false,
+            "character": true,
             "other": false
           }
         },
@@ -1113,7 +1116,8 @@
             }
           ],
           "permissions": {
-            "community": true,
+            "community": false,
+            "character": true,
             "other": false
           }
         },
@@ -1129,7 +1133,8 @@
             }
           ],
           "permissions": {
-            "community": true,
+            "community": false,
+            "character": true,
             "other": false
           }
         },
@@ -1143,7 +1148,12 @@
               "value": 0,
               "comparison": "greater_than"
             }
-          ]
+          ],
+          "permissions": {
+            "community": false,
+            "character": false,
+            "other": true
+          }
         },
         {
           "description": "Destroy stand",

--- a/packages/json-generator/test/expectedServer.json
+++ b/packages/json-generator/test/expectedServer.json
@@ -1059,7 +1059,8 @@
           "action": "add_item",
           "while_carried": false,
           "permissions": {
-            "community": true,
+            "community": false,
+            "character": true,
             "other": false
           }
         },
@@ -1075,7 +1076,8 @@
             }
           ],
           "permissions": {
-            "community": true,
+            "community": false,
+            "character": true,
             "other": false
           }
         },
@@ -1091,7 +1093,8 @@
             }
           ],
           "permissions": {
-            "community": true,
+            "community": false,
+            "character": true,
             "other": false
           }
         },
@@ -1107,7 +1110,8 @@
             }
           ],
           "permissions": {
-            "community": true,
+            "community": false,
+            "character": true,
             "other": false
           }
         },
@@ -1123,7 +1127,8 @@
             }
           ],
           "permissions": {
-            "community": true,
+            "community": false,
+            "character": true,
             "other": false
           }
         },
@@ -1137,7 +1142,12 @@
               "value": 0,
               "comparison": "greater_than"
             }
-          ]
+          ],
+          "permissions": {
+            "community": false,
+            "character": false,
+            "other": true
+          }
         },
         {
           "description": "Destroy stand",

--- a/packages/server/global.json
+++ b/packages/server/global.json
@@ -1035,7 +1035,8 @@
                 "action": "add_item",
                 "while_carried": false,
                 "permissions": {
-                  "community": true,
+                  "community": false,
+                  "character": true,
                   "other": false
                 }
               },
@@ -1051,7 +1052,8 @@
                   }
                 ],
                 "permissions": {
-                  "community": true,
+                  "community": false,
+                  "character": true,
                   "other": false
                 }
               },
@@ -1067,7 +1069,8 @@
                   }
                 ],
                 "permissions": {
-                  "community": true,
+                  "community": false,
+                  "character": true,
                   "other": false
                 }
               },
@@ -1083,7 +1086,8 @@
                   }
                 ],
                 "permissions": {
-                  "community": true,
+                  "community": false,
+                  "character": true,
                   "other": false
                 }
               },
@@ -1099,7 +1103,8 @@
                   }
                 ],
                 "permissions": {
-                  "community": true,
+                  "community": false,
+                  "character": true,
                   "other": false
                 }
               },
@@ -1113,7 +1118,12 @@
                     "value": 0,
                     "comparison": "greater_than"
                   }
-                ]
+                ],
+                "permissions": {
+                  "community": false,
+                  "character": false,
+                  "other": true
+                }
               },
               {
                 "description": "Destroy stand",

--- a/world_assets/global.json
+++ b/world_assets/global.json
@@ -1032,7 +1032,8 @@
                 "action": "add_item",
                 "while_carried": false,
                 "permissions": {
-                  "community": true,
+                  "community": false,
+                  "character": true,
                   "other": false
                 }
               },
@@ -1048,7 +1049,8 @@
                   }
                 ],
                 "permissions": {
-                  "community": true,
+                  "community": false,
+                  "character": true,
                   "other": false
                 }
               },
@@ -1064,7 +1066,8 @@
                   }
                 ],
                 "permissions": {
-                  "community": true,
+                  "community": false,
+                  "character": true,
                   "other": false
                 }
               },
@@ -1080,7 +1083,8 @@
                   }
                 ],
                 "permissions": {
-                  "community": true,
+                  "community": false,
+                  "character": true,
                   "other": false
                 }
               },
@@ -1096,7 +1100,8 @@
                   }
                 ],
                 "permissions": {
-                  "community": true,
+                  "community": false,
+                  "character": true,
                   "other": false
                 }
               },
@@ -1110,7 +1115,12 @@
                     "value": 0,
                     "comparison": "greater_than"
                   }
-                ]
+                ],
+                "permissions": {
+                  "community": false,
+                  "character": false,
+                  "other": true
+                }
               },
               {
                 "description": "Destroy stand",


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
These changes restores the functionality that was overwritten and fixes the individual-based ownership interactions that were not applied to the client side through JSON configuration files. 

Changing these files, the client side can now:
* carry items that are owned by player
* have individual permissions instead of community
* more flexible and dynamic configurations with `community`, `character`, and `other`

## Problem
<!--- Why is this change required? What problem does it solve? -->
<!--- You can just link to the issue if applicable with "Closes #XYZ" -->
These changes are required to make the server and client permissions consistent with each other, and allowing players to have more access and actions in the game. 

## Context
<!--- What alternatives were considered, and why was this approach chosen? -->
<!--- Mention any design decisions or trade-offs. -->
Alternative approaches like creating new permission types were considered, but the current method was chosen to avoid unnecessary complexity while being flexible and simple. By using optional()  for the fields, the system can now accept configurations where certain permissions can be omitted without breaking functionality.

## Impact
<!--- Does this change break anything or require documentation updates? -->
<!--- How will this change affect other developers? Can that burden be minimized? --> 
<!--- Should they be notified (e.g., via Slack)? -->
* This change does not break existing functionality. 
* Developers will need to be aware of the new permission structure and the optional nature of some fields in the schema.
* This change should not require any major documentation updates but may require some clarification for developers working on permissions or item interactions.

## Testing
<!--- Describe how you tested the changes -->
<!--- Mention automated tests, manual testing, or reasons for not testing -->
We manually tested this on the client side by checking the behavior of potions with the modified permissions to see if the system behaves as expected.