### PR TITLE
734 fix: repeated nondescriptive client console warning "Cannot set properties of undefined"

### DIFF
--- a/packages/client/src/services/serverToBroadcast.ts
+++ b/packages/client/src/services/serverToBroadcast.ts
@@ -108,9 +108,12 @@ export function setupBroadcast(
   function handleDoing(data: DoingData) {
     const mob = world.mobs[data.id] as SpriteMob;
     if (mob == undefined) {
-      console.warn(`Mob with id ${data.id} is undefined.`);
+      console.warn(
+        `Ably attempting to assign 'doing' to undefined mob with id ${data.id}`
+      );
+    } else {
+      mob.doing = data.action;
     }
-    mob.doing = data.action;
   }
 
   function handleMove(data: MoveData) {

--- a/packages/client/src/services/serverToBroadcast.ts
+++ b/packages/client/src/services/serverToBroadcast.ts
@@ -109,7 +109,7 @@ export function setupBroadcast(
     const mob = world.mobs[data.id] as SpriteMob;
     if (mob == undefined) {
       console.warn(
-        `client/src/serverToBroadcast.ts: Ably attempting to assign 'doing' to undefined mob with id ${data.id}`
+        `client/src/services/serverToBroadcast.ts: Ably attempting to assign 'doing' to undefined mob with id ${data.id}`
       );
     } else {
       mob.doing = data.action;

--- a/packages/client/src/services/serverToBroadcast.ts
+++ b/packages/client/src/services/serverToBroadcast.ts
@@ -109,7 +109,7 @@ export function setupBroadcast(
     const mob = world.mobs[data.id] as SpriteMob;
     if (mob == undefined) {
       console.warn(
-        `Ably attempting to assign 'doing' to undefined mob with id ${data.id}`
+        `client/src/serverToBroadcast.ts: Ably attempting to assign 'doing' to undefined mob with id ${data.id}`
       );
     } else {
       mob.doing = data.action;

--- a/packages/client/src/services/serverToBroadcast.ts
+++ b/packages/client/src/services/serverToBroadcast.ts
@@ -107,6 +107,9 @@ export function setupBroadcast(
 
   function handleDoing(data: DoingData) {
     const mob = world.mobs[data.id] as SpriteMob;
+    if (mob == undefined) {
+      console.warn(`Mob with id ${data.id} is undefined.`);
+    }
     mob.doing = data.action;
   }
 


### PR DESCRIPTION
## Description

There was a client console warning that came up frequently that did not specify the location. It has to do with the handleDoing attempting to assign a 'doing' value to a mob that does not exist.

## Problem
Closes #734 

## Context
<!--- What alternatives were considered, and why was this approach chosen? -->
This is simple fix that adds the location of the error and makes the overall error message smaller, so there is not really any alternative ways to do so.
<!--- Mention any design decisions or trade-offs. -->

## Impact
<!--- Does this change break anything or require documentation updates? -->
<!--- How will this change affect other developers? Can that burden be minimized? --> 
<!--- Should they be notified (e.g., via Slack)? -->
This change does not affect other developers beyond being able to identify client console logs easier.

## Testing
<!--- Describe how you tested the changes -->
<!--- Mention automated tests, manual testing, or reasons for not testing -->
Ran the game to confirm the error was being properly handled

## Screenshots (if appropriate)
<!--- Remove this section if not appropriate -->
