### PR TITLE
Fix inventory dropping

### DIFF
--- a/packages/client/src/world/item.ts
+++ b/packages/client/src/world/item.ts
@@ -121,10 +121,12 @@ export class Item extends Physical {
     if (!mob.position) {
       throw new Error('Mob has no position');
     }
-    this.carried_by = undefined;
-    this.position = position;
-    world.addItemToGrid(this);
     world.removeStoredItem(this); // Remove from stored items
+    if (mob.carrying) {
+      world.items[mob.carrying].stash(world, mob, position);
+    }
+    mob.carrying = this.key;
+    this.carried_by = mob.key;
   }
 
   tick(world: World, deltaTime: number) {

--- a/packages/client/test/items/inventoryUnstash.test.ts
+++ b/packages/client/test/items/inventoryUnstash.test.ts
@@ -1,0 +1,97 @@
+import { Item } from '../../src/world/item';
+import { Mob } from '../../src/world/mob';
+import { World } from '../../src/world/world';
+import { ItemType } from '../../src/worldDescription';
+
+describe('"Unstash" action item interaction tests', () => {
+  let world: World;
+  let log_item: Item;
+  let heartbeet_item: Item;
+  let nearby_mob: Mob;
+
+  beforeAll(() => {
+    world = new World();
+    world.load({
+      tiles: [
+        [-1, -1],
+        [-1, -1]
+      ],
+      terrain_types: [{ id: 0, name: 'Grass', walkable: true }],
+      item_types: [],
+      mob_types: []
+    });
+
+    const log_type: ItemType = {
+      name: 'Log',
+      type: 'log',
+      carryable: true,
+      smashable: true,
+      walkable: false,
+      interactions: [],
+      attributes: []
+    };
+    log_item = new Item(world!, 'log', { x: 1, y: 1 }, log_type);
+    world.items['log'] = log_item;
+
+    const heartbeet_type: ItemType = {
+      name: 'Heartbeet',
+      type: 'heartbeet',
+      carryable: true,
+      smashable: true,
+      walkable: false,
+      interactions: [],
+      attributes: []
+    };
+
+    heartbeet_item = new Item(
+      world!,
+      'heartbeet',
+      { x: 1, y: 2 },
+      heartbeet_type
+    );
+    world.items['heartbeet'] = heartbeet_item;
+
+    nearby_mob = new Mob(
+      world!,
+      'mob2',
+      'Player2',
+      'player',
+      100,
+      { x: 1, y: 1 },
+      {},
+      {},
+      {}
+    );
+  });
+
+  test('Unstash item when not carrying an item', () => {
+    log_item.pickup(world, nearby_mob);
+    expect(!nearby_mob.carrying).toBe(false);
+
+    log_item.stash(world, nearby_mob, { x: 1, y: 1 });
+    expect(world.getStoredItems().length == 1).toBe(true);
+    expect(!nearby_mob.carrying).toBe(true);
+
+    log_item.unstash(world, nearby_mob, { x: 1, y: 1 });
+    expect(world.getStoredItems().length == 0).toBe(true);
+    expect(!nearby_mob.carrying).toBe(false);
+  });
+
+  test('Unstash item when carrying an item', () => {
+    log_item.pickup(world, nearby_mob);
+    expect(!nearby_mob.carrying).toBe(false);
+
+    log_item.stash(world, nearby_mob, { x: 1, y: 1 });
+    expect(world.getStoredItems().length == 1).toBe(true);
+    expect(!nearby_mob.carrying).toBe(true);
+
+    heartbeet_item.pickup(world, nearby_mob);
+    expect(!nearby_mob.carrying).toBe(false);
+
+    log_item.unstash(world, nearby_mob, { x: 1, y: 1 });
+    expect(world.getStoredItems().length == 1).toBe(true);
+    expect(!nearby_mob.carrying).toBe(false);
+  });
+
+  afterAll(() => {});
+});

--- a/packages/server/test/items/stashAndUnstash.test.ts
+++ b/packages/server/test/items/stashAndUnstash.test.ts
@@ -67,10 +67,9 @@ describe('Stash and Unstash Item', () => {
     const stashResult = carryablePotion!.stash(testMob!);
     expect(stashResult).toBe(true);
     expect(testMob!.carrying).toBeUndefined();
-    carryablePotion!.unstash(testMob!);
+    const unstashResult = carryablePotion!.unstash(testMob!);
+    expect(unstashResult).toBe(true);
+    expect(testMob!.carrying).toBeDefined();
     expect(carryablePotion).toBeDefined();
-    expect(potion!.position).toBeDefined();
-    expect(typeof potion!.position!.x).toBe('number');
-    expect(typeof potion!.position!.y).toBe('number');
   });
 });


### PR DESCRIPTION
## Description
I fixed the logic in the 'unstash' function in both the server and client so that when you unstash an item from your inventory, it does not drop it on the floor but instead moves that item to your hand (carrying). If you are currently carrying an item, and you want to unstash another item from your inventory, the function first stashes the item you are carrying then moves the other item from your inventory to your hand.

## Problem
According to the PM's, the previous logic of unstash dropping items on the floor was incorrect and needed to change.

## Context
I did not really consider many other alternatives; this problem seemed cut and dry. Instead of dropping the item, it needed to be added to the mob's hand, so that needed to be reflected in the image on the client side and the database on the server side.

## Impact
This change does not break anything else and is highly decoupled from any other code logic other than the broadcasting of the unstash message, but nothing in that message sending structure has changed.  

## Testing
I tested both manually and automatically. In both cases I went through workflows of picking up an item, stashing it, unstashing it, and seeing the user carry it once again.
