### PR TITLE
Fix #773: Make potion and market stands walkable

### DIFF
--- a/packages/client/world_assets/global.json
+++ b/packages/client/world_assets/global.json
@@ -1051,7 +1051,7 @@
       "description": "A stand that sells health potions.",
       "type": "potion-stand",
       "carryable": false,
-      "walkable": false,
+      "walkable": true,
       "interactions": [
         {
           "description": "Add $item_name",
@@ -1204,7 +1204,7 @@
       "description": "A stand that sells THINGS.",
       "type": "market-stand",
       "carryable": false,
-      "walkable": false,
+      "walkable": true,
       "interactions": [
         {
           "description": "Add $item_name",

--- a/packages/json-generator/global.json
+++ b/packages/json-generator/global.json
@@ -1056,7 +1056,7 @@
       "type": "potion-stand",
       "carryable": false,
       "smashable": true,
-      "walkable": false,
+      "walkable": true,
       "attributes": [
         {
           "name": "items",
@@ -1210,7 +1210,7 @@
       "type": "market-stand",
       "carryable": false,
       "smashable": true,
-      "walkable": false,
+      "walkable": true,
       "attributes": [
           {
               "name": "items",

--- a/packages/server/world_assets/global.json
+++ b/packages/server/world_assets/global.json
@@ -1044,7 +1044,7 @@
       "description": "A stand that sells health potions.",
       "type": "potion-stand",
       "carryable": false,
-      "walkable": false,
+      "walkable": true,
       "interactions": [
         {
           "description": "Add $item_name",
@@ -1197,7 +1197,7 @@
       "description": "A stand that sells THINGS.",
       "type": "market-stand",
       "carryable": false,
-      "walkable": false,
+      "walkable": true,
       "interactions": [
         {
           "description": "Add $item_name",


### PR DESCRIPTION
## Description  
This PR updates potion stands and market stands to be walkable, allowing mobs and players to pass through them. This prevents players from creating impassable barriers that would block movement.

## Problem  
Potion and market stands were previously non-walkable. While this was not a problem in the past, both items will soon only be smashable by those who owned them. This change ensures that players and mobs can freely navigate around placed stands without being blocked.

Closes #773

## Context
Alternative solutions were considered, such as making stands decay over time and eventually disappearing. However, making stands walkable quickly fixes the problem while also making it less ambiguous as to which stand you are currently interacting with when surrounded by multiple stands as making it walkable now requires one to stand on top of a it to interact with it.

## Impact
No breaking changes. Improves movement mechanics by preventing unintentional barriers.

## Testing  
- Manually verified that both players and mobs can walk through potion and market stands.
- No new unit tests needed, as this modifies movement behavior, not interaction logic.
