### PR TITLE
Delete Potion From World After Suicide

### DIFF
--- a/packages/server/src/items/potionEffects.ts
+++ b/packages/server/src/items/potionEffects.ts
@@ -177,7 +177,7 @@ export function drinkPotion(
 
 function giveRandomEffect(mob: Mob) {
   const randomNum = Math.floor(Math.random() * 8); // amount of current effects
-
+  console.log(`This is the number of the effect you got: ${randomNum}`);
   switch (randomNum) {
     case 0:
       // Random Effect: Reduce Speed
@@ -245,7 +245,11 @@ function closeToBlack(potionStr: string, mob: Mob): boolean {
     potionRgb.g < thresholdBlack &&
     potionRgb.b < thresholdBlack
   ) {
-    // Potion is black, mob dies
+    const carriedItem = mob.carrying;
+    // delete the potion they just drank from the world
+    if (carriedItem) {
+      carriedItem.destroy();
+    }
     mob.changeHealth(-mob.health);
     return true;
   }

--- a/packages/server/src/items/potionEffects.ts
+++ b/packages/server/src/items/potionEffects.ts
@@ -177,7 +177,6 @@ export function drinkPotion(
 
 function giveRandomEffect(mob: Mob) {
   const randomNum = Math.floor(Math.random() * 8); // amount of current effects
-  console.log(`This is the number of the effect you got: ${randomNum}`);
   switch (randomNum) {
     case 0:
       // Random Effect: Reduce Speed

--- a/packages/server/test/potions/potionEffects/toxicPotion.test.ts
+++ b/packages/server/test/potions/potionEffects/toxicPotion.test.ts
@@ -49,6 +49,9 @@ describe('Test consumption of toxic potions', () => {
     const test = testDrink.interact(testMob!, potionItem!);
     expect(test).toBe(true);
 
+    // ensure the player is no longer carrying the potion after drinking it
+    expect(testMob!.carrying).toBeUndefined();
+
     // Player should be dead
     expect(testMob!.health).toBe(0);
   });


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
When drinking a potion whose brew color is close to black (i.e, a potion made from tar), a closeToBlack function is called which immediately kills the player. The potion from which the player drank is now deleted from the world
## Problem
<!--- Why is this change required? What problem does it solve? -->
<!--- You can just link to the issue if applicable with "Closes #XYZ" -->
Closes [#738 ](url)
## Context
<!--- What alternatives were considered, and why was this approach chosen? -->
<!--- Mention any design decisions or trade-offs. -->
One decision that was considered was to just leave the potion in the world as the world is created anew when a player dies. However, this approach does not lend favorably to future plans in which we might want to save the world state to how it was before the player died, so that a player might pick up their items from where they previously died. In this scenario, the player could theoretically still use and drink the potion and have it exist forever since it does not despawn. Thus the decision to remove the potion immediately upon drinking was made

## Impact
<!--- Does this change break anything or require documentation updates? -->
<!--- How will this change affect other developers? Can that burden be minimized? --> 
<!--- Should they be notified (e.g., via Slack)? -->
This change does not break anything nor requires documentation updates. As such no developers need to be notified

## Testing
<!--- Describe how you tested the changes -->
<!--- Mention automated tests, manual testing, or reasons for not testing -->
added a condition in the existing `toxicPotion.test.ts`

## Screenshots
<!--- Remove this section if not appropriate -->
Before Fix:
![image](https://github.com/user-attachments/assets/d1f018f4-809e-4a3a-8833-ef9c9ae03b88)

After Fix:
![image](https://github.com/user-attachments/assets/e9584484-6557-49b3-9750-a134823f5979)

