### PR TITLE
Carried items now show up over world structures

### DIFF
--- a/packages/client/src/sprite/sprite_mob.ts
+++ b/packages/client/src/sprite/sprite_mob.ts
@@ -481,6 +481,7 @@ export class SpriteMob extends Mob {
         throw new Error(`Item not found ${this.key} carrying ${this.carrying}`);
       }
       spriteItem.sprite.setPosition(this.sprite.x, this.sprite.y - 24);
+      spriteItem.sprite.setDepth(1000);
     }
 
     if (this.position) {


### PR DESCRIPTION

## Description
Fixed the issue where an item that you are carrying doesn't show up over parts of the world such as fences, stands, house walls, inside houses, etc. It makes it such that the item you're carrying shows up with the same priority as the sprite itself. 

## Problem
It previously looked super awkward with items morphing through stands and gates and then when you're inside a house you just couldn't see the item at all. It was cooked.

## Context
No alternatives, it just needed to be fixed. 

## Impact
Shouldn't break anything else, this is a very straightforward change. 

## Testing
Visual Testing.

## Screenshots (if appropriate)
<img width="423" alt="Screenshot 2025-03-10 at 5 30 34 PM" src="https://github.com/user-attachments/assets/2499484e-9153-490b-aa0d-105bbdc4a900" />
<img width="424" alt="Screenshot 2025-03-10 at 5 30 28 PM" src="https://github.com/user-attachments/assets/59af9001-ca1a-4a75-9679-7344dd3c3b51" />


