### PR TITLE
bug: fixed incorrect items spawning in water world

### DIFF
--- a/packages/client/world_assets/global.json
+++ b/packages/client/world_assets/global.json
@@ -584,26 +584,6 @@
             "radius": 3,
             "rate": 0.1
           }
-        },
-        {
-          "action": "spawn_item",
-          "parameters": {
-            "type": "sun-drop",
-            "global_max": 10,
-            "local_max": 2,
-            "radius": 4,
-            "rate": 0.1
-          }
-        },
-        {
-          "action": "spawn_item",
-          "parameters": {
-            "type": "sunflower",
-            "global_max": 10,
-            "local_max": 2,
-            "radius": 4,
-            "rate": 0.1
-          }
         }
       ]
     },

--- a/packages/json-generator/global.json
+++ b/packages/json-generator/global.json
@@ -588,26 +588,6 @@
             "radius": 3,
             "rate": 0.1
           }
-        },
-        {
-          "action": "spawn_item",
-          "parameters": {
-            "type": "sun-drop",
-            "global_max": 10,
-            "local_max": 2,
-            "radius": 4,
-            "rate": 0.1
-          }
-        },
-        {
-          "action": "spawn_item",
-          "parameters": {
-            "type": "sunflower",
-            "global_max": 10,
-            "local_max": 2,
-            "radius": 4,
-            "rate": 0.1
-          }
         }
       ]
     },

--- a/packages/json-generator/test/expectedClient.json
+++ b/packages/json-generator/test/expectedClient.json
@@ -584,26 +584,6 @@
             "radius": 3,
             "rate": 0.1
           }
-        },
-        {
-          "action": "spawn_item",
-          "parameters": {
-            "type": "sun-drop",
-            "global_max": 10,
-            "local_max": 2,
-            "radius": 4,
-            "rate": 0.1
-          }
-        },
-        {
-          "action": "spawn_item",
-          "parameters": {
-            "type": "sunflower",
-            "global_max": 10,
-            "local_max": 2,
-            "radius": 4,
-            "rate": 0.1
-          }
         }
       ]
     },

--- a/packages/json-generator/test/expectedServer.json
+++ b/packages/json-generator/test/expectedServer.json
@@ -578,26 +578,6 @@
             "radius": 3,
             "rate": 0.1
           }
-        },
-        {
-          "action": "spawn_item",
-          "parameters": {
-            "type": "sun-drop",
-            "global_max": 10,
-            "local_max": 2,
-            "radius": 4,
-            "rate": 0.1
-          }
-        },
-        {
-          "action": "spawn_item",
-          "parameters": {
-            "type": "sunflower",
-            "global_max": 10,
-            "local_max": 2,
-            "radius": 4,
-            "rate": 0.1
-          }
         }
       ]
     },

--- a/packages/server/world_assets/global.json
+++ b/packages/server/world_assets/global.json
@@ -577,26 +577,6 @@
             "radius": 3,
             "rate": 0.1
           }
-        },
-        {
-          "action": "spawn_item",
-          "parameters": {
-            "type": "sun-drop",
-            "global_max": 10,
-            "local_max": 2,
-            "radius": 4,
-            "rate": 0.1
-          }
-        },
-        {
-          "action": "spawn_item",
-          "parameters": {
-            "type": "sunflower",
-            "global_max": 10,
-            "local_max": 2,
-            "radius": 4,
-            "rate": 0.1
-          }
         }
       ]
     },


### PR DESCRIPTION
## Description
Removes villager-world exclusive items from spawning in water world

## Problem
Closes issue #596

## Context
n/a

## Impact
- Confirmed this was a bug with the product team
- Had to fix hardcoded json test files to ensure json generator worked correctly - confirmed this with team that wrote the test


## Testing
Walked around all locations with seaweed in water-world and confirmed these times were not spawning

## Screenshots (if appropriate)
![image](https://github.com/user-attachments/assets/2916e505-5752-4121-912e-3c6bce2dd68b)
no more sunflowers or sun-drops