### PR TITLE
Fix Black Potion - Can Spawn Multiple Monsters

### DIFF
--- a/packages/server/src/mobs/mob.ts
+++ b/packages/server/src/mobs/mob.ts
@@ -18,6 +18,7 @@ import { gameWorld } from '../services/gameWorld/gameWorld';
 import { selectAction } from './plans/actionRunner';
 import { Favorability } from '../favorability/favorability';
 import { mobFactory } from './mobFactory';
+import { MonstrousNames } from './names/monstrousNames';
 import { logger } from '../util/logger';
 
 export type MobData = {
@@ -578,10 +579,12 @@ export class Mob {
 
     // randomize monster position based off of player position
     const monsterPosition = playerPosition;
+    const monsterNameGenerator = new MonstrousNames();
+    const monsterName = 'Monster ' + monsterNameGenerator.generateName();
 
     // spawn a monster (blob)
-    mobFactory.makeMob('blob', monsterPosition, 'Monster', 'Monster');
-    const monster = Mob.getMob('Monster');
+    mobFactory.makeMob('blob', monsterPosition, monsterName, monsterName);
+    const monster = Mob.getMob(monsterName);
 
     // make the blob fight everyone (set satiation super low, hunt)
     DB.prepare(

--- a/packages/server/src/mobs/mob.ts
+++ b/packages/server/src/mobs/mob.ts
@@ -20,6 +20,7 @@ import { Favorability } from '../favorability/favorability';
 import { mobFactory } from './mobFactory';
 import { MonstrousNames } from './names/monstrousNames';
 import { logger } from '../util/logger';
+import { v4 as uuidv4 } from 'uuid';
 
 export type MobData = {
   personalities: Personality;
@@ -582,9 +583,10 @@ export class Mob {
     const monsterNameGenerator = new MonstrousNames();
     const monsterName = 'Monster ' + monsterNameGenerator.generateName();
 
+    const monsterId = uuidv4();
     // spawn a monster (blob)
-    mobFactory.makeMob('blob', monsterPosition, monsterName, monsterName);
-    const monster = Mob.getMob(monsterName);
+    mobFactory.makeMob('blob', monsterPosition, monsterId, monsterName);
+    const monster = Mob.getMob(monsterId);
 
     // make the blob fight everyone (set satiation super low, hunt)
     DB.prepare(

--- a/packages/server/test/potions/potionEffects/blackPotion.test.ts
+++ b/packages/server/test/potions/potionEffects/blackPotion.test.ts
@@ -79,6 +79,84 @@ describe('Try to consume black potion in various cases', () => {
   });
 });
 
+describe('Try to consume black potion in various cases', () => {
+  test('Spawn multiple monsters', () => {
+    FantasyDate.initialDate();
+
+    const playerPosition: Coord = { x: 0, y: 0 };
+    const potionLocation: Coord = { x: 1, y: 0 };
+
+    // create a fight initiator (blob -> hunt)
+    mobFactory.makeMob('player', playerPosition, 'TestingID', 'MonsterSpawner');
+    const testMob = Mob.getMob('TestingID');
+    expect(testMob).not.toBeNull();
+
+    // create a potion
+    itemGenerator.createItem({
+      type: 'potion',
+      subtype: String(hexStringToNumber('#166060')),
+      position: potionLocation,
+      carriedBy: testMob
+    });
+    const potion = Item.getItemIDAt(potionLocation);
+    expect(potion).not.toBeNull();
+    const potionItem = Item.getItem(potion!);
+    expect(potionItem).not.toBeNull();
+
+    // ensure the initiator is carrying the potion
+    expect(testMob!.carrying).not.toBeNull();
+    expect(testMob!.carrying!.type).toBe('potion');
+    expect(testMob!.carrying!.subtype).toBe(
+      String(hexStringToNumber('#166060'))
+    );
+
+    // have the attacker drink the potion
+    const testDrink = new Drink();
+    const test = testDrink.interact(testMob!, potionItem!);
+    expect(test).toBe(true);
+
+    // check to make sure potion is not being carried
+    expect(testMob!.carrying).toBeUndefined();
+
+    // create a second potion
+    itemGenerator.createItem({
+      type: 'potion',
+      subtype: String(hexStringToNumber('#166060')),
+      position: potionLocation,
+      carriedBy: testMob
+    });
+    const potion2 = Item.getItemIDAt(potionLocation);
+    expect(potion2).not.toBeNull();
+    const potionItem2 = Item.getItem(potion2!);
+    expect(potionItem2).not.toBeNull();
+
+    // ensure the initiator is carrying the potion
+    expect(testMob!.carrying).not.toBeNull();
+    expect(testMob!.carrying!.type).toBe('potion');
+    expect(testMob!.carrying!.subtype).toBe(
+      String(hexStringToNumber('#166060'))
+    );
+
+    // have the attacker drink the potion
+    const testDrink2 = new Drink();
+    const test2 = testDrink2.interact(testMob!, potionItem2!);
+    expect(test2).toBe(true);
+
+    // check to make sure potion is not being carried
+    expect(testMob!.carrying).toBeUndefined();
+
+    // get monster data
+    const monsters = DB.prepare(
+      `
+            SELECT id, name, COUNT(*) as number FROM mobs WHERE name LIKE 'Monster %'
+        `
+    ).get() as { id: string; name: string; number: number };
+
+    // check that there are 2 monster rows in mobs
+    expect(monsters.number).toBe(2);
+  });
+});
+
 describe('Try to consume an unknown potion that is similar to black potion in various cases', () => {
   test('test weak black potion effect', () => {
     FantasyDate.initialDate();

--- a/packages/server/test/potions/potionEffects/blackPotion.test.ts
+++ b/packages/server/test/potions/potionEffects/blackPotion.test.ts
@@ -55,8 +55,15 @@ describe('Try to consume black potion in various cases', () => {
     // check to make sure potion is not being carried
     expect(testMob!.carrying).toBeUndefined();
 
+    // get monster name
+    const unique_monster = DB.prepare(
+      `
+              SELECT id, name FROM mobs WHERE name LIKE 'Monster %'
+          `
+    ).get() as { id: string; name: string };
+
     // check that monster exists
-    const monster = Mob.getMob('Monster');
+    const monster = Mob.getMob(unique_monster.id);
     expect(monster).not.toBeNull();
 
     //wait to make the monster time out
@@ -67,7 +74,7 @@ describe('Try to consume black potion in various cases', () => {
     monster?.tick(500);
 
     // check to make sure monster is dead
-    const deadMonster = Mob.getMob('Monster');
+    const deadMonster = Mob.getMob(unique_monster.id);
     expect(deadMonster?.action).toBe('destroyed');
   });
 });
@@ -111,8 +118,15 @@ describe('Try to consume an unknown potion that is similar to black potion in va
     // check to make sure potion is not being carried
     expect(testMob!.carrying).toBeUndefined();
 
+    // get monster name
+    const unique_monster = DB.prepare(
+      `
+              SELECT id, name FROM mobs WHERE name LIKE 'Monster %'
+          `
+    ).get() as { id: string; name: string };
+
     // check that monster exists
-    const monster = Mob.getMob('Monster');
+    const monster = Mob.getMob(unique_monster.id);
     expect(monster).not.toBeNull();
 
     // wait to make the monster time out
@@ -123,7 +137,7 @@ describe('Try to consume an unknown potion that is similar to black potion in va
     monster?.tick(500);
 
     // check to make sure monster is dead
-    const deadMonster = Mob.getMob('Monster');
+    const deadMonster = Mob.getMob(unique_monster.id);
     expect(deadMonster?.action).toBe('destroyed');
   });
 });


### PR DESCRIPTION
## Description
When spawning a monster, ID is hardcoded so we can only create one monster at a time.  Randomize names/ID of monster spawned by black potion to be able to create multiple. 

## Problem
Closes #621 

## Context
We still want to differentiate monsters from regular blobs, so the name should include 'Monster'. We also want to differentiate from other monsters. It's easiest to just spawn the monster with an randomized ID/name which will allow you to insert multiple monsters into mobs.

## Impact
<!--- Does this change break anything or require documentation updates? -->
<!--- How will this change affect other developers? Can that burden be minimized? --> 
<!--- Should they be notified (e.g., via Slack)? -->
Not much impact in terms of notification/shouldn't affect anyone else that much.

## Testing
<!--- Describe how you tested the changes -->
<!--- Mention automated tests, manual testing, or reasons for not testing -->
Changed automated tests to grab monster by name similarity ('Monster %') and made sure tests still pass. Added test for multiple monsters.
