### PR TITLE
fix: the leaderboard will only call rerender if it is active

### DIFF
--- a/packages/client/src/services/serverToBroadcast.ts
+++ b/packages/client/src/services/serverToBroadcast.ts
@@ -199,7 +199,11 @@ export function setupBroadcast(
     setLeaderboardData(data.scores);
     const leaderboardScene = scene.scene.get('LeaderboardScene');
     if (leaderboardScene instanceof LeaderboardScene) {
-      leaderboardScene.renderLeaderboard();
+      if (scene.scene.isActive('LeaderboardScene')) {
+        leaderboardScene.renderLeaderboard();
+      } else if (scene.scene.get('LeaderboardScene')) {
+        console.debug('LeaderboardScene is initialized but not active.');
+      }
     } else {
       throw new Error('Leaderboard scene not found');
     }


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
We added a check to see if the LeaderBoardScene (the expanded version) is active before calling the rerenderLeaderBoard function. 

## Problem
<!--- Why is this change required? What problem does it solve? -->
<!--- You can just link to the issue if applicable with "Closes #XYZ" -->
This change cleans up console warnings with error stack traces that occur when the expanded LeaderBoardScene has not been created by Phaser at the start of the game (because the miniLeaderBoardScene is default). It is most likely that the code was initially structured under the assumption that the expanded leaderboard would always be there and did not change to handle the new edge case when the option of a collapsed leaderboard was added.  As a small added benefit, it makes the code more efficient by not attempting to rerender a scene that is not active. 

Closes #726

## Context
<!--- What alternatives were considered, and why was this approach chosen? -->
<!--- Mention any design decisions or trade-offs. -->
We had initially thought to initialize the titleText within the constructor but this is not allowed by Phaser. We also thought that our current solution is quite simple and helps make the code more efficient.

## Impact
<!--- Does this change break anything or require documentation updates? -->
<!--- How will this change affect other developers? Can that burden be minimized? --> 
<!--- Should they be notified (e.g., via Slack)? -->
This is a very small change that should not have any impact on development. 

## Testing
<!--- Describe how you tested the changes -->
<!--- Mention automated tests, manual testing, or reasons for not testing -->
This bug isn't fit for unit testing since it uses the state of Phaser UI elements and is triggered by Ably messages. The changes were tested manually by running the potions game and verifying that the exception isn't appearing in the console.

## Screenshot of Fixed Error Message
![image](https://github.com/user-attachments/assets/decb9c1a-7f46-43c8-aca7-4dec554fae2c)