### PR TITLE
676 bug placing potion stands in front of gate ruins npc pathing

### DIFF
--- a/packages/server/src/items/uses/marketstand/createMarket.ts
+++ b/packages/server/src/items/uses/marketstand/createMarket.ts
@@ -17,6 +17,11 @@ export class CreateMarket implements Use {
   }
 
   interact(mob: Mob, item: Item): boolean {
+    // Find if Fence Gates Are Near Mob In Radius of 1, If Yes Stop Player From Placing Fence To Prevent Pathing Errors
+    if (Item.countTypeOfItemInRadius('gate', mob.position, 1) > 0) {
+      return false;
+    }
+
     return Create.createItemFrom(item, mob, this.type);
   }
 }

--- a/packages/server/test/items/marketstand/createMarket.test.ts
+++ b/packages/server/test/items/marketstand/createMarket.test.ts
@@ -9,6 +9,12 @@ jest.mock('../../../src/items/uses/create', () => ({
   }
 }));
 
+jest.mock('../../../src/items/item', () => ({
+  Item: {
+    countTypeOfItemInRadius: jest.fn()
+  }
+}));
+
 describe('CreateMarket', () => {
   let createMarket: CreateMarket;
   let mockMob: jest.Mocked<Mob>;
@@ -59,5 +65,25 @@ describe('CreateMarket', () => {
       mockMob,
       'market-stand'
     );
+  });
+
+  test('should not create market if a gate is within the radius of the mob', () => {
+    // return 1, indicating a gate is nearby
+    (Item.countTypeOfItemInRadius as jest.Mock).mockReturnValue(1);
+
+    const result = createMarket.interact(mockMob, mockItem);
+
+    // The market should not be created, result being false
+    expect(result).toBe(false);
+
+    // Ensure method was called with the correct arguments
+    expect(Item.countTypeOfItemInRadius).toHaveBeenCalledWith(
+      'gate',
+      mockMob.position,
+      1
+    );
+
+    // Ensure that createItemFrom was not called since the gate is nearby
+    expect(Create.createItemFrom).not.toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
## Description
Upon placing a Marketstand in front of a gate, this messes with the NPC pathing behavior and completely breaks any gathering behavior by NPCs.

## Problem
This change is required as players could place Marketstands in front of gates and completely destroy any NPC gathering that would occur. 

## Context
This solution presents the simplest option to solving this problem. There is no reason to abstract this issue to other items as other placed items are walkable (meaning they can be walked through).

## Impact
This change is self isolated and was appropriately tested in a unit test.

## Testing
This functionality is tested within createMartket.test.ts with a mock test automatically.
