### PR TITLE
fix: add broadcast to delete gold item

### DIFF
--- a/packages/server/src/items/item.ts
+++ b/packages/server/src/items/item.ts
@@ -422,6 +422,9 @@ export class Item {
     giveTo: Mob | undefined = undefined
   ): void {
     const use = UsesRegistry.instance.getUse(action);
+    if (action === 'pickup' && this.itemType.type === 'gold') {
+      pubSub.destroy(this);
+    }
     use.interact(mob, this, giveTo);
   }
 

--- a/packages/server/src/items/uses/pickup.ts
+++ b/packages/server/src/items/uses/pickup.ts
@@ -2,6 +2,7 @@ import { Mob } from '../../mobs/mob';
 import { Carryable } from '../carryable';
 import { Item } from '../item';
 import { Use } from './use';
+import { pubSub } from '../../services/clientCommunication/pubsub';
 
 export class Pickup implements Use {
   key: string;
@@ -21,6 +22,7 @@ export class Pickup implements Use {
     if (item.type === 'gold') {
       mob.changeGold(item.getAttribute('amount'));
       item.destroy();
+      pubSub.destroy(item);
 
       return true;
     }

--- a/packages/server/src/items/uses/pickup.ts
+++ b/packages/server/src/items/uses/pickup.ts
@@ -2,7 +2,6 @@ import { Mob } from '../../mobs/mob';
 import { Carryable } from '../carryable';
 import { Item } from '../item';
 import { Use } from './use';
-import { pubSub } from '../../services/clientCommunication/pubsub';
 
 export class Pickup implements Use {
   key: string;
@@ -22,7 +21,6 @@ export class Pickup implements Use {
     if (item.type === 'gold') {
       mob.changeGold(item.getAttribute('amount'));
       item.destroy();
-      pubSub.destroy(item);
 
       return true;
     }


### PR DESCRIPTION
## Description
Update item.ts to add a message to the pubsub when a gold item is deleted for marshaling. 

## Problem
This prevents phantom gold that appears on the client side from accumulating for the most part. They still appear it seems to be from another bug, but this fixes the server side of things.

## Context
Considered implementing client side approach to deleting gold on npc collision and player pickup, but put on hold for sake of time.

## Impact
Minimal impact to the code base as it only adds one line to broadcast the destruction of gold items to the pub sub whenever gold is picked up and another to check for the action. 

## Testing
Only manually testing to view if gold was marshaled. The pubsub functions are already tested and since this change only requires an additional call to broadcast a destroy for gold items we felt it was unnecessary. 
