### PR TITLE
Enhancement: Centered Buttons

### DIFF
--- a/packages/client/src/components/button.ts
+++ b/packages/client/src/components/button.ts
@@ -1,6 +1,6 @@
 export const BUTTON_WIDTH = 120;
 export const BUTTON_HEIGHT = 40;
-export const BUTTON_SPACING = 10;
+export const BUTTON_SPACING = 25;
 export const SUBHEADING_OFFSET = 25;
 import Phaser from 'phaser';
 


### PR DESCRIPTION
## Description
Centers buttons across all of the frame pages

## Problem
Some final polishing, the off-centered buttons just lacked polishing
<!--- You can just link to the issue if applicable with "Closes #XYZ" -->

## Context
Changing the width and height instead of the spacing. Though current buttons are able to display all text appropriately so just made the page less crammed by changing the spacing.
<!--- Mention any design decisions or trade-offs. -->

## Impact
This change does not break anything nor require documentation.
<!--- Does this change break anything or require documentation updates? -->
<!--- How will this change affect other developers? Can that burden be minimized? --> 
<!--- Should they be notified (e.g., via Slack)? -->

## Testing
Ran against the potion build until altered spacing till it seemed appropriate.

## Screenshots (if appropriate)
Before:
<img width="685" alt="Screenshot 2025-03-11 at 4 37 01 PM" src="https://github.com/user-attachments/assets/0b94ab6c-42d1-4666-846f-b904d601993c" />
After:
<img width="688" alt="Screenshot 2025-03-11 at 4 36 01 PM" src="https://github.com/user-attachments/assets/88961657-60be-4464-8ecb-5bb7ec38c0ff" />

