### PR TITLE
fix: remove duplicate calls causing excessive updates

### DIFF
--- a/packages/server/src/services/gameWorld/serverWorld.ts
+++ b/packages/server/src/services/gameWorld/serverWorld.ts
@@ -131,13 +131,7 @@ export class ServerWorld implements GameWorld {
     measureTime('Mob ticks', () => this.runMobTicks(deltaTime));
     measureTime('Conversation tracker', () => conversationTracker.tick());
     measureTime('Fantasy date', () => FantasyDate.runTick());
-    measureTime('Data logging', () => DataLogger.logData());
-
-    conversationTracker.tick();
-    FantasyDate.runTick();
-
-    // log data for Prometheus
-    DataLogger.logData();
+    measureTime('Data logging', () => DataLogger.logTick());
 
     //const totalTime = Date.now() - startTime;
     //logger.log('time to tick', totalTime);


### PR DESCRIPTION
## Description
Fix serverworld.ts tick function that had duplicate calls for tick functions for conversationTracker and FantasyDate. Also updated DataLogger calls, since it calls the wrong function causing some metrics to not be updated. 

## Problem
Closes #740 

## Context
No trade-offs made 

## Impact
No impact on codebase

## Testing
No testing needed functions are already tested
