### PR TITLE
Stash Button Shouldn't Populate with Full Inventory

### DIFF
--- a/packages/client/src/services/serverToBroadcast.ts
+++ b/packages/client/src/services/serverToBroadcast.ts
@@ -93,7 +93,6 @@ export function setupBroadcast(
     const item = world.items[data.item_key];
     const mob = world.mobs[data.mob_key];
     item.stash(world, mob, data.position);
-    world.addStoredItem(item);
     updateInventory();
   }
 

--- a/packages/client/src/world/controller.ts
+++ b/packages/client/src/world/controller.ts
@@ -26,6 +26,8 @@ export type Interactions = {
   give_to?: string;
 };
 
+const MAX_STASH: number = 12;
+
 let interactionCallback: (interactions: Interactions[]) => void;
 let chatCompanionCallback: (companions: Mob[]) => void;
 let fightOpponentCallback: (opponents: Mob[]) => void;
@@ -197,11 +199,13 @@ export function getCarriedItemInteractions(
     label: `Drop ${item.itemType.name}`
   });
 
-  interactions.push({
-    action: 'stash',
-    item: item as Item,
-    label: `Stash ${item.itemType.name}`
-  });
+  if (world.getStoredItems().length < MAX_STASH) {
+    interactions.push({
+      action: 'stash',
+      item: item as Item,
+      label: `Stash ${item.itemType.name}`
+    });
+  }
 
   // give to nearby mobs
   nearbyMobs.forEach((mob) => {

--- a/packages/client/src/world/controller.ts
+++ b/packages/client/src/world/controller.ts
@@ -199,7 +199,7 @@ export function getCarriedItemInteractions(
     label: `Drop ${item.itemType.name}`
   });
 
-  if (world.getStoredItems().length < MAX_STASH) {
+  if (world?.getStoredItems().length < MAX_STASH) {
     interactions.push({
       action: 'stash',
       item: item as Item,

--- a/packages/client/src/world/item.ts
+++ b/packages/client/src/world/item.ts
@@ -4,8 +4,6 @@ import { Physical } from './physical';
 import { World } from './world';
 import { InteractionType, ItemType } from '../worldDescription';
 
-const MAX_STASH: number = 12;
-
 export class Item extends Physical {
   name?: string;
   carried_by?: string;
@@ -104,9 +102,6 @@ export class Item extends Physical {
   stash(world: World, mob: Mob, position: Coord) {
     if (!this.carried_by) {
       throw new Error('Must carry item being stashed.');
-    }
-    if (world.getStoredItems().length >= MAX_STASH) {
-      throw new Error('Cannot stash more than 12 items.');
     }
     console.log('stashing item', this.key, this.carried_by);
     mob.carrying = undefined;

--- a/packages/client/test/items/uses/playerCarriedItems.test.ts
+++ b/packages/client/test/items/uses/playerCarriedItems.test.ts
@@ -53,7 +53,9 @@ describe('"Give" action item interaction tests', () => {
       'player'
     );
 
-    expect(interactions.some((interaction) => interaction.action === 'give'));
+    expect(
+      interactions.some((interaction) => interaction.action === 'give')
+    ).toBe(true);
   });
 
   test('Give action is absent when receiver is carrying item', () => {


### PR DESCRIPTION
## Description
Previously, the user was given the option to stash an item even if they had a full inventory. Now, the stash button doesn't populate when inventory is full.

## Problem
Closes [Issue #580](https://github.com/sloalchemist/potions/issues/580).

## Context
This issue was originally raised because of a bug in which the user could not drop an item after attempting to stash it with a full inventory. However, while addressing that issue I realized (with the help of @spruhaN) that it made more sense to just not provide the option to stash when inventory is full. That is what this PR accomplishes.

## Impact
This change should not have any significant effect on other developers.

## Testing
Tested manually.

