### PR TITLE
Add back world loading

### DIFF
--- a/packages/client/src/scenes/worldScene.ts
+++ b/packages/client/src/scenes/worldScene.ts
@@ -102,7 +102,6 @@ export class WorldScene extends Phaser.Scene {
   }
 
   preload() {
-    /* COMMENTING OUT FOR NOW SINCE IT BREAKS THE GAME
     // Initialize loading bar first
     console.log('Preload started');
     this.loadingBar.create();
@@ -111,9 +110,6 @@ export class WorldScene extends Phaser.Scene {
     this.events.on('update', () => {
       this.loadingBar.update();
     });
-
-    // Hide world immediately
-    this.hideWorld();
 
     // Set initial progress to show something is happening
     this.loadingBar.setProgress(0.1);
@@ -131,13 +127,10 @@ export class WorldScene extends Phaser.Scene {
 
       // Wait 500ms to show 100% before destroying
       setTimeout(() => {
-        // Remove update listener
-        this.events.off('update');
         this.loadingBar.destroy();
       }, 500);
     });
-*/
-    // Start loading assets
+
     const worldID = getWorldID();
     this.load.image(
       'background',

--- a/packages/client/world_assets/global.json
+++ b/packages/client/world_assets/global.json
@@ -1304,7 +1304,7 @@
           "value": 1
         }
       ],
-      "smashable": false,
+      "smashable": true,
       "show_price_at": {
         "x": 7,
         "y": -10

--- a/packages/server/world_assets/global.json
+++ b/packages/server/world_assets/global.json
@@ -1297,7 +1297,7 @@
           "value": 1
         }
       ],
-      "smashable": false,
+      "smashable": true,
       "show_price_at": {
         "x": 7,
         "y": -10


### PR DESCRIPTION
## Description
The original changes in #746 broke some animations and menu screen and as a result had to be rolled back. This pr adds the loading bar back in with several optimizations including lazy loading of audio so the initial game load is MUCH faster. Probably 5x.

## Problem
#722 

## Context
same as #746 

## Impact
same as #746

## Testing
same as #746

## Screenshots (if appropriate)
same as #746 