### PR TITLE
699 sfx music toggle

### DIFF
--- a/packages/client/src/components/button.ts
+++ b/packages/client/src/components/button.ts
@@ -122,7 +122,9 @@ export class Button extends Phaser.GameObjects.Container {
         event: Phaser.Types.Input.EventData
       ) => {
         event.stopPropagation();
-        this.scene.sound.play('buttonClick');
+        if (this.scene.registry.get('soundEffects') === true) {
+          this.scene.sound.play('buttonClick');
+        }
         this.buttonSprite.setScale(0.9);
         this.buttonBackground?.setScale(0.95);
         this.buttonBackground?.setFillStyle(this.pressedColor); // Pressed color
@@ -135,7 +137,10 @@ export class Button extends Phaser.GameObjects.Container {
       this.buttonBackground?.setFillStyle(this.hoverColor); // Hover color
       this.callback();
       // play interaction sound
-      if (this.interactionSound) {
+      if (
+        this.scene.registry.get('soundEffects') === true &&
+        this.interactionSound
+      ) {
         this.scene.sound.play(this.interactionSound);
       }
     });

--- a/packages/client/src/components/button.ts
+++ b/packages/client/src/components/button.ts
@@ -13,6 +13,9 @@ export class Button extends Phaser.GameObjects.Container {
   fixedWidth: number;
   fixedHeight: number;
   interactionSound?: string;
+  defaultColor: number;
+  hoverColor: number;
+  pressedColor: number;
 
   constructor(
     scene: Phaser.Scene,
@@ -33,6 +36,10 @@ export class Button extends Phaser.GameObjects.Container {
     this.fixedWidth = buttonWidth;
     this.fixedHeight = buttonHeight;
 
+    this.defaultColor = 0x8ca0b3;
+    this.hoverColor = 0xc0d9e8;
+    this.pressedColor = 0x5e7485;
+
     if (interactionSound) {
       this.interactionSound = interactionSound;
     }
@@ -45,7 +52,7 @@ export class Button extends Phaser.GameObjects.Container {
         0,
         this.fixedWidth,
         this.fixedHeight,
-        0x8ca0b3 // Background color
+        this.defaultColor // Background color
       ).setOrigin(0.5);
 
       // Create the text object
@@ -97,13 +104,13 @@ export class Button extends Phaser.GameObjects.Container {
     this.on('pointerover', () => {
       this.buttonSprite.setScale(1.1);
       this.buttonBackground?.setScale(1.05);
-      this.buttonBackground?.setFillStyle(0xc0d9e8); // Hover color
+      this.buttonBackground?.setFillStyle(this.hoverColor); // Hover color
     });
 
     this.on('pointerout', () => {
       this.buttonSprite.setScale(1.0);
       this.buttonBackground?.setScale(1.0);
-      this.buttonBackground?.setFillStyle(0x8ca0b3); // Default color
+      this.buttonBackground?.setFillStyle(this.defaultColor); // Default color
     });
 
     this.on(
@@ -118,14 +125,14 @@ export class Button extends Phaser.GameObjects.Container {
         this.scene.sound.play('buttonClick');
         this.buttonSprite.setScale(0.9);
         this.buttonBackground?.setScale(0.95);
-        this.buttonBackground?.setFillStyle(0x5e7485); // Pressed color
+        this.buttonBackground?.setFillStyle(this.pressedColor); // Pressed color
       }
     );
 
     this.on('pointerup', () => {
       this.buttonSprite.setScale(1.1);
       this.buttonBackground?.setScale(1.05);
-      this.buttonBackground?.setFillStyle(0xc0d9e8); // Hover color
+      this.buttonBackground?.setFillStyle(this.hoverColor); // Hover color
       this.callback();
       // play interaction sound
       if (this.interactionSound) {
@@ -162,13 +169,29 @@ export class Button extends Phaser.GameObjects.Container {
   /**
    * Implement the setStyle method to dynamically change button styles
    */
-  setStyle(style: { backgroundColor?: string; color?: string }) {
+  setStyle(style: {
+    backgroundColor?: {
+      default: string;
+      hover: string;
+      pressed: string;
+    };
+    color?: string;
+  }) {
     if (style.backgroundColor !== undefined && this.buttonBackground) {
-      // Convert the color string to a Phaser color number
-      const colorNumber = Phaser.Display.Color.HexStringToColor(
-        style.backgroundColor
+      // Convert the color strings to Phaser color numbers
+      const defaultColorNumber = Phaser.Display.Color.HexStringToColor(
+        style.backgroundColor.default
       ).color;
-      this.buttonBackground.setFillStyle(colorNumber);
+      this.buttonBackground.setFillStyle(defaultColorNumber);
+      this.defaultColor = defaultColorNumber;
+
+      this.hoverColor = Phaser.Display.Color.HexStringToColor(
+        style.backgroundColor.hover
+      ).color;
+
+      this.pressedColor = Phaser.Display.Color.HexStringToColor(
+        style.backgroundColor.pressed
+      ).color;
     }
 
     if (

--- a/packages/client/src/components/tabButton.ts
+++ b/packages/client/src/components/tabButton.ts
@@ -135,7 +135,9 @@ export class TabButton extends Phaser.GameObjects.Container {
     });
 
     this.on('pointerdown', () => {
-      this.scene.sound.play('tabClick');
+      if (this.scene.registry.get('soundEffects') === true) {
+        this.scene.sound.play('tabClick');
+      }
       this.callback();
     });
   }

--- a/packages/client/src/scenes/loadWorldScene.ts
+++ b/packages/client/src/scenes/loadWorldScene.ts
@@ -59,10 +59,15 @@ export class LoadWorldScene extends Phaser.Scene {
   }
 
   create() {
-    this.sound.add('menu_music', { loop: true, volume: 0.2 }).play();
+    if (!this.registry.has('music')) {
+      this.registry.set('music', true);
+    }
 
     // Play menu music
-    if (!this.sound.isPlaying('menu_music')) {
+    if (
+      this.registry.get('music') === true &&
+      !this.sound.isPlaying('menu_music')
+    ) {
       // fairy music
       this.sound.add('menu_music', { loop: true, volume: 0.2 }).play();
     }

--- a/packages/client/src/scenes/uxScene.ts
+++ b/packages/client/src/scenes/uxScene.ts
@@ -850,8 +850,10 @@ export class UxScene extends Phaser.Scene {
 
   callSpeak(response: string, i: number) {
     // randomly select a chat sound
-    const chatSound = Phaser.Math.RND.pick(this.chatSounds);
-    chatSound.play();
+    if (this.registry.get('soundEffects') === true) {
+      const chatSound = Phaser.Math.RND.pick(this.chatSounds);
+      chatSound.play();
+    }
     speak(response, i);
     this.setChatOptions([]);
   }

--- a/packages/client/src/scenes/uxScene.ts
+++ b/packages/client/src/scenes/uxScene.ts
@@ -465,13 +465,11 @@ export class UxScene extends Phaser.Scene {
             backgroundColor: this.registry.get('music') ? onStyles : offStyles
           });
           const worldScene = this.scene.get('WorldScene');
-          if (this.registry.get('music') === true) {
-            if (worldScene) {
-              worldScene.sound.get('background_music').play();
-              worldScene.sound.get('background_music_layer').play();
-            }
-          } else {
-            if (worldScene) {
+          if (worldScene) {
+            if (this.registry.get('music') === true) {
+              worldScene.sound.get('background_music').resume();
+              worldScene.sound.get('background_music_layer').resume();
+            } else {
               worldScene.sound.get('background_music').pause();
               worldScene.sound.get('background_music_layer').pause();
             }

--- a/packages/client/src/scenes/uxScene.ts
+++ b/packages/client/src/scenes/uxScene.ts
@@ -422,6 +422,56 @@ export class UxScene extends Phaser.Scene {
         yOffset += 30;
       });
 
+      // Sound/music controls
+      this.registry.set('soundEffects', true);
+      this.registry.set('music', true);
+
+      const onStyles = {
+        default: '#8CA0B3',
+        hover: '#C0D9E8',
+        pressed: '#5E7485'
+      };
+      const offStyles = {
+        default: '#C43B3D',
+        hover: '#E5AAAB',
+        pressed: '#A33133'
+      };
+      const soundEffectsToggle = new Button(
+        this,
+        SCREEN_WIDTH / 2 + 100,
+        265,
+        true,
+        'Sound',
+        () => {
+          this.registry.set('soundEffects', !this.registry.get('soundEffects'));
+          soundEffectsToggle.setStyle({
+            backgroundColor: this.registry.get('soundEffects')
+              ? onStyles
+              : offStyles
+          });
+        },
+        60,
+        30
+      );
+      const musicToggle = new Button(
+        this,
+        SCREEN_WIDTH / 2 + 160,
+        265,
+        true,
+        'Music',
+        () => {
+          this.registry.set('music', !this.registry.get('music'));
+          musicToggle.setStyle({
+            backgroundColor: this.registry.get('music') ? onStyles : offStyles
+          });
+        },
+        60,
+        30
+      );
+
+      this.infoContainer?.add(soundEffectsToggle);
+      this.infoContainer?.add(musicToggle);
+
       // action tab texts
       this.itemsText = this.add.text(160, 35, 'ITEMS / Fight');
       this.itemsContainer.add(this.itemsText);

--- a/packages/client/src/scenes/uxScene.ts
+++ b/packages/client/src/scenes/uxScene.ts
@@ -464,6 +464,18 @@ export class UxScene extends Phaser.Scene {
           musicToggle.setStyle({
             backgroundColor: this.registry.get('music') ? onStyles : offStyles
           });
+          const worldScene = this.scene.get('WorldScene');
+          if (this.registry.get('music') === true) {
+            if (worldScene) {
+              worldScene.sound.get('background_music').play();
+              worldScene.sound.get('background_music_layer').play();
+            }
+          } else {
+            if (worldScene) {
+              worldScene.sound.get('background_music').pause();
+              worldScene.sound.get('background_music_layer').pause();
+            }
+          }
         },
         60,
         30

--- a/packages/client/src/scenes/worldScene.ts
+++ b/packages/client/src/scenes/worldScene.ts
@@ -418,13 +418,15 @@ export class WorldScene extends Phaser.Scene {
     this.nightOverlay.setDepth(1000); // Set a low depth, so it's below the speech bubbles
     this.hideWorld();
 
-    if (!this.sound.isPlaying('background_music')) {
-      this.sound.add('background_music', { loop: true, volume: 0.8 }).play();
-    }
-    if (!this.sound.isPlaying('background_music_layer')) {
-      this.sound
-        .add('background_music_layer', { loop: true, volume: 0.3 })
-        .play();
+    if (this.registry.get('music') === true) {
+      if (!this.sound.isPlaying('background_music')) {
+        this.sound.add('background_music', { loop: true, volume: 0.8 }).play();
+      }
+      if (!this.sound.isPlaying('background_music_layer')) {
+        this.sound
+          .add('background_music_layer', { loop: true, volume: 0.3 })
+          .play();
+      }
     }
 
     bindAblyToWorldScene(this);
@@ -567,7 +569,10 @@ export class WorldScene extends Phaser.Scene {
       const roundedY = Math.floor(this.hero.y);
 
       if (roundedX !== this.cameraDolly.x || roundedY !== this.cameraDolly.y) {
-        if (!this.sound.isPlaying('walk')) {
+        if (
+          this.registry.get('soundEffects') === true &&
+          !this.sound.isPlaying('walk')
+        ) {
           this.sound.add('walk', { loop: true, volume: 0.6 }).play();
         }
       } else {


### PR DESCRIPTION
## Description
Adding an option to toggle both music and sound effects in the game.
Both toggle buttons are in the `Player` tab of the console, taking up minimal space. When toggled off, the buttons are highlighted red, indicating that the user has switched those values to off. They can turn it back on by pressing the button once more.

## Problem
Closes #699 

## Context
The main considerations in play included where the toggles should be added in the game interface as well as what the users should see when they're toggled off or on. We ultimately decided to add both toggles as small buttons on the `Player` tab, as it made the most sense for player/system-wide controls.

## Impact
This provides players better customizability for their gameplay. By granting the ability to independently toggle off either sound effects or music, it provides a more personalized experience for players. This also gives them more control, where muting either/or can be done rather than turning off all sound by muting their system volume.

## Testing
We tested this functionality in our local environments. We tested all cases:
- Muting/unmuting only sound effects
- Muting/unmuting only music
  - Ensuring music resumes on unmute
- Muting/unmuting both sound effects and music
- Returning to menu and re-joining the world

## Screenshots (if appropriate)

![image](https://github.com/user-attachments/assets/c67fd43c-1672-4c55-bee0-3810d41ec5e0)

![image](https://github.com/user-attachments/assets/730d70c9-6f77-434f-9470-3d12a5d851fb)