### PR TITLE
Separate world metrics from each other

### DIFF
--- a/packages/server/src/grafana/dataLogger.ts
+++ b/packages/server/src/grafana/dataLogger.ts
@@ -12,7 +12,6 @@ import {
 import 'dotenv/config';
 import { getEnv } from '@rt-potion/common';
 import { logger } from '../util/logger';
-//import { worldID } from '../services/setup';
 
 export class DataLogger {
   private static register = new Registry();
@@ -115,6 +114,9 @@ export function pushMetrics() {
     return;
   }
 
+  // Get world id to seperate worlds
+  const worldID = process.argv.slice(2)[0];
+
   const gateway = new Pushgateway(gatewayURL, {
     timeout: 5000, //Set the request timeout to 5000ms
     agent: new Agent({
@@ -124,13 +126,13 @@ export function pushMetrics() {
 
   // Load metrics under World Name 'Metric'
   gateway
-    .pushAdd({ jobName: `Metrics` })
+    .pushAdd({ jobName: `${worldID} Metrics` })
     .then()
     .catch((e) => logger.warn(`Failed to pushAdd metrics:`, e));
 
   function pushData() {
     gateway
-      .push({ jobName: `Metrics` })
+      .push({ jobName: `${worldID} Metrics` })
       .then()
       .catch((e) => logger.warn(`Failed to push metrics:`, e));
   }


### PR DESCRIPTION
## Description
Added world names to metrics to separate metrics between servers. 

## Problem
It separates the metric between worlds, allowing metrics to be useful in that each server's metrics can be differentiated now. 

Closes #691 

## Context
Initially we used the worldID from an another file export, but this caused test to fail from the dependency, so we just used the world name in the arguments to differentiate the servers. We used the world name, since it follows our current sharding scheme. This relies on each server running a unique world to separate the metrics. If worlds are ran on multiple servers, this may cause the metrics to be mixed again. 

## Impact
No impact on codebase

## Testing
Manually tested the name of the metric job to check it included the world name. 
