### PR TITLE
Fix healthbars obscuring "GAME OVER" text 

### DIFF
--- a/packages/client/src/scenes/worldScene.ts
+++ b/packages/client/src/scenes/worldScene.ts
@@ -762,7 +762,7 @@ export class WorldScene extends Phaser.Scene {
       const menu = this.add.text(290, 200, 'MENU', buttonStyle);
       menu.setOrigin(0, 0);
       menu.setScrollFactor(0);
-      menu.setDepth(100);
+      menu.setDepth(1001);
       menu.setInteractive({ useHandCursor: true });
 
       // Hover effects


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
The "GAME OVER" text appearing when the player dies can be obscured by mob health bars. This change ensures the "GAME OVER" text is always on top.

## Problem
<!--- Why is this change required? What problem does it solve? -->
<!--- You can just link to the issue if applicable with "Closes #XYZ" -->
Closes #687 

## Context
<!--- What alternatives were considered, and why was this approach chosen? -->
<!--- Mention any design decisions or trade-offs. -->
None

## Impact
<!--- Does this change break anything or require documentation updates? -->
<!--- How will this change affect other developers? Can that burden be minimized? --> 
<!--- Should they be notified (e.g., via Slack)? -->
Aesthetic effect only

## Testing
<!--- Describe how you tested the changes -->
<!--- Mention automated tests, manual testing, or reasons for not testing -->
Manual testing confirms health bar is no longer obscured.

## Screenshots (if appropriate)
<!--- Remove this section if not appropriate -->
<img width="294" alt="Screenshot 2025-03-09 at 8 14 52 PM" src="https://github.com/user-attachments/assets/5b80ee10-6b5b-4a79-94fa-bd2fb0b9f317" />