### PR TITLE
Fix Phantom Mobs

### DIFF
--- a/packages/client/src/services/serverToBroadcast.ts
+++ b/packages/client/src/services/serverToBroadcast.ts
@@ -106,7 +106,9 @@ export function setupBroadcast(
 
   function handleDoing(data: DoingData) {
     const mob = world.mobs[data.id] as SpriteMob;
-    mob.doing = data.action;
+    if (mob) {
+      mob.doing = data.action;
+    }
   }
 
   function handleMove(data: MoveData) {
@@ -258,6 +260,7 @@ export function setupBroadcast(
             'BROADCAST UNSTASH ITEM'
           );
           handleUnstashItem(broadcastItem.data as UnstashItemData);
+          break;
         case 'doing':
           handleDoing(broadcastItem.data as DoingData);
           break;


### PR DESCRIPTION
## Description
Added a condition on handleDoing to prevent errors on client. Also added a missing break statement in switch for processing server broadcast. 

## Problem
The errors from handleDoing was blocking the ably broadcast from processing the entirety of the message causing missing delete actions for mobs and items. This caused the client to have a build up of phantom mobs that lagged the client side. 

## Context
The handleDoing code only needed a condition to check before setting an action for an undefined value. This was the simplest way to prevent the error from occur and by extension blocking. 

## Impact
No impact on codebase.

## Testing
Manually tested if errors appeared on client console. 
