### PR TITLE
subscribe player to channels if change name

### DIFF
--- a/packages/client/src/worldMetadata.ts
+++ b/packages/client/src/worldMetadata.ts
@@ -158,7 +158,7 @@ export async function changeName(name: string) {
     characterId = uuidv4();
     publicCharacterId = characterId.substr(0, 8);
     localStorage.setItem('characterId', characterId);
-    setupAbly();
+    setupAbly(true);
   }
   localStorage.setItem('name', name);
   currentCharacter!.name = name;


### PR DESCRIPTION
## Description
After your character dies, if you decide to go back to the menu and change your name before rejoining, the game does not load. If you don't change your name before rejoining, the bug does not happen.

In `packages\client\src\services\ablySetup.ts` after the first time a player joins the game `bindAblyToWorldScene` sets up the player subscriptions. However, if the player changes their name after dying and going back to the menu, `bindAblyToWorldScene` does not check if `playerChannel` is the same as last time. Therefore, it does not set up the player subscriptions for the new `playerChannel` after it is updated with a new `publicCharacterId`.

## Problem
Closes [Issue #750](https://github.com/sloalchemist/potions/issues/750)