### PR TITLE
Fix: removed redundant stand smash/destroy for potion stands

### DIFF
--- a/packages/client/world_assets/global.json
+++ b/packages/client/world_assets/global.json
@@ -1155,18 +1155,6 @@
               "comparison": "greater_than"
             }
           ]
-        },
-        {
-          "description": "Destroy stand",
-          "action": "destroy_stand",
-          "while_carried": false,
-          "conditions": [
-            {
-              "attribute_name": "items",
-              "value": 0,
-              "comparison": "equals"
-            }
-          ]
         }
       ],
       "attributes": [

--- a/packages/json-generator/global.json
+++ b/packages/json-generator/global.json
@@ -1178,18 +1178,6 @@
             "character": false,
             "other": true
           }
-        },
-        {
-          "description": "Destroy stand",
-          "action": "destroy_stand",
-          "while_carried": false,
-          "conditions": [
-            {
-              "attribute_name": "items",
-              "value": 0,
-              "comparison": "equals"
-            }
-          ]
         }
       ],
       "show_price_at": {

--- a/packages/json-generator/test/expectedClient.json
+++ b/packages/json-generator/test/expectedClient.json
@@ -1155,18 +1155,6 @@
               "comparison": "greater_than"
             }
           ]
-        },
-        {
-          "description": "Destroy stand",
-          "action": "destroy_stand",
-          "while_carried": false,
-          "conditions": [
-            {
-              "attribute_name": "items",
-              "value": 0,
-              "comparison": "equals"
-            }
-          ]
         }
       ],
       "attributes": [

--- a/packages/json-generator/test/expectedServer.json
+++ b/packages/json-generator/test/expectedServer.json
@@ -1148,18 +1148,6 @@
               "comparison": "greater_than"
             }
           ]
-        },
-        {
-          "description": "Destroy stand",
-          "action": "destroy_stand",
-          "while_carried": false,
-          "conditions": [
-            {
-              "attribute_name": "items",
-              "value": 0,
-              "comparison": "equals"
-            }
-          ]
         }
       ],
       "attributes": [

--- a/packages/server/world_assets/global.json
+++ b/packages/server/world_assets/global.json
@@ -1148,18 +1148,6 @@
               "comparison": "greater_than"
             }
           ]
-        },
-        {
-          "description": "Destroy stand",
-          "action": "destroy_stand",
-          "while_carried": false,
-          "conditions": [
-            {
-              "attribute_name": "items",
-              "value": 0,
-              "comparison": "equals"
-            }
-          ]
         }
       ],
       "attributes": [


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
Removed all instances of 'destroy stand' in JSON files

## Problem
<!--- Why is this change required? What problem does it solve? -->
<!--- You can just link to the issue if applicable with "Closes #XYZ" -->
The existing 'destroy stand' button performs no functionality and the desired functionality can be achieved with the existing 'smash potion stand button'

## Context
<!--- What alternatives were considered, and why was this approach chosen? -->
<!--- Mention any design decisions or trade-offs. -->
Could have removed 'smash potion stand' and added the functionality 'destroy stand' but requires extra work when an existing button with the desired functionality already exists. 

## Impact
<!--- Does this change break anything or require documentation updates? -->
<!--- How will this change affect other developers? Can that burden be minimized? --> 
<!--- Should they be notified (e.g., via Slack)? -->
No breaking changes made

## Testing
<!--- Describe how you tested the changes -->
<!--- Mention automated tests, manual testing, or reasons for not testing -->
Went into the world and made sure breaking potion stands both with and without potions was possible. 

## Screenshots (if appropriate)
<!--- Remove this section if not appropriate -->
example of destroy stand and smash potion stand buttons
![image](https://github.com/user-attachments/assets/7539babc-f235-46d1-8e07-274fc2c62ea9)

