### PR TITLE
fix: toggleable keybinds manual screen

### DIFF
--- a/packages/client/src/scenes/uxScene.ts
+++ b/packages/client/src/scenes/uxScene.ts
@@ -467,6 +467,9 @@ export class UxScene extends Phaser.Scene {
       this.keybindGuideContainer.add(
         this.add.text(200, 170, 'F: Favorability Stats')
       );
+      this.keybindGuideContainer.add(
+        this.add.text(135, 270, 'Press "k" to dismiss')
+      );
 
       // recipe text
       this.recipeText = this.add.text(160, 35, 'POTION RECIPES');
@@ -769,7 +772,11 @@ export class UxScene extends Phaser.Scene {
               console.log('Pressed F');
               break;
             case 'k':
-              this.showKeyBindGuideTab();
+              if (!this.keybindGuideContainer?.visible) {
+                this.showKeyBindGuideTab();
+              } else {
+                this.showInfoTab();
+              }
               console.log('Pressed K');
               break;
             default:


### PR DESCRIPTION
Group: Daniel Ching, Josh Queja, Keith Lee

## Bug
The keybinds manual screen should be toggleable with the "k" key. Currently there is no way to dismiss it besides manually clicking another tab.

## Changes
https://github.com/sloalchemist/potions/commit/af47eeafe3efffa9e551d3a235af544e88dc6969

- Dismiss the keybinds manual screen when "k" is pressed
